### PR TITLE
Use Secure RubyGems Source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in auth0.gemspec
 gemspec


### PR DESCRIPTION
This PR switches the Gemfile over to use the HTTPS RubyGems source, as advised by running `bundle audit` on the project.