### PR TITLE
Add delay to integration test

### DIFF
--- a/spec/integration/lib/auth0/api/v2/api_client_grants_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_client_grants_spec.rb
@@ -5,20 +5,26 @@ describe Auth0::Api::V2::ClientGrants do
   before(:all) do
     @client = Auth0Client.new(v2_creds)
     @client_id = v2_creds[:client_id]
+    sleep 1
     @audience = "https://#{client.clients[0]['tenant']}.auth0.com/api/v2/"
     @scope = [Faker::Lorem.word]
+    sleep 1
     @existing_grant = client.create_client_grant('client_id' => client_id, 'audience' => audience, 'scope' => scope)
   end
 
   after(:all) do
     grants = client.client_grants
     grants.each do |grant|
+      sleep 1
       client.delete_client_grant(grant['id'])
     end
   end
 
   describe '.client_grants' do
-    let(:client_grants) { client.client_grants }
+    let(:client_grants) do
+      sleep 1
+      client.client_grants
+    end
 
     it { expect(client_grants.size).to be > 0 }
     it { expect(client_grants).to include(existing_grant) }
@@ -27,6 +33,7 @@ describe Auth0::Api::V2::ClientGrants do
   describe '.patch_client_grant' do
     let(:new_scope) { [Faker::Lorem.word] }
     it do
