### PR TITLE
Client information headers

### DIFF
--- a/lib/auth0/mixins/initializer.rb
+++ b/lib/auth0/mixins/initializer.rb
@@ -34,7 +34,7 @@ module Auth0
         {
           'Content-Type' => 'application/json',
           'User-Agent' => "Ruby/#{RUBY_VERSION}",
-          'X-Auth0-Client' => "Ruby/#{Auth0::VERSION}"
+          'Auth0-Client' => "Ruby/#{Auth0::VERSION}"
         }
       end
 

--- a/lib/auth0/mixins/initializer.rb
+++ b/lib/auth0/mixins/initializer.rb
@@ -34,7 +34,7 @@ module Auth0
         {
           'Content-Type' => 'application/json',
           'User-Agent' => "Ruby/#{RUBY_VERSION}",
-          'X-Auth0-Client' => Auth0::VERSION
+          'X-Auth0-Client' => "Ruby/#{Auth0::VERSION}"
         }
       end
 

--- a/lib/auth0/mixins/initializer.rb
+++ b/lib/auth0/mixins/initializer.rb
@@ -12,7 +12,9 @@ module Auth0
         domain = api_domain options
         raise InvalidApiNamespace, "Api namespace must supply an API domain" if domain.nil?
         self.class.base_uri "https://#{domain}"
-        self.class.headers "Content-Type"  => 'application/json'
+
+        self.class.headers client_headers
+
         self.extend Auth0::Api::AuthenticationEndpoints
         @client_id      = options[:client_id]
         initialize_v2(options) if api_v2?(options)
@@ -27,6 +29,14 @@ module Auth0
       end
 
       private
+
+      def client_headers
+        {
+          'Content-Type' => 'application/json',
+          'X-Auth0-Client' => "Ruby/#{RUBY_VERSION}",
+          'X-Auth0-Client-Version' => Auth0::VERSION
+        }
+      end
 
       def api_domain(options)
         options[:domain] || options[:namespace]

--- a/lib/auth0/mixins/initializer.rb
+++ b/lib/auth0/mixins/initializer.rb
@@ -33,8 +33,8 @@ module Auth0
       def client_headers
         {
           'Content-Type' => 'application/json',
-          'X-Auth0-Client' => "Ruby/#{RUBY_VERSION}",
-          'X-Auth0-Client-Version' => Auth0::VERSION
+          'User-Agent' => "Ruby/#{RUBY_VERSION}",
+          'X-Auth0-Client' => Auth0::VERSION
         }
       end
 

--- a/spec/integration/lib/auth0/auth0_client_spec.rb
+++ b/spec/integration/lib/auth0/auth0_client_spec.rb
@@ -63,7 +63,7 @@ describe Auth0::Client do
     end
 
     it "sets the client version" do
-      headers['X-Auth0-Client'].should eql Auth0::VERSION
+      headers['X-Auth0-Client'].should eql "Ruby/#{Auth0::VERSION}"
     end
   end
 end

--- a/spec/integration/lib/auth0/auth0_client_spec.rb
+++ b/spec/integration/lib/auth0/auth0_client_spec.rb
@@ -47,23 +47,23 @@ describe Auth0::Client do
     let(:headers) { client.class.headers }
 
     it "has the correct headers present" do
-      headers.keys.sort.should eql ['Authorization', 'Content-Type', 'User-Agent', 'X-Auth0-Client']
+      expect(headers.keys.sort).to eql ['Authorization', 'Content-Type', 'User-Agent', 'X-Auth0-Client']
     end
 
     it "uses the correct access token" do
-      headers['Authorization'].should eql "Bearer abc123"
+      expect(headers['Authorization']).to eql "Bearer abc123"
     end
 
     it "is always json" do
-      headers['Content-Type'] = 'application/json'
+      expect(headers['Content-Type']).to eql 'application/json'
     end
 
     it "sets the ruby version" do
-      headers['User-Agent'].should eql "Ruby/#{RUBY_VERSION}"
+      expect(headers['User-Agent']).to eql "Ruby/#{RUBY_VERSION}"
     end
 
     it "sets the client version" do
-      headers['X-Auth0-Client'].should eql "Ruby/#{Auth0::VERSION}"
+      expect(headers['X-Auth0-Client']).to eql "Ruby/#{Auth0::VERSION}"
     end
   end
 end

--- a/spec/integration/lib/auth0/auth0_client_spec.rb
+++ b/spec/integration/lib/auth0/auth0_client_spec.rb
@@ -42,4 +42,28 @@ describe Auth0::Client do
     let(:credentials) { v2_credentials.merge({access_token: ENV["MASTER_JWT"]}) }
   end
 
+  context "client headers" do
+    let(:client) { Auth0::Client.new(v2_credentials.merge({access_token: 'abc123', domain: 'myhost.auth0.com'})) }
+    let(:headers) { client.class.headers }
+
+    it "has the correct headers present" do
+      headers.keys.sort.should eql ['Authorization', 'Content-Type', 'X-Auth0-Client', 'X-Auth0-Client-Version']
+    end
+
+    it "uses the correct access token" do
+      headers['Authorization'].should eql "Bearer abc123"
+    end
+
+    it "is always json" do
+      headers['Content-Type'] = 'application/json'
+    end
+
+    it "sets the ruby version" do
+      headers['X-Auth0-Client'].should eql "Ruby/#{RUBY_VERSION}"
+    end
+
+    it "sets the client version" do
+      headers['X-Auth0-Client-Version'].should eql Auth0::VERSION
+    end
+  end
 end

