### PR TITLE
Fix error in the readme regarding timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ puts auth0.get_users
 ```
 
 ### Timeout
-You can setup a custom timeout in the Auth0Client. By default it is set to 10 minutes.
+You can setup a custom timeout in the Auth0Client. By default it is set to 10 seconds.
 
 ```ruby
 require "auth0"


### PR DESCRIPTION
I believe the integer passed into as timeout is used as seconds in the rest_client gem. This PR simply updates the readme and fixes the misleading typo. 😄 