### PR TITLE
Add support to /api/v2/users-by-email

### DIFF
--- a/lib/auth0/api/v2.rb
+++ b/lib/auth0/api/v2.rb
@@ -8,6 +8,7 @@ require 'auth0/api/v2/jobs'
 require 'auth0/api/v2/rules'
 require 'auth0/api/v2/stats'
 require 'auth0/api/v2/users'
+require 'auth0/api/v2/users_by_email'
 require 'auth0/api/v2/user_blocks'
 require 'auth0/api/v2/tenants'
 require 'auth0/api/v2/tickets'
@@ -28,6 +29,7 @@ module Auth0
       include Auth0::Api::V2::Rules
       include Auth0::Api::V2::Stats
       include Auth0::Api::V2::Users
+      include Auth0::Api::V2::UsersByEmail
       include Auth0::Api::V2::UserBlocks
       include Auth0::Api::V2::Tenants
       include Auth0::Api::V2::Tickets

--- a/lib/auth0/api/v2/users_by_email.rb
+++ b/lib/auth0/api/v2/users_by_email.rb
@@ -1,0 +1,35 @@
+module Auth0
+  module Api
+    module V2
+      # Methods to use the Users By Email endpoints
+      module UsersByEmail
+        attr_reader :users_by_email_path
+
+        # Retrieves a list of existing users by their email.
+        # @see https://auth0.com/docs/api/v2#!/Users/get_users
+        # @see https://auth0.com/docs/api/management/v2#!/Users_By_Email/get_users_by_email
+        # @param fields [string] A comma separated list of fields to include or exclude from the result.
+        # @param include_fields [boolean] True if the fields specified are to be included in the result, false otherwise.
+        # @param email [string] E-mail to be searched
+        #
+        # @return [json] Returns the list of existing users.
+        def users_by_email(email, options = {})
+          raise Auth0::InvalidParameter, 'Must supply a valid email' if email.to_s.empty?
+          request_params = {
+            fields:         options.fetch(:fields, nil),
+            include_fields: options.fetch(:include_fields, nil)
+          }
+          request_params[:email] = email
+          get(users_by_email_path, request_params)
+        end
+
+        private
+
+        # Users By Emails API path
+        def users_by_email_path
+          @users_by_email_path ||= '/api/v2/users-by-email'
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/auth0/api/v2/users_by_email_spec.rb
+++ b/spec/lib/auth0/api/v2/users_by_email_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+describe Auth0::Api::V2::UsersByEmail do
+  before :all do
+    dummy_instance = DummyClass.new
+    dummy_instance.extend(Auth0::Api::V2::UsersByEmail)
+    @instance = dummy_instance
+  end
+
+  context '.users_by_email' do
+    it { expect(@instance).to respond_to(:users_by_email) }
+    it 'is expected to call /api/v2/users-by-email' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/users-by-email',
+        fields: nil,
+        include_fields: nil,
+        email: 'email'
+      )
+      expect { @instance.users_by_email('email') }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
Hey, we would like to use the `users-by-email` API. I've tested locally against auth0 and it seems to be working fine. Should I also add an integration test?

Thanks!

API docs https://auth0.com/docs/api/management/v2#!/Users_By_Email/get_users_by_email