### PR TITLE
make AuthenticationEndpoints available to client in v2 mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ require "auth0"
 
 auth0 = Auth0Client.new(
   :api_version => 2,
+  :client_id => "YOUR CLIENT ID",
   :token => "YOUR JWT HERE",
   :namespace => "<YOUR ACCOUNT>.auth0.com"
 );

--- a/lib/auth0/mixins/initializer.rb
+++ b/lib/auth0/mixins/initializer.rb
@@ -11,12 +11,13 @@ module Auth0
         options = Hash[config.map{|(k,v)| [k.to_sym,v]}]
         self.class.base_uri "https://#{options[:namespace]}"
         self.class.headers "Content-Type"  => 'application/json'
+        self.extend Auth0::Api::AuthenticationEndpoints
         if options[:protocols].to_s.include?("v2") or options[:api_version] === 2
           self.extend Auth0::Api::V2
-          @token = (options[:access_token] or options[:token])
+          @client_id      = options[:client_id]
+          @token          = (options[:access_token] or options[:token])
         else
           self.extend Auth0::Api::V1
-          self.extend Auth0::Api::AuthenticationEndpoints
           @client_id      = options[:client_id]
           @client_secret  = options[:client_secret]
           @token          = obtain_access_token

--- a/spec/lib/auth0/client_spec.rb
+++ b/spec/lib/auth0/client_spec.rb
@@ -36,12 +36,12 @@ describe Auth0::Client do
     it {expect(subject).to be_a Auth0::Api::V2::Stats}
     it {expect(subject).to be_a Auth0::Api::V2::Jobs}
     it {expect(subject).to be_a Auth0::Api::V2::Blacklists}
+    it {expect(subject).to be_a Auth0::Api::AuthenticationEndpoints}
     it {expect(subject).not_to be_a Auth0::Api::V1}
     it {expect(subject).not_to be_a Auth0::Api::V1::Users}
     it {expect(subject).not_to be_a Auth0::Api::V1::Connections}
     it {expect(subject).not_to be_a Auth0::Api::V1::Clients}
     it {expect(subject).not_to be_a Auth0::Api::V1::Rules}
     it {expect(subject).not_to be_a Auth0::Api::V1::Logs}
-    it {expect(subject).not_to be_a Auth0::Api::AuthenticationEndpoints}
   end
 end


### PR DESCRIPTION
This is a fix for https://github.com/auth0/ruby-auth0/issues/20
It implies :client_id is required when creating a v2 client.