### PR TITLE
Use JSON (result.body) for exception messages in requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
+---
 language: ruby
 sudo: false
 cache: bundler
 rvm:
-- 2.1.0
-- 2.2.1
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
 script: "./build_travis.sh"
 after_success: "./deploy_documentation.sh"
 deploy:

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'http://rubygems.org'
 gemspec
 
 group :development do
-  gem 'terminal-notifier-guard', require: false
+  gem 'terminal-notifier-guard', require: false unless ENV['TRAVIS']
   gem 'coveralls', require: false
   gem 'rubocop', require: false
   gem 'yard', require: false

--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'fuubar', '~> 2.0'
-  s.add_development_dependency 'guard-rspec', '~> 4.5'
+  s.add_development_dependency 'guard-rspec', '~> 4.5' unless ENV['TRAVIS']
   s.add_development_dependency 'dotenv-rails', '~> 2.0'
   s.add_development_dependency 'pry', '~> 0.10'
   s.add_development_dependency 'pry-nav', '~> 0.2.4'

--- a/lib/auth0/mixins/httparty_proxy.rb
+++ b/lib/auth0/mixins/httparty_proxy.rb
@@ -15,23 +15,23 @@ module Auth0
           else
             result = self.class.send(method, safe_path, body: body.to_json)
           end
-          response_body =
-          begin
-            JSON.parse(result.body.to_s)
-          rescue JSON::ParserError
-            result.body
-          end
+
           case result.code
-          when 200...226 then response_body
-          when 400 then fail Auth0::BadRequest, response_body
-          when 401 then fail Auth0::Unauthorized, response_body
-          when 403 then fail Auth0::AccessDenied, response_body
-          when 404 then fail Auth0::NotFound, response_body
-          when 500 then fail Auth0::ServerError, response_body
-          else
-            fail Auth0::Unsupported, response_body
+          when 200...226 then safe_parse_json(result.body)
+          when 400       then fail Auth0::BadRequest, result.body
+          when 401       then fail Auth0::Unauthorized, result.body
+          when 403       then fail Auth0::AccessDenied, result.body
+          when 404       then fail Auth0::NotFound, result.body
+          when 500       then fail Auth0::ServerError, result.body
+          else                fail Auth0::Unsupported, result.body
           end
         end
+      end
+
+      def safe_parse_json(body)
+        JSON.parse(body.to_s)
+      rescue JSON::ParserError
+        body
       end
     end
   end

--- a/spec/lib/auth0/mixins/httparty_proxy_spec.rb
+++ b/spec/lib/auth0/mixins/httparty_proxy_spec.rb
@@ -1,4 +1,6 @@
+require 'json'
 require 'spec_helper'
+
 describe Auth0::Mixins::HTTPartyProxy do
   before :all do
     dummy_instance = DummyClassForProxy.new
@@ -142,6 +144,19 @@ describe Auth0::Mixins::HTTPartyProxy do
         expect(DummyClassForProxy).to receive(http_method).with('/te%20st', body: '{}')
           .and_return(StubResponse.new('{}', true, 200))
         expect { @instance.send(http_method, '/te st') }.not_to raise_error
+      end
+
+      it "should give the JSON representation of the error as the error message" do
+        allow(DummyClassForProxy).to receive(http_method).with('http://login.auth0.com/test', body: '{}')
+        res = JSON.generate({
+          "statusCode"=>404,
+          "error"=>"Bad Request",
+          "message"=>"Path validation error: 'String does not match pattern ^.+\\|.+$: 3241312' on property id (The user_id of the user to retrieve).",
+          "errorCode"=>"invalid_uri"
+        })
+        expect(DummyClassForProxy).to receive(http_method).with('/test', body: '{}')
+          .and_return(StubResponse.new(res, false, 404))
+        expect { @instance.send(http_method, '/test') }.to raise_error(Auth0::NotFound, res)
       end
     end
   end


### PR DESCRIPTION
Previously, Auth0::Exception was being fed a Hash for its message content.
All messages are stringified, so when a user accesses the error message,
they are left with a string representation of a hash. Here is an example.

```ruby
def some_method
  auth0_client.user('notarealuser')
rescue Auth0::Exception => e
  puts e.message # => "{\"statusCode\"=>400, \"error\"=>\"Bad Request\", \"message\"=>\"Path validation error: 'String does not match pattern ^.+\\\\|.+$: 3241312' on property id (The user_id of the user to retrieve).\", \"errorCode\"=>\"invalid_uri\"}"

  # cannot parse this error, :(
end
```

These hash representations do not have an efficient, robust parsing mechanism.
Therefore, I propose we simply use the JSON representation from the response
body as the message, so users can parse the message and do what they need
with it. A new example would work like this:

```ruby
def some_method
  auth0_client.user('notarealuser')
rescue Auth0::Exception => e
  JSON.parse(e.message) #=> {"statusCode"=>400, "error"=>"Bad Request", "message"=>"Path validation error: 'String does not match pattern ^.+\\|.+$: 3241312' on property id (The user_id of the user to retrieve).", "errorCode"=>"invalid_uri"}

  # yay!
end
```