### PR TITLE
updated readme to add required api_version input for api v2 client init

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Using [APIv2](https://auth0.com/docs/api/v2)
 require "auth0"
 
 auth0 = Auth0Client.new(
+  :api_version => 2,
   :token => "YOUR JWT HERE",
   :domain => "<YOUR ACCOUNT>.auth0.com"
 )

--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ auth0 = Auth0Client.new(
 puts auth0.get_users
 ```
 
+## API Documentation
+
+Build API docs locally
+
+``` bash
+bundle exec rake documentation
+```
+
+To view API docs, go to `doc` folder and open `index.html`
+
+
 ## What is Auth0?
 
 Auth0 helps you to:


### PR DESCRIPTION
If no `api_version` while initializing for API v2 call, sdk throws `initialize_v1': Invalid API v1 client_id and client_secret (Auth0::InvalidCredentials)` so need to pass `api_version` during init.