### PR TITLE
allow to pass extra parameters to delegation method

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -14,7 +14,7 @@ module Auth0
       end
 
       # {https://auth0.com/docs/auth-api#!#post--delegation}
-      def delegation(id_token, target, scope = "openid", api_type = "app")
+      def delegation(id_token, target, scope = "openid", api_type = "app", extra_parameters = {})
         request_params = {
                       client_id:  @client_id,
                       grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
@@ -22,7 +22,7 @@ module Auth0
                       target:     target,
                       api_type:   api_type,
                       scope:      scope
-        }
+        }.merge(extra_parameters)
         post("/delegation", request_params)
       end
 

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -28,6 +28,12 @@ describe Auth0::Api::AuthenticationEndpoints do
                                                               api_type: "salesforce_api"})
       @instance.delegation("", "", "", "salesforce_api")
     end
+    it "allows to pass extra parameters" do
+      expect(@instance).to receive(:post).with("/delegation",{:client_id=>nil, :grant_type=>"urn:ietf:params:oauth:grant-type:jwt-bearer", 
+                                                              :id_token=>"", :target=>"", :scope=>"", :api_type => "",
+                                                               :community_name => 'test-community', community_url: 'test-url'})
+      @instance.delegation("", "", "", "", community_name: 'test-community', community_url: 'test-url')
+    end
   end
 
   context ".impersonate" do


### PR DESCRIPTION
To use with salesforce community auth it's required to pass extra parameters for delegation. See description of "Salesforce API" addon