### PR TITLE
Make delete user safe

### DIFF
--- a/lib/auth0/client.rb
+++ b/lib/auth0/client.rb
@@ -32,6 +32,7 @@ class Auth0Client
   end
 
   def delete_user(id)
+    fail "#{__method__}: No id" if id.to_s.empty?
 
     uri = URI.escape("/api/users/#{id}")
     response = self.class.delete(uri, { headers: @headers })


### PR DESCRIPTION
If id is an empty string, the call will look like

```
POST /api/users/
```

which is another API call – to remove all users – we sure don't want that to happen unexpectedly.
