### PR TITLE
Update readme.md api v2 basic usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ require "auth0"
 
 auth0 = Auth0Client.new(
   :api_version => 2,
-  :token => "YOUR JWT HERE"
+  :token => "YOUR JWT HERE",
+  :namespace => "<YOUR ACCOUNT>.auth0.com"
 );
 
 puts auth0.get_users;


### PR DESCRIPTION
By following the existing api v2 basic usage example, a rather obscure error is generated - 'SocketError: getaddrinfo: Name or service not known'. Including this key/value pair as in api v1 makes it work.