--- a/spec/integration/lib/auth0/auth0_client_spec.rb
+++ b/spec/integration/lib/auth0/auth0_client_spec.rb
@@ -47,7 +47,7 @@ describe Auth0::Client do
     let(:headers) { client.class.headers }
 
     it "has the correct headers present" do
-      headers.keys.sort.should eql ['Authorization', 'Content-Type', 'X-Auth0-Client', 'X-Auth0-Client-Version']
+      headers.keys.sort.should eql ['Authorization', 'Content-Type', 'User-Agent', 'X-Auth0-Client']
     end
 
     it "uses the correct access token" do
@@ -59,11 +59,11 @@ describe Auth0::Client do
     end
 
     it "sets the ruby version" do
-      headers['X-Auth0-Client'].should eql "Ruby/#{RUBY_VERSION}"
+      headers['User-Agent'].should eql "Ruby/#{RUBY_VERSION}"
     end
 
     it "sets the client version" do
-      headers['X-Auth0-Client-Version'].should eql Auth0::VERSION
+      headers['X-Auth0-Client'].should eql Auth0::VERSION
     end
   end
 end

--- a/spec/integration/lib/auth0/auth0_client_spec.rb
+++ b/spec/integration/lib/auth0/auth0_client_spec.rb
@@ -47,7 +47,7 @@ describe Auth0::Client do
     let(:headers) { client.class.headers }
 
     it "has the correct headers present" do
-      expect(headers.keys.sort).to eql ['Authorization', 'Content-Type', 'User-Agent', 'X-Auth0-Client']
+      expect(headers.keys.sort).to eql ['Auth0-Client', 'Authorization', 'Content-Type', 'User-Agent']
     end
 
     it "uses the correct access token" do
@@ -63,7 +63,7 @@ describe Auth0::Client do
     end
 
     it "sets the client version" do
-      expect(headers['X-Auth0-Client']).to eql "Ruby/#{Auth0::VERSION}"
+      expect(headers['Auth0-Client']).to eql "Ruby/#{Auth0::VERSION}"
     end
   end
 end


### PR DESCRIPTION
I'd like to discuss the idea of adding some client information to our API libraries — these changes would need to be implemented in a all of our official clients, as well as requiring some effort on the devops, and data tracking sides. I'll do my best to explain why this could be such a valuable enhancement.

---

### What I want to do

Add two headers to all of our API clients when they're talking to auth0 APIs. These headers would carry the "platform" of the client, and the "version", so in the case of this Ruby client, it'd have the following two headers: 

```
User-Agent: Ruby/2.2.1 (Rails 4.2.2)
Auth0-Client: Ruby/3.4.1
```

To break it down a little bit: The client is "ruby" (language/sdk), and the version of ruby that we're using is `2.2.1`. The client version corresponds to the semantic version used for this gem (at next bump, it'll be `3.4.1`)

In addition, the each client library should allow "overloading" the client, for example, this ruby library _might_ be used in rails applications. For the `omniauth` library, we could set `Auth0::ClientVersion` to `Ruby/2.2.1 (Rails 4.2.2)`.

Client side example: 
* `User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36`
* As a querystring: `?auth0_client=auth0.js/1.1.1`

---

### What it'll give us the ability to do

##### Support & CSE
I understand I'm speaking _for_ team @eugeniop a little here, but I can foresee that adding client information to an given companies requests (then store them in something like intercom) would make for really useful information when trying to help diagnose client issues, or help us point to relevant documentation. 

##### Developer advocacy
Understanding the volume and capacity of clients that are in use (and also tracking package downloads from rubygems, npm, bower etc) helps the advocacy team understand the effect/results of efforts with vertical conferences and events (Eg, if we speak at a ruby event, do we get a client bump? Do we get sign ups?). Additionally, we can work harder to improve documentation or SDKs for the more popular platforms (or, perhaps the UNpopular ones). In short, data helps us better understand our work. 

##### Statistics
![screen shot 2015-05-07 at 12 34 57 pm](https://cloud.githubusercontent.com/assets/924/7524262/82c503f6-f4b5-11e4-8142-e66f5be5f4ff.png)

(Mocked graph) — We could show API requests by client type, and then also intersect that information by region, or customer details.

Further to this, we could identify customers that are using older versions of clients that require updates, or help them deal with deprecations. 

Webtask to store this in Google analytics anyone? (cc @tjanczuk )

---

### Effort required to make it a reality

- [ ] Server side logging needs to be able to log API headers somewhere (Redshift, Librato, or Google Analytics would be an obvious place)
- [ ] Update PHP client
- [ ] Update auth0.js
- [ ] Update iOS Lock
- [ ] Update Android Lock
- [ ] Update Auth0 Xamarin Client
- [ ] Update clients that I missed above

The changes to the Ruby client were conducted in less than an hour, and while this isn't an exact guide for all clients, its a good indication that we should be able to knock through the PRs pretty easily. 

---

### Feedback
Clearly, I'm not yet familiar with pitching features at auth0, nor am I aware of the entire way that this stack works. If you've got thoughts, pointers or general hand holding advice, please leave it below in the comments. From here, I can do my best to drive this through to the end. 