### PR TITLE
Add pagination and tests to Clients and Connections endpoints

### DIFF
--- a/lib/auth0/api/v2/clients.rb
+++ b/lib/auth0/api/v2/clients.rb
@@ -6,16 +6,19 @@ module Auth0
         attr_reader :clients_path
 
         # Retrieves a list of all client applications. Accepts a list of fields to include or exclude.
-        # @see https://auth0.com/docs/api/v2#!/clients/get_clients
-        # @param fields [string] A comma separated list of fields to include or exclude from the result.
+        # @see https://auth0.com/docs/api/management/v2#!/Clients/get_clients
+        # @param fields [string|Array] A comma separated list or an array of fields.
         # @param include_fields [boolean] True if the fields specified are to be included in the result, false otherwise.
-        #
+        # @param page [int] Page number to get, 0-based.
+        # @param per_page [int] Results per page if also passing a page number.
         # @return [json] Returns the clients applications.
-        def clients(fields: nil, include_fields: nil)
+        def clients(fields: nil, include_fields: nil, page: nil, per_page: nil)
           include_fields = true if !fields.nil? && include_fields.nil?
           request_params = {
-            fields: fields,
-            include_fields: include_fields
+            fields: fields.is_a?(Array) ? fields.join(',') : fields,
+            include_fields: include_fields,
+            page: !page.nil? ? page.to_i : nil,
+            per_page: !page.nil? && !per_page.nil? ? per_page.to_i : nil
           }
           get(clients_path, request_params)
         end

--- a/lib/auth0/api/v2/connections.rb
+++ b/lib/auth0/api/v2/connections.rb
@@ -7,18 +7,27 @@ module Auth0
 
         # Retrieves every connection matching the specified strategy. All connections are retrieved if no strategy is
         # being specified. Accepts a list of fields to include or exclude in the resulting list of connection objects.
-        # @see https://auth0.com/docs/api/v2#!/Connections/get_connections
-        # @param strategy [string] Provide a type of strategy to only retrieve connections with that strategy (e.g. 'ad',
-        # 'facebook', 'twitter').
+        # @see https://auth0.com/docs/api/management/v2#!/Connections/get_connections
+        # @param strategy [string] Strategy to filter connection results.
         # @param fields [string] A comma separated list of fields to include or exclude from the result.
         # @param include_fields [boolean] True if the fields specified are to be included in the result, false otherwise.
-        #
+        # @param page [int] Page number to get, 0-based.
+        # @param per_page [int] Results per page if also passing a page number.
         # @return [json] Returns the existing connections matching the strategy.
-        def connections(strategy: nil, fields: nil, include_fields: true)
+        def connections(
+          strategy: nil,
+          fields: nil,
+          include_fields: nil,
+          page: nil,
+          per_page: nil
+        )
+          include_fields = true if !fields.nil? && include_fields.nil?
           request_params = {
             strategy: strategy,
-            fields: fields,
-            include_fields: include_fields
+            fields: fields.is_a?(Array) ? fields.join(',') : fields,
+            include_fields: include_fields,
+            page: !page.nil? ? page.to_i : nil,
+            per_page: !page.nil? && !per_page.nil? ? per_page.to_i : nil
           }
           get(connections_path, request_params)
         end

--- a/spec/integration/lib/auth0/api/v2/api_clients_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_clients_spec.rb
@@ -26,15 +26,31 @@ describe Auth0::Api::V2::Clients do
     context '#filters' do
       it do
         sleep 1
-        expect(client.clients(fields: [:name, :callbacks].join(',')).first).to(include('name', 'callbacks'))
+        expect(client.clients(
+          fields: [:name, :callbacks].join(',')
+        ).first).to(include('name', 'callbacks'))
       end
       it do
         sleep 1
-        expect(client.clients(fields: [:callbacks].join(',')).first).to_not(include('name'))
+        expect(client.clients(
+          fields: [:callbacks].join(',')).first
+        ).to_not(include('name'))
       end
       it do
         sleep 1
