### PR TITLE
Introduce and raise exception for timeout

### DIFF
--- a/lib/auth0/exception.rb
+++ b/lib/auth0/exception.rb
@@ -15,6 +15,8 @@ module Auth0
   class ServerError < Auth0::Exception; end
   # exception for incorrect request, you've sent wrong params
   class BadRequest < Auth0::Exception; end
+  # exception for timeouts
+  class RequestTimeout < Auth0::Exception; end
   # exception for unset user_id, this might cause removal of
   # all users, or other unexpected behaviour
   class MissingUserId < Auth0::Exception; end

--- a/lib/auth0/mixins/httpproxy.rb
+++ b/lib/auth0/mixins/httpproxy.rb
@@ -52,7 +52,7 @@ module Auth0
         when RestClient::RequestTimeout
           raise Auth0::RequestTimeout
         else
-          raise e
+          return e.response
         end
       end
     end

--- a/lib/auth0/mixins/httpproxy.rb
+++ b/lib/auth0/mixins/httpproxy.rb
@@ -48,7 +48,12 @@ module Auth0
       def call(method, url, timeout, headers, body = nil)
         RestClient::Request.execute(method: method, url: url, timeout: timeout, headers: headers, payload: body)
       rescue RestClient::Exception => e
-        e.response
+        case e
+        when RestClient::RequestTimeout
+          raise Auth0::RequestTimeout
+        else
+          raise e
+        end
       end
     end
   end


### PR DESCRIPTION
If `RestClient` _actually_ times out, the current code breaks.

Probably because there is no `e.reponse` in the case of a timeout.

I couldn't run the specs, so could someone maybe help out?