### PR TITLE
set the search engine if a query is set

### DIFF
--- a/lib/auth0/api/v2/users.rb
+++ b/lib/auth0/api/v2/users.rb
@@ -14,6 +14,11 @@ module Auth0
             fields:         fields,
             q:              q
           }
+
+          if request_params[:q]
+            request_params[:search_engine] = :v2
+          end
+
           path = "/api/v2/users"
           get(path, request_params)
         end


### PR DESCRIPTION
The `search_engine` param must be set in order to use the `q` param