### PR TITLE
Impersonation

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -25,6 +25,22 @@ module Auth0
         post("/delegation", request_params)
       end
 
+      # {https://auth0.com/docs/auth-api#!#post--users--user_id--impersonate}
+      def impersonate(user_id, app_client_id, impersonator_id, options)
+        request_params = {
+          protocol:         options.fetch(:protocol, "oauth2"),
+          impersonator_id:  impersonator_id,
+          client_id:        app_client_id,
+          additionalParameters: {
+            response_type:  options.fetch(:response_type, "code"),
+            state:          options.fetch(:state, ""),
+            scope:          options.fetch(:scope, "openid"),
+            callback_url:   options.fetch(:callback_url, ""),
+          }
+        }
+        post("/users/#{user_id}/impersonate", request_params)
+      end
+
       # {https://auth0.com/docs/auth-api#!#post--oauth-ro}
       def login(username, password, scope = "openid", id_token=nil, connection_name="Username-Password-Authentication")
         request_params = {

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -24,6 +24,18 @@ describe Auth0::Api::AuthenticationEndpoints do
     end
   end
 
+  context ".impersonate" do
+    let(:user_id)         {"some_user_id"}
+    let(:app_client_id)   {"some_app_client_id"}
+    let(:impersonator_id) {"some_impersonator_id"}
+
+    it {expect(@instance).to respond_to(:impersonate)}
+    it "is expected to make post request to '/users/{user_id}/impersonate'" do
+      expect(@instance).to receive(:post).with("/users/#{user_id}/impersonate",{:protocol=>"oauth2", :impersonator_id=>impersonator_id, :client_id=>app_client_id, :additionalParameters=>{:response_type=>"code", :state=>"", :scope=>"openid", :callback_url=>""}})
+      @instance.impersonate(user_id, app_client_id, impersonator_id, {})
+    end
+  end
+
   context ".login" do
     it {expect(@instance).to respond_to(:signup)}
     it "is expected to make post to /oauth/ro" do


### PR DESCRIPTION
https://auth0.com/docs/auth-api#!#post--users--user_id--impersonate

> Using this API you can generate a link that could be used to
> impersonate a user. This is useful for troubleshooting. Note: this API
> can only be used with the Global Client credentials.