### PR TITLE
Adding support for v2 password change ticket endpoint

### DIFF
--- a/lib/auth0/api/v2.rb
+++ b/lib/auth0/api/v2.rb
@@ -4,6 +4,7 @@ require 'auth0/api/v2/blacklists'
 require 'auth0/api/v2/jobs'
 require 'auth0/api/v2/stats'
 require 'auth0/api/v2/connections'
+require 'auth0/api/v2/tickets'
 
 module Auth0
   module Api
@@ -15,6 +16,7 @@ module Auth0
       include Auth0::Api::V2::Jobs
       include Auth0::Api::V2::Stats
       include Auth0::Api::V2::Connections
+      include Auth0::Api::V2::Tickets
     end
   end
 end

--- a/lib/auth0/api/v2/tickets.rb
+++ b/lib/auth0/api/v2/tickets.rb
@@ -1,0 +1,16 @@
+module Auth0
+  module Api
+    module V2
+       # https://auth0.com/docs/apiv2#!/tickets
+      module Tickets
+        # https://auth0.com/docs/api/v2#!/Tickets/post_password_change
+        def create_password_change_ticket(new_password, options = {})
+          path = '/api/v2/tickets/password-change'
+          request_params = Hash[options.map { |(k, v)| [k.to_sym, v] }]
+          request_params[:new_password] = new_password
+          post(path, request_params)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/auth0/api/v2/tickets_spec.rb
+++ b/spec/lib/auth0/api/v2/tickets_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+describe Auth0::Api::V2::Tickets do
+  before :all do
+    dummy_instance = DummyClass.new
+    dummy_instance.extend(Auth0::Api::V2::Tickets)
+    @instance = dummy_instance
+  end
+
+  context '.create_password_change_ticket' do
+    it { expect(@instance).to respond_to(:create_password_change_ticket) }
+    it 'is expected to call post to /api/v2/tickets/password-change' do
+      expect(@instance).to receive(:post).with(
+        '/api/v2/tickets/password-change',
+        result_url: 'http://myapp.com/callback',
+        user_id: 'auth0|user',
+        connection: 'conn',
+        email: 'test@test.com',
+        new_password: 'password'
+      )
+      @instance.create_password_change_ticket(
+        'password',
+        result_url: 'http://myapp.com/callback',
+        user_id: 'auth0|user',
+        connection: 'conn',
+        email: 'test@test.com')
+    end
+  end
+end


### PR DESCRIPTION
This adds support for the v2 password change ticket creation endpoint. 

![](http://www.awesomelyluvvie.com/wp-content/uploads/2014/03/GoldenTicket.gif)