-        expect(client.clients(fields: [:callbacks].join(','), include_fields: false).first).to_not(include('callbacks'))
+        expect(client.clients(
+          fields: [:callbacks].join(','),
+          include_fields: false
+        ).first).to_not(include('callbacks'))
+      end
+      it do
+        sleep 1
+        results = client.clients(
+          fields: :name,
+          page: 0,
+          per_page: 1
+        )
+        expect(results.first).to equal(results.last)
       end
     end
   end

--- a/spec/lib/auth0/api/v2/clients_spec.rb
+++ b/spec/lib/auth0/api/v2/clients_spec.rb
@@ -5,18 +5,62 @@ describe Auth0::Api::V2::Clients do
     dummy_instance.extend(Auth0::Api::V2::Clients)
     @instance = dummy_instance
   end
+  
   context '.clients' do
     it { expect(@instance).to respond_to(:clients) }
     it { expect(@instance).to respond_to(:get_clients) }
+
     it 'is expected to send get request to /api/v2/clients/' do
-      expect(@instance).to receive(:get).with('/api/v2/clients', fields: nil, include_fields: nil)
+      expect(@instance).to receive(:get).with(
+        '/api/v2/clients',
+        fields: nil,
+        include_fields: nil,
+        page: nil,
+        per_page: nil
+      )
       expect { @instance.clients }.not_to raise_error
     end
+
     it 'is expected to send get request to /api/v2/clients?fields=name' do
-      expect(@instance).to receive(:get).with('/api/v2/clients', include_fields: true, fields: [:name])
-      expect { @instance.clients(fields: [:name], include_fields: true) }.not_to raise_error
+      expect(@instance).to receive(:get).with(
+        '/api/v2/clients',
+        include_fields: true,
+        fields: 'name',
+        page: nil,
+        per_page: nil
+      )
+      expect {
+        @instance.clients(fields: 'name', include_fields: true)
+      }.not_to raise_error
+    end
+
+    it 'is expected to convert fields param from Array to string' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/clients',
+        include_fields: true,
+        fields: 'name,app_type',
+        page: nil,
+        per_page: nil
+      )
+      expect {
+        @instance.clients(fields: ['name','app_type'], include_fields: true)
+      }.not_to raise_error
+    end
+
+    it 'is expected to add pagination' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/clients',
+        page: 1,
+        per_page: 10,
+        fields: nil,
+        include_fields: nil
+      )
+      expect {
+        @instance.clients(page: 1, per_page: 10)
+      }.not_to raise_error
     end
   end
+
   context '.client' do
     it { expect(@instance).to respond_to(:client) }
     it 'is expected to send get request to /api/v2/clients/1' do
@@ -38,6 +82,7 @@ describe Auth0::Api::V2::Clients do
     end
     it { expect { @instance.create_client('') }.to raise_error 'Must specify a valid client name' }
   end
+
   context '.delete_client' do
     it { expect(@instance).to respond_to(:delete_client) }
     it 'is expected to send delete to /api/v2/clients/1' do

--- a/spec/lib/auth0/api/v2/clients_spec.rb
+++ b/spec/lib/auth0/api/v2/clients_spec.rb
@@ -5,12 +5,12 @@ describe Auth0::Api::V2::Clients do
     dummy_instance.extend(Auth0::Api::V2::Clients)
     @instance = dummy_instance
   end
-  
+
   context '.clients' do
     it { expect(@instance).to respond_to(:clients) }
     it { expect(@instance).to respond_to(:get_clients) }
 
