### PR TITLE
Refresh token delegation

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -28,6 +28,19 @@ module Auth0
         post('/delegation', request_params)
       end
 
+      # {https://auth0.com/docs/auth-api#!#post--delegation}
+      def refresh_delegation(refresh_token, target, scope = 'openid', api_type = 'app', extra_parameters = {})
+        request_params = {
+          client_id:      @client_id,
+          grant_type:     'urn:ietf:params:oauth:grant-type:jwt-bearer',
+          refresh_token:  refresh_token,
+          target:         target,
+          api_type:       api_type,
+          scope:          scope
+        }.merge(extra_parameters)
+        post('/delegation', request_params)
+      end
+
       # {https://auth0.com/docs/auth-api#!#post--users--user_id--impersonate}
       def impersonate(user_id, app_client_id, impersonator_id, options)
         request_params = {

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -54,6 +54,19 @@ describe Auth0::Api::AuthenticationEndpoints do
     end
   end
 
+  context '.refresh_delegation' do
+    it { expect(@instance).to respond_to(:refresh_delegation) }
+    it "is expected to make post request to '/delegation'" do
+      expect(@instance).to receive(:post).with(
+        '/delegation',
+        client_id: nil,
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        refresh_token: '', target: '', api_type: '', scope: '',
+        additional_parameter: 'parameter')
+        @instance.refresh_delegation('', '', '', '', additional_parameter: 'parameter')
+    end
+  end
+
   context '.impersonate' do
     let(:user_id)         { 'some_user_id' }
     let(:app_client_id)   { 'some_app_client_id' }


### PR DESCRIPTION
Adding support to the authentication endpoints to be able to send in a refresh token and get a new unexpired JWT. 

![](https://media.giphy.com/media/vTKXchNrmZ6RW/giphy.gif)