+      sleep 1
       expect(
         client.patch_client_grant(
           existing_grant['id'],
@@ -37,6 +44,9 @@ describe Auth0::Api::V2::ClientGrants do
   end
 
   describe '.delete_client_grant' do
-    it { expect { client.delete_client_grant(existing_grant['id']) }.to_not raise_error }
+    it do
+      sleep 1
+      expect { client.delete_client_grant(existing_grant['id']) }.to_not raise_error
+    end
   end
 end

--- a/spec/integration/lib/auth0/api/v2/api_clients_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_clients_spec.rb
@@ -1,38 +1,58 @@
 require 'spec_helper'
 describe Auth0::Api::V2::Clients do
   let(:client) { Auth0Client.new(v2_creds) }
-  let(:existing_client) { client.create_client("existing#{entity_suffix}") }
+  let(:existing_client) do
+    sleep 1
+    client.create_client("existing#{entity_suffix}")
+  end
   let(:client_name) { "ClientV2#{entity_suffix}" }
 
-  it { expect(client.clients).to_not be_empty }
+  it do
+    sleep 1
+    expect(client.clients).to_not be_empty
+  end
 
   describe '.clients' do
-    let(:clients) { client.clients }
+    let(:clients) do
+      sleep 1
+      client.clients
+    end
 
     it { expect(clients.size).to be > 0 }
 
     context '#filters' do
       it do
+        sleep 1
         expect(client.clients(fields: [:name, :callbacks].join(',')).first).to(include('name', 'callbacks'))
       end
       it do
+        sleep 1
         expect(client.clients(fields: [:callbacks].join(',')).first).to_not(include('name'))
       end
       it do
+        sleep 1
         expect(client.clients(fields: [:callbacks].join(','), include_fields: false).first).to_not(include('callbacks'))
       end
     end
   end
 
   describe '.client' do
-    it { expect(client.client(existing_client['client_id'])).to include('client_id' => existing_client['client_id']) }
-    it { expect { client.client '' }.to raise_error(Auth0::MissingClientId) }
+    it do
+      sleep 1
+      expect(client.client(existing_client['client_id'])).to include('client_id' => existing_client['client_id'])
+    end
+    it do
+      sleep 1
+      expect { client.client '' }.to raise_error(Auth0::MissingClientId)
+    end
 
     context '#filters' do
       let(:client_include) do
+        sleep 1
         client.client(existing_client['client_id'], fields: [:name, :client_secret, :jwt_configuration].join(','))
       end
       let(:client_not_include) do
+        sleep 1
         client.client(existing_client['client_id'], fields: :jwt_configuration, include_fields: false)
       end
 
@@ -49,6 +69,7 @@ describe Auth0::Api::V2::Clients do
 
   describe '.create_client' do
     it do
+      sleep 1
       expect(client.create_client(client_name, custom_login_page_on: false)).to(
         include('name' => client_name, 'custom_login_page_on' => false)
       )
@@ -58,6 +79,7 @@ describe Auth0::Api::V2::Clients do
 
   describe '.patch_client' do
     it do
+      sleep 1
       expect(
         client.patch_client(
           existing_client['client_id'],
@@ -66,11 +88,20 @@ describe Auth0::Api::V2::Clients do
         )
       ).to(include('custom_login_page_on' => false, 'sso' => true))
     end
-    it { expect { client.patch_client('', custom_login_page_on: false) }.to raise_error(Auth0::MissingClientId) }
+    it do
+      sleep 1
+      expect { client.patch_client('', custom_login_page_on: false) }.to raise_error(Auth0::MissingClientId)
+    end
   end
 
   describe '.delete_rule' do
-    it { expect { client.delete_client(existing_client['client_id']) }.to_not raise_error }
-    it { expect { client.delete_client '' }.to raise_error(Auth0::MissingClientId) }
+    it do
+      sleep 1
+      expect { client.delete_client(existing_client['client_id']) }.to_not raise_error
+    end
+    it do
+      sleep 1
+      expect { client.delete_client '' }.to raise_error(Auth0::MissingClientId)
+    end
   end
 end

--- a/spec/integration/lib/auth0/api/v2/api_connections_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_connections_spec.rb
@@ -17,13 +17,26 @@ describe Auth0::Api::V2::Connections do
   describe '.connections' do
     let(:connections) { client.connections }
 
-    it { expect(connections.size).to be > 0 }
-    it { expect(connections.find { |con| con['name'] == name }).to_not be_empty }
+    it do
+      sleep 1
+      expect(connections.size).to be > 0
+    end
+    it do
+      sleep 1
+      expect(connections.find { |con| con['name'] == name }).to_not be_empty
+    end
 
     context '#filters' do
-      it { expect(client.connections(strategy: strategy).size).to be > 0 }
-      it { expect(client.connections(strategy: strategy, fields: [:name].join(',')).first).to include('name') }
       it do
+        sleep 1
+        expect(client.connections(strategy: strategy).size).to be > 0
+      end
+      it do
+        sleep 1
+        expect(client.connections(strategy: strategy, fields: [:name].join(',')).first).to include('name')
+      end
+      it do
+        sleep 1
         expect(client.connections(strategy: strategy, fields: [:name].join(','), include_fields: false).first).to_not(
           include('name')
         )
@@ -32,13 +45,20 @@ describe Auth0::Api::V2::Connections do
   end
 
   describe '.connection' do
-    let(:subject) { client.connection(connection['id']) }
+    let(:subject) do
+      sleep 1
+      client.connection(connection['id'])
+    end
 
     it { should include('name' => connection['name']) }
 
     context '#filters' do
-      it { expect(client.connection(connection['id'], fields: [:name, :id].join(','))).to include('id', 'name') }
       it do
+        sleep 1
+        expect(client.connection(connection['id'], fields: [:name, :id].join(','))).to include('id', 'name')
+      end
+      it do
+        sleep 1
         expect(client.connection(connection['id'], fields: [:name, :id].join(','), include_fields: false)).to_not(
           include('id', 'name')
         )
@@ -54,7 +74,10 @@ describe Auth0::Api::V2::Connections do
   end
 
   describe '.delete_connection' do
-    it { expect { client.delete_connection connection['id'] }.to_not raise_error }
+    it do
+      sleep 1
+      expect { client.delete_connection connection['id'] }.to_not raise_error
+    end
   end
 
   describe '.update_connection' do
@@ -67,6 +90,7 @@ describe Auth0::Api::V2::Connections do
     new_name = SecureRandom.uuid[0..25]
     let(:options) { { username: new_name } }
     it do
+      sleep 1
       expect(client.update_connection(connection_to_update['id'], 'options' => options)['options']).to include(
         'username' => new_name
       )
@@ -78,6 +102,7 @@ describe Auth0::Api::V2::Connections do
     let(:email) { "#{entity_suffix}#{Faker::Internet.safe_email(username)}" }
     let(:password) { Faker::Internet.password }
     let!(:user_to_delete) do
+      sleep 1
       client.create_user(username,  email: email,
                                     password: password,
                                     email_verified: false,
@@ -85,10 +110,14 @@ describe Auth0::Api::V2::Connections do
                                     app_metadata: {})
     end
     let(:connection) do
+      sleep 1
       client.connections.find { |connection| connection['name'] == Auth0::Api::AuthenticationEndpoints::UP_AUTH }
     end
 
-    it { expect(client.delete_connection_user(connection['id'], email)).to be_empty }
+    it do
+      sleep 1
+      expect(client.delete_connection_user(connection['id'], email)).to be_empty
+    end
   end
 
   after(:all) do

--- a/spec/integration/lib/auth0/api/v2/api_device_credentials_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_device_credentials_spec.rb
@@ -8,6 +8,7 @@ describe Auth0::Api::V2::DeviceCredentials do
     username = Faker::Internet.user_name
     email = "#{entity_suffix}#{Faker::Internet.safe_email(username)}"
     password = Faker::Internet.password
+    sleep 1
     @user = client.create_user(username,  'email' => email,
                                           'password' => password,
                                           'email_verified' => true,
@@ -20,6 +21,7 @@ describe Auth0::Api::V2::DeviceCredentials do
                     authorization: 'Basic' }
 
     @basic_client = Auth0Client.new(v2_creds.merge(basic_creds))
+    sleep 1
     @existing_device_credentials = basic_client.create_device_credential(
       "#{user['name']}_phone_1",
       'dmFsdWU=',
@@ -29,16 +31,24 @@ describe Auth0::Api::V2::DeviceCredentials do
   end
 
   after(:all) do
+    sleep 1
     client.delete_user(user['user_id'])
   end
 
   describe '.device_credentials' do
     let(:device_credentials) { basic_client.device_credentials(ENV['CLIENT_ID']) }
-    it { expect(device_credentials.size).to be > 0 }
-    it { expect(device_credentials.find { |cred| cred['id'] == existing_device_credentials['id'] }).to_not be_empty }
+    it do
+      sleep 1
+      expect(device_credentials.size).to be > 0
+    end
+    it do
+      sleep 1
+      expect(device_credentials.find { |cred| cred['id'] == existing_device_credentials['id'] }).to_not be_empty
+    end
     context '#filter_by_type' do
       let(:filtered_device_credentials) { basic_client.device_credentials(ENV['CLIENT_ID'], type: 'refresh_token') }
       it do
+        sleep 1
         expect(filtered_device_credentials.find do |cred|
                  cred['id'] == existing_device_credentials['id']
                end).to eq nil
@@ -56,12 +66,16 @@ describe Auth0::Api::V2::DeviceCredentials do
       )
     end
     it do
+      sleep 1
       expect(basic_client.device_credentials(ENV['CLIENT_ID'])
         .find { |cred| cred['id'] == new_credentials['id'] }).to_not be_empty
     end
   end
 
   describe '.delete_device_credential' do
-    it { expect { basic_client.delete_device_credential(existing_device_credentials['id']) }.to_not raise_error }
+    it do
+      sleep 1
+      expect { basic_client.delete_device_credential(existing_device_credentials['id']) }.to_not raise_error
+    end
   end
 end

--- a/spec/integration/lib/auth0/api/v2/api_email_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_email_spec.rb
@@ -3,6 +3,7 @@ describe Auth0::Api::V2::Emails do
   before(:all) do
     client = Auth0Client.new(v2_creds)
     begin
+      sleep 1
       client.delete_provider
     rescue
       puts 'no email provider to delete'
@@ -22,7 +23,10 @@ describe Auth0::Api::V2::Emails do
   end
 
   describe '.configure_provider' do
-    let!(:email_provider) { client.configure_provider(body) }
+    let!(:email_provider) do
+      sleep 1
+      client.configure_provider(body)
+    end
     it do
       expect(email_provider).to include(
         'name' => name, 'enabled' => enabled, 'credentials' => credentials, 'settings' => settings
@@ -31,12 +35,18 @@ describe Auth0::Api::V2::Emails do
   end
 
   describe '.get_provider' do
-    let(:provider) { client.get_provider }
+    let(:provider) do
+      sleep 1
+      client.get_provider
+    end
 
-    it { expect(provider.size).to be > 0 }
+    it do
+      expect(provider.size).to be > 0
+    end
 
     context '#filters' do
       it do
+        sleep 1
         expect(
           client.get_provider(fields: [:name, :enabled, :credentials].join(','), include_fields: true)
         ).to(
@@ -44,6 +54,7 @@ describe Auth0::Api::V2::Emails do
         )
       end
       it do
+        sleep 1
         expect(
           client.get_provider(fields: [:enabled].join(','), include_fields: false).first
         ).to_not(include('enabled'))
@@ -61,6 +72,7 @@ describe Auth0::Api::V2::Emails do
         'settings' => update_settings }
     end
     it do
+      sleep 1
       expect(
         client.update_provider(update_body)
       ).to(
@@ -72,7 +84,13 @@ describe Auth0::Api::V2::Emails do
   end
 
   describe '.delete_provider' do
-    it { expect { client.delete_provider }.to_not raise_error }
-    it { expect { client.get_provider }.to raise_error(Auth0::NotFound) }
+    it do
+      sleep 1
+      expect { client.delete_provider }.to_not raise_error
+    end
+    it do
+      sleep 1
+      expect { client.get_provider }.to raise_error(Auth0::NotFound)
+    end
   end
 end

--- a/spec/integration/lib/auth0/api/v2/api_logs_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_logs_spec.rb
@@ -8,6 +8,7 @@ describe Auth0::Api::V2::Logs do
     username = Faker::Internet.user_name
     email = "#{entity_suffix}#{Faker::Internet.safe_email(username)}"
     password = Faker::Internet.password
+    sleep 1
     @user = client.create_user(username,  'email' => email,
                                           'password' => password,
                                           'email_verified' => false,
@@ -16,11 +17,15 @@ describe Auth0::Api::V2::Logs do
   end
 
   after(:all) do
+    sleep 1
     client.delete_user(user['user_id'])
   end
 
   describe '.logs' do
-    let(:logs) { client.logs }
+    let(:logs) do
+      sleep 1
+      client.logs
+    end
     it 'is expected to get a log about user creation' do
       wait 30 do
         expect(find_create_user_log_by_email(user['email'])).to_not be_empty
@@ -28,14 +33,19 @@ describe Auth0::Api::V2::Logs do
     end
 
     context '#filters' do
-      it { expect(client.logs(per_page: 1).size).to be 1 }
       it do
+        sleep 1
+        expect(client.logs(per_page: 1).size).to be 1
+      end
+      it do
+        sleep 1
         expect(
           client.logs(per_page: 1, fields: [:date, :description, :type].join(','), include_fields: true).first
         ).to(include('date', 'description', 'type'))
       end
       it { expect(client.logs(per_page: 1, fields: [:date].join(',')).first).to_not include('type', 'description') }
       it do
+        sleep 1
         expect(
           client.logs(per_page: 1, fields: [:date].join(','), include_fields: false).first
         ).to include('type', 'description')
@@ -43,13 +53,22 @@ describe Auth0::Api::V2::Logs do
     end
 
     context '#from' do
-      it { expect(client.logs(from: logs.last['_id'], take: 1).size).to be 1 }
+      it do
+        sleep 1
+        expect(client.logs(from: logs.last['_id'], take: 1).size).to be 1
+      end
     end
   end
 
   describe '.log' do
-    let(:first_log) { client.logs.first }
-    let(:log) { client.log(first_log['_id']) }
+    let(:first_log) do
+      sleep 1
+      client.logs.first
+    end
+    let(:log) do
+      sleep 1
+      client.log(first_log['_id'])
+    end
     it { expect(log).to_not be_empty }
     it { expect(log['_id']).to eq(first_log['_id']) }
     it { expect(log['date']).to eq(first_log['date']) }
@@ -58,6 +77,7 @@ describe Auth0::Api::V2::Logs do
   private
 
   def find_create_user_log_by_email(email)
+    sleep 1
     logs = client.logs
     logs.find do |log|
       log['description'] == 'Create a user' &&

--- a/spec/integration/lib/auth0/api/v2/api_resource_servers_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_resource_servers_spec.rb
@@ -5,15 +5,18 @@ describe Auth0::Api::V2::ResourceServers do
   before(:all) do
     @client = Auth0Client.new(v2_creds)
     identifier = SecureRandom.uuid
+    sleep 1
     @resource_server = client.create_resource_server(identifier)
   end
 
   after(:all) do
+    sleep 1
     client.delete_resource_server(resource_server['id'])
   end
 
   describe '.resource_server' do
     it do
+      sleep 1
       expect(client.resource_server(resource_server['id'])).to(
         include('identifier' => resource_server['identifier'], 'id' => resource_server['id'],
                 'signing_alg' => resource_server['signing_alg'],
@@ -29,6 +32,7 @@ describe Auth0::Api::V2::ResourceServers do
     let(:signing_secret) { Faker::Lorem.characters(16) }
     let(:token_lifetime) { rand(1000..3000) }
     let!(:resource_server) do
+      sleep 1
       client.create_resource_server(identifier, 'name' => name, 'signing_alg' => signing_alg,
                                                 'signing_secret' => signing_secret,
                                                 'token_lifetime' => token_lifetime)
@@ -37,12 +41,19 @@ describe Auth0::Api::V2::ResourceServers do
       expect(resource_server).to include('name' => name, 'identifier' => identifier, 'signing_alg' => signing_alg,
                                          'signing_secret' => signing_secret,
                                          'token_lifetime' => token_lifetime)
+      sleep 1
       expect { client.delete_resource_server(resource_server['id']) }.to_not raise_error
     end
-    it { expect { client.delete_resource_server(resource_server['id']) }.to_not raise_error }
+    it do
+      sleep 1
+      expect { client.delete_resource_server(resource_server['id']) }.to_not raise_error
+    end
   end
 
   describe '.delete_resource_server' do
-    it { expect { client.delete_resource_server(resource_server['id']) }.to_not raise_error }
+    it do
+      sleep 1
+      expect { client.delete_resource_server(resource_server['id']) }.to_not raise_error
+    end
   end
 end

--- a/spec/integration/lib/auth0/api/v2/api_rules_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_rules_spec.rb
@@ -7,35 +7,45 @@ describe Auth0::Api::V2::Rules do
     suffix = Faker::Lorem.word
     script = 'function (user, context, callback) { callback(null, user, context);}'
     stage = 'login_success'
+    sleep 1
     @enabled_rule = client.create_rule("Enabled Rule #{suffix}", script, rand(1..10), true, stage)
+    sleep 1
     @disabled_rule = client.create_rule("Disabled Rule #{suffix}", script, rand(11..20), false, stage)
   end
 
   after(:all) do
     rules = client.rules
     rules.each do |rule|
+      sleep 1
       client.delete_rule(rule['id'])
     end
   end
 
   describe '.rules' do
-    let(:rules) { client.rules }
+    let(:rules) do
+      sleep 1
+      client.rules
+    end
 
     it { expect(rules.size).to be > 0 }
 
     context '#filters' do
       it do
+        sleep 1
         expect(client.rules(enabled: true).size).to be 1
       end
 
       it do
+        sleep 1
         expect(client.rules(enabled: false).size).to be 1
       end
 
       it do
+        sleep 1
         expect(client.rules(enabled: true, fields: [:script, :order].join(',')).first).to(include('script', 'order'))
       end
       it do
+        sleep 1
         expect(client.rules(enabled: true, fields: [:script].join(',')).first).to_not(include('order', 'name'))
       end
     end
@@ -43,14 +53,21 @@ describe Auth0::Api::V2::Rules do
 
   describe '.rule' do
     it do
+      sleep 1
       expect(client.rule(enabled_rule['id'])).to(
         include('stage' => enabled_rule['stage'], 'order' => enabled_rule['order'], 'script' => enabled_rule['script'])
       )
     end
 
     context '#filters' do
-      let(:rule_include) { client.rule(enabled_rule['id'], fields: [:stage, :order, :script].join(',')) }
-      let(:rule_not_include) { client.rule(enabled_rule['id'], fields: :stage, include_fields: false) }
+      let(:rule_include) do
+        sleep 1
+        client.rule(enabled_rule['id'], fields: [:stage, :order, :script].join(','))
+      end
+      let(:rule_not_include) do
+        sleep 1
+        client.rule(enabled_rule['id'], fields: :stage, include_fields: false)
+      end
 
       it do
         expect(rule_include).to(include('stage', 'order', 'script'))
@@ -69,16 +86,28 @@ describe Auth0::Api::V2::Rules do
     let(:stage) { 'login_success' }
     let(:script) { 'function(test)' }
     let(:enabled) { false }
-    let!(:rule) { client.create_rule(name, script, order, enabled, stage) }
+    let!(:rule) do
+      sleep 1
+      client.create_rule(name, script, order, enabled, stage)
+    end
     it { expect(rule).to include('name' => name, 'stage' => stage, 'order' => order, 'script' => script) }
   end
 
   describe '.delete_rule' do
-    it { expect { client.delete_rule(enabled_rule['id']) }.to_not raise_error }
-    it { expect { client.delete_rule '' }.to raise_error(Auth0::InvalidParameter) }
+    it do
+      sleep 1
+      expect { client.delete_rule(enabled_rule['id']) }.to_not raise_error
+    end
+    it do
+      sleep 1
+      expect { client.delete_rule '' }.to raise_error(Auth0::InvalidParameter)
+    end
   end
 
   describe '.update_rule' do
-    it { expect(client.update_rule(disabled_rule['id'], enabled: true)).to(include('enabled' => true)) }
+    it do
+      sleep 1
+      expect(client.update_rule(disabled_rule['id'], enabled: true)).to(include('enabled' => true))
+    end
   end
 end

--- a/spec/integration/lib/auth0/api/v2/api_stats_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_stats_spec.rb
@@ -3,14 +3,20 @@ describe Auth0::Api::V2::Stats do
   let(:client) { Auth0Client.new(v2_creds) }
 
   describe '.active_users' do
-    it { expect(Integer(client.active_users)).to be >= 0 }
+    it do
+      sleep 1
+      expect(Integer(client.active_users)).to be >= 0
+    end
   end
 
   # rubocop:disable Date
   describe '.daily_stats' do
     let(:from) { Date.today.prev_day.strftime('%Y%m%d') }
     let(:to) { Date.today.strftime('%Y%m%d') }
-    let(:daily_stats) { client.daily_stats(from, to) }
+    let(:daily_stats) do
+      sleep 1
+      client.daily_stats(from, to)
+    end
     it { expect(daily_stats.size).to be > 0 }
   end
 end

--- a/spec/integration/lib/auth0/api/v2/api_tenants_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_tenants_spec.rb
@@ -16,13 +16,20 @@ describe Auth0::Api::V2::Tenants do
       'support_url' => 'https://mycompany.org/support'
     }
 
+    sleep 1
     client.update_tenant_settings(body)
   end
 
   describe '.get_tenant_settings' do
-    it { expect(client.get_tenant_settings).to include(body) }
+    it do
+      sleep 1
+      expect(client.get_tenant_settings).to include(body)
+    end
 
-    let(:tenant_setting_fields) { client.get_tenant_settings(fields: 'picture_url') }
+    let(:tenant_setting_fields) do
+      sleep 1
+      client.get_tenant_settings(fields: 'picture_url')
+    end
     it { expect(tenant_setting_fields).to_not include('friendly_name' => 'My Company') }
     it { expect(tenant_setting_fields).to include('picture_url' => 'https://mycompany.org/logo.png') }
   end
@@ -32,6 +39,9 @@ describe Auth0::Api::V2::Tenants do
     let(:body_tenant) do
       { 'friendly_name' => tenant_name }
     end
-    it { expect(client.update_tenant_settings(body_tenant)['friendly_name']).to include(tenant_name) }
+    it do
+      sleep 1
+      expect(client.update_tenant_settings(body_tenant)['friendly_name']).to include(tenant_name)
+    end
   end
 end

--- a/spec/integration/lib/auth0/api/v2/api_tickets_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_tickets_spec.rb
@@ -7,6 +7,7 @@ describe Auth0::Api::V2::Tickets do
     username = Faker::Internet.user_name
     email = "#{entity_suffix}#{Faker::Internet.safe_email(username)}"
     password = Faker::Internet.password
+    sleep 1
     @user = client.create_user(username,  'email' => email,
                                           'password' => password,
                                           'email_verified' => false,
@@ -15,16 +16,21 @@ describe Auth0::Api::V2::Tickets do
   end
 
   after(:all) do
+    sleep 1
     client.delete_user(user['user_id'])
   end
 
   describe '.post_email_verification' do
-    let(:email_verification) { client.post_email_verification(user['user_id'], result_url: 'http://myapp.com/callback') }
+    let(:email_verification) do
+      sleep 1
+      client.post_email_verification(user['user_id'], result_url: 'http://myapp.com/callback')
+    end
     it { expect(email_verification).to include('ticket') }
   end
 
   describe '.post_password_change' do
     let(:password_change) do
+      sleep 1
       client.post_password_change(new_password: 'secret', user_id: user['user_id'],
                                   result_url: 'http://myapp.com/callback')
     end

--- a/spec/integration/lib/auth0/api/v2/api_users_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_users_spec.rb
@@ -5,6 +5,7 @@ describe Auth0::Api::V2::Users do
   let(:email) { "#{entity_suffix}#{Faker::Internet.safe_email(username)}" }
   let(:password) { Faker::Internet.password }
   let!(:user) do
+    sleep 1
     client.create_user(username,  'email' => email,
                                   'password' => password,
                                   'email_verified' => false,
@@ -13,19 +14,30 @@ describe Auth0::Api::V2::Users do
   end
 
   describe '.users' do
-    let(:users) { client.users }
+    let(:users) do
+      sleep 1
+      client.users
+    end
 
     it { expect(users.size).to be > 0 }
 
     context '#filters' do
-      it { expect(client.users(per_page: 1).size).to be 1 }
       it do
+        sleep 1
+        expect(client.users(per_page: 1).size).to be 1
+      end
+      it do
+        sleep 1
         expect(
           client.users(per_page: 1, fields: [:picture, :email, :user_id].join(','), include_fields: true).first
         ).to(include('email', 'user_id', 'picture'))
       end
-      it { expect(client.users(per_page: 1, fields: [:email].join(',')).first).to_not include('user_id', 'picture') }
       it do
+        sleep 1
+        expect(client.users(per_page: 1, fields: [:email].join(',')).first).to_not include('user_id', 'picture')
+      end
+      it do
+        sleep 1
         expect(
           client.users(per_page: 1, fields: [:email].join(','), include_fields: false).first
         ).to include('user_id', 'picture')
@@ -34,15 +46,20 @@ describe Auth0::Api::V2::Users do
   end
 
   describe '.user' do
-    let(:subject) { client.user(user['user_id']) }
+    let(:subject) do
+      sleep 1
+      client.user(user['user_id'])
+    end
 
     it { should include('email' => email, 'name' => username) }
     it do
+      sleep 1
       expect(
         client.user(user['user_id'], fields: [:picture, :email, :user_id].join(','), include_fields: true)
       ).to(include('email', 'user_id', 'picture'))
     end
     it do
+      sleep 1
       expect(
         client.user(user['user_id'], fields: [:picture, :email, :user_id].join(','), include_fields: false)
       ).not_to(include('email', 'user_id', 'picture'))
@@ -50,11 +67,15 @@ describe Auth0::Api::V2::Users do
 
     context '#filters' do
       it do
+        sleep 1
         expect(client.user(user['user_id'], fields: [:picture, :email, :user_id].join(','))).to(
           include('email', 'user_id', 'picture')
         )
       end
-      it { expect(client.user(user['user_id'], fields: [:email].join(','))).to_not include('user_id', 'picture') }
+      it do
+        sleep 1
+        expect(client.user(user['user_id'], fields: [:email].join(','))).to_not include('user_id', 'picture')
+      end
     end
   end
 
@@ -62,16 +83,28 @@ describe Auth0::Api::V2::Users do
     let(:subject) { user }
 
     it { should include('user_id', 'identities') }
-    it { expect(client.patch_user(user['user_id'], 'email_verified' => true)).to include('email_verified' => true) }
+    it do
+      sleep 1
+      expect(client.patch_user(user['user_id'], 'email_verified' => true)).to include('email_verified' => true)
+    end
   end
 
   describe '.delete_user' do
-    it { expect { client.delete_user user['user_id'] }.to_not raise_error }
-    it { expect { client.delete_user '' }.to raise_error(Auth0::MissingUserId) }
+    it do
+      sleep 1
+      expect { client.delete_user user['user_id'] }.to_not raise_error
+    end
+    it do
+      sleep 1
+      expect { client.delete_user '' }.to raise_error(Auth0::MissingUserId)
+    end
   end
 
   describe '.patch_user' do
-    it { expect(client.patch_user(user['user_id'], 'email_verified' => true)).to(include('email_verified' => true)) }
+    it do
+      sleep 1
+      expect(client.patch_user(user['user_id'], 'email_verified' => true)).to(include('email_verified' => true))
+    end
     let(:body_path) do
       {
         'user_metadata' => {
@@ -80,6 +113,7 @@ describe Auth0::Api::V2::Users do
       }
     end
     it do
+      sleep 1
       expect(
         client.patch_user(user['user_id'], body_path)
       ).to(include('user_metadata' => { 'addresses' => { 'home_address' => '742 Evergreen Terrace' } }))
@@ -89,6 +123,7 @@ describe Auth0::Api::V2::Users do
   describe '.link_user_account and .unlink_users_account' do
     let(:email_link) { "#{entity_suffix}#{Faker::Internet.safe_email(Faker::Internet.user_name)}" }
     let!(:link_user) do
+      sleep 1
       client.create_user(username,  'email' => email_link,
                                     'password' => Faker::Internet.password,
                                     'email_verified' => false,
@@ -97,6 +132,7 @@ describe Auth0::Api::V2::Users do
     end
     let(:email_primary) { "#{entity_suffix}#{Faker::Internet.safe_email(Faker::Internet.user_name)}" }
     let!(:primary_user) do
+      sleep 1
       client.create_user(username,  'email' => email_primary,
                                     'password' => Faker::Internet.password,
                                     'email_verified' => false,


### PR DESCRIPTION
Add delay to integration test in order to avoid 429 error for exceeding API rate limit.