### PR TITLE
Fix typo delegation signature; open_id => openid

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -14,7 +14,7 @@ module Auth0
       end
 
       # {https://auth0.com/docs/auth-api#!#post--delegation}
-      def delegation(id_token, target, scope = "open_id")
+      def delegation(id_token, target, scope = "openid")
         request_params = {
                       client_id:  @client_id,
                       grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",


### PR DESCRIPTION
According to https://auth0.com/docs/protocols it's "openid".