### PR TITLE
Correctly default grant_type to 'password' in login method

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -63,7 +63,7 @@ module Auth0
           password:      password,
           scope:         options.fetch(:scope, 'openid'),
           connection:    connection_name,
-          grant_type:    options.fetch(:grant_type, password),
+          grant_type:    options.fetch(:grant_type, 'password'),
           id_token:      id_token,
           device:        options.fetch(:device, nil)
         }

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -63,10 +63,10 @@ describe Auth0::Api::AuthenticationEndpoints do
         client_id: @instance.client_id,
         username: 'test@test.com',
         client_secret: @instance.client_secret,
-        password: 'password', scope: 'openid', connection: 'Username-Password-Authentication',
+        password: 'test12345', scope: 'openid', connection: 'Username-Password-Authentication',
         grant_type: 'password', id_token: nil, device: nil
       )
-      @instance.login('test@test.com', 'password')
+      @instance.login('test@test.com', 'test12345')
     end
     it { expect { @instance.login('', '') }.to raise_error 'Must supply a valid username' }
     it { expect { @instance.login('username', '') }.to raise_error 'Must supply a valid password' }


### PR DESCRIPTION
This PR changes the default `grant_type` option in `AuthenticationEndpoints#login` from the value of the password parameter to "password". It also updates the spec to use a test password other than "password" to verify that the default grant type is set correctly.