### PR TITLE
Resolve v1 API example error

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ auth0 = Auth0Client.new(
   :client_id => "YOUR CLIENT ID",
   :client_secret => "YOUR CLIENT SECRET",
   :domain => "<YOUR ACCOUNT>.auth0.com",
-  :api_version => "1"
+  :api_version => 1
 )
 
 puts auth0.get_users


### PR DESCRIPTION
API Version must be an integer, otherwise api_v1?(options) returns false and the API thinks you're intending to use the v2 API.