### PR TITLE
Add ability to login via the oauth/ro endpoint

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -70,6 +70,26 @@ module Auth0
         post('/oauth/token', request_params)
       end
 
+      # Login using username/password with the /oauth/ro endpoint
+      # @see https://auth0.com/docs/auth-api#!#post--oauth-ro
+      # @param username [string] Username
+      # @param password [string] User's password
+      # Active Directory/LDAP, Windows Azure AD and ADF
+      # @return [json] Returns the access token and id token
+      def login_with_legacy_endpoint(username, password)
+        raise Auth0::InvalidParameter, 'Must supply a valid username' if username.to_s.empty?
+        raise Auth0::InvalidParameter, 'Must supply a valid password' if password.to_s.empty?
+        request_params = {
+          client_id:  @client_id,
+          username:   username,
+          password:   password,
+          connection: UP_AUTH,
+          grant_type: 'password',
+          scope:      'openid'
+        }
+        post('/oauth/ro', request_params)
+      end
+
       # Signup using username/password
       # @see https://auth0.com/docs/auth-api#!#post--dbconnections-signup
       # @param email [string] User email

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -72,6 +72,24 @@ describe Auth0::Api::AuthenticationEndpoints do
     it { expect { @instance.login('username', '') }.to raise_error 'Must supply a valid password' }
   end
 
+  context '.login_with_legacy_endpoint' do
+    it { expect(@instance).to respond_to(:login_with_legacy_endpoint) }
+    it 'is expected to make post to /oauth/ro' do
+      expect(@instance).to receive(:post).with(
+        '/oauth/ro',
+        client_id: @instance.client_id,
+        username: 'test@test.com',
+        password: 'test12345',
+        connection: 'Username-Password-Authentication',
+        grant_type: 'password',
+        scope: 'openid'
+      )
+      @instance.login_with_legacy_endpoint('test@test.com', 'test12345')
+    end
+    it { expect { @instance.login('', '') }.to raise_error 'Must supply a valid username' }
+    it { expect { @instance.login('username', '') }.to raise_error 'Must supply a valid password' }
+  end
+
   context '.signup' do
     it { expect(@instance).to respond_to(:signup) }
     it 'is expected to make post to /dbconnections/signup' do


### PR DESCRIPTION
This PR introduces `AuthenticationEndpoints.login_with_legacy_endpoint` to post username and password credentials to the "/oauth/ro" endpoint that is currently still available for some auth0 accounts. 

This makes it possible to reap the benefits of upgrading the auth0 gem including upgrading to rest-client 2.x without having to change the `grant_type` or introduce `audience` and `realm` parameters that the `.login` method does not yet support.