### PR TITLE
Fix start_passwordless_email_flow

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -91,9 +91,10 @@ module Auth0
         fail Auth0::InvalidParameter, 'Must supply a valid email' if email.to_s.empty?
         request_params = {
           client_id:    @client_id,
+          connection: 'email',
           email:        email,
           send:         send,
-          auth_params:  auth_params
+          authParams:  auth_params
         }
         post('/passwordless/start', request_params)
       end

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -78,7 +78,8 @@ describe Auth0::Api::AuthenticationEndpoints do
         client_id: nil,
         email: 'test@test.com',
         send: 'link',
-        auth_params: {
+        connection: 'email',
+        authParams: {
           scope: 'scope',
           protocol: 'protocol'
         })


### PR DESCRIPTION
Updated start_passwordless_email_flow endpoint to match the documentation on auth0.com.