-    it 'is expected to send get request to /api/v2/clients/' do
+    it 'is expected to send get request to the Clients endpoint' do
       expect(@instance).to receive(:get).with(
         '/api/v2/clients',
         fields: nil,
@@ -21,7 +21,7 @@ describe Auth0::Api::V2::Clients do
       expect { @instance.clients }.not_to raise_error
     end
 
-    it 'is expected to send get request to /api/v2/clients?fields=name' do
+    it 'is expected to send get request to the Clients endpoint with a name parameter' do
       expect(@instance).to receive(:get).with(
         '/api/v2/clients',
         include_fields: true,
@@ -34,7 +34,7 @@ describe Auth0::Api::V2::Clients do
       }.not_to raise_error
     end
 
-    it 'is expected to convert fields param from Array to string' do
+    it 'is expected to send get request to Clients endpoint using an array of fields' do
       expect(@instance).to receive(:get).with(
         '/api/v2/clients',
         include_fields: true,
@@ -47,7 +47,7 @@ describe Auth0::Api::V2::Clients do
       }.not_to raise_error
     end
 
-    it 'is expected to add pagination' do
+    it 'is expected to send get request to Clients endpoint with pagination' do
       expect(@instance).to receive(:get).with(
         '/api/v2/clients',
         page: 1,

--- a/spec/lib/auth0/api/v2/connections_spec.rb
+++ b/spec/lib/auth0/api/v2/connections_spec.rb
@@ -15,9 +15,53 @@ describe Auth0::Api::V2::Connections do
         '/api/v2/connections',
         strategy: nil,
         fields: nil,
-        include_fields: true
+        include_fields: nil,
+        page: nil,
+        per_page: nil
       )
       expect { @instance.connections }.not_to raise_error
+    end
+
+    it 'is expected to send get request to /api/v2/connections?fields=name' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/connections',
+        include_fields: true,
+        fields: 'name',
+        strategy: nil,
+        page: nil,
+        per_page: nil
+      )
+      expect {
+        @instance.connections(fields: 'name', include_fields: true)
+      }.not_to raise_error
+    end
+
+    it 'is expected to convert fields param from Array to string' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/connections',
+        include_fields: true,
+        fields: 'name,strategy',
+        strategy: nil,
+        page: nil,
+        per_page: nil
+      )
+      expect {
+        @instance.connections(fields: ['name','strategy'], include_fields: true)
+      }.not_to raise_error
+    end
+
+    it 'is expected to add pagination' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/connections',
+        page: 1,
+        per_page: 10,
+        strategy: nil,
+        fields: nil,
+        include_fields: nil
+      )
+      expect {
+        @instance.connections(page: 1, per_page: 10)
+      }.not_to raise_error
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ Dir['./spec/support/**/*.rb'].each { |f| require f }
 Dir['./spec/support/*.rb'].each { |f| require f }
 
 def entity_suffix
-  (ENV['TRAVIS_JOB_ID'] || 'local').delete('_')
+  (ENV['TRAVIS_JOB_ID'] || ENV['TEST_ENTITY_SUFFIX'] || 'rubytest').delete('_')
 end
 
 puts "Entity suffix is #{entity_suffix}"

--- a/spec/spec_helper_full.rb
+++ b/spec/spec_helper_full.rb
@@ -27,7 +27,7 @@ RSpec.configure do |config|
       }
     v2_client
       .users
-      .select { |user| user['email'].split('@').first.include? entity_suffix }
+      .select { |user| !user['email'].nil? && user['email'].split('@').first.include?(entity_suffix) }
       .each { |user|
         sleep 1
         v2_client.delete_user(user['user_id'])

--- a/spec/spec_helper_full.rb
+++ b/spec/spec_helper_full.rb
@@ -26,10 +26,9 @@ RSpec.configure do |config|
         v2_client.delete_client(client['client_id'])
       }
     v2_client
-      .users
-      .select { |user| !user['email'].nil? && user['email'].split('@').first.include?(entity_suffix) }
+      .users(q: "email:#{entity_suffix}*", fields: 'user_id', page: 0, per_page: 50)
       .each { |user|
-        sleep 1
+        sleep 0.6
         v2_client.delete_user(user['user_id'])
       }
     puts "Finished cleaning up for #{entity_suffix}"


### PR DESCRIPTION
- Add new `:page` and `:per_page` method parameters to `Auth0::Api::V2::Clients` and `Auth0::Api::V2::Connections` modules.
- Add ability to pass an `Array` for the `fields:` parameter and convert to comma-sep string
- Add tests for all changes above.