### PR TITLE
Add search_engine parameter to Users endpoint + tests

### DIFF
--- a/lib/auth0/api/v2/users.rb
+++ b/lib/auth0/api/v2/users.rb
@@ -5,18 +5,21 @@ module Auth0
       module Users
         attr_reader :users_path
 
-        # Retrieves a list of existing users.
-        # @see https://auth0.com/docs/api/v2#!/Users/get_users
-        # @param per_page [integer] The amount of entries per page. Default: 50. Max value: 100.
-        # @param page [integer]  The page number. Zero based.
-        # @param include_totals [boolean] True if a query summary must be included in the result.
-        # @param sort [string] The field to use for sorting. 1 == ascending and -1 == descending.
-        # @param connection [string] Connection filter.
-        # @param fields [string] A comma separated list of fields to include or exclude from the result.
-        # @param include_fields [boolean] True if the fields specified are to be included in the result, false otherwise.
-        # @param q [string] Query in Lucene query string syntax. Only fields in app_metadata, user_metadata or the
-        # normalized user profile are searchable.
-        #
+        # Retrieves a list of Auth0 users.
+        # @see https://auth0.com/docs/api/management/v2#!/Users/get_users
+        # @param options - The Hash options used to refine the User results.
+        #   :per_page [integer] The amount of entries per page. Default: 50. Max value: 100.
+        #   :page [integer] The page number. Zero based.
+        #   :include_totals [boolean] True if a query summary must be included in the result.
+        #   :sort [string] The field to use for sorting. 1 == ascending and -1 == descending.
+        #   :connection [string] Connection to filter results by.
+        #   :fields [string] A comma separated list of result fields.
+        #   :include_fields [boolean] True to include :fields, false to exclude.
+        #   :q [string] Query in Lucene query string syntax.
+        #   :search_engine [string] User search engine version.
+        #     - Will default to v2 if no value is passed.
+        #     - Default will change to v3 on 11/13/2018
+        #     - See https://auth0.com/docs/users/search/v3#migrate-from-search-engine-v2-to-v3
         # @return [json] Returns the list of existing users.
         def users(options = {})
           request_params = {
@@ -27,9 +30,9 @@ module Auth0
             connection:     options.fetch(:connection, nil),
             fields:         options.fetch(:fields, nil),
             include_fields: options.fetch(:include_fields, nil),
-            q:              options.fetch(:q, nil)
+            q:              options.fetch(:q, nil),
+            search_engine:  options.fetch(:search_engine, nil)
           }
-          request_params[:search_engine] = :v2 if request_params[:q]
           get(users_path, request_params)
         end
         alias get_users users

--- a/spec/integration/lib/auth0/api/v2/api_users_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_users_spec.rb
@@ -52,7 +52,7 @@ describe Auth0::Api::V2::Users do
           client.users(
             per_page: 1,
             fields: 'user_id',
-            q: "updated_at:>=2016-01-01",
+            q: "updated_at:{2016-01-01 TO *}",
             search_engine: 'v2'
           ).first
         ).to include('user_id')

--- a/spec/integration/lib/auth0/api/v2/api_users_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_users_spec.rb
@@ -45,6 +45,30 @@ describe Auth0::Api::V2::Users do
           client.users(per_page: 1, fields: [:email].join(','), include_fields: false).first
         ).to include('user_id', 'picture')
       end
+
+      it 'is expected to find a user with a v2 search engine query' do
+        sleep 1
+        expect(
+          client.users(
+            per_page: 1,
+            fields: 'user_id',
+            q: "updated_at:>=2016-01-01",
+            search_engine: 'v2'
+          ).first
+        ).to include('user_id')
+      end
+
+      it 'is expected to find a user with a v3 search engine query' do
+        sleep 1
+        expect(
+          client.users(
+            per_page: 1,
+            fields: 'user_id',
+            q: "updated_at:[2016-01-01 TO *]",
+            search_engine: 'v3'
+          ).first
+        ).to include('user_id')
+      end
     end
   end
 
@@ -150,19 +174,6 @@ describe Auth0::Api::V2::Users do
     end
 
     let(:body_link) { { 'provider' => 'auth0', 'user_id' => link_user['user_id'] } }
-    skip 'Link user account examples are skipped to avoid errors on users deletion' do
-      it do
-        expect(
-          client.link_user_account(primary_user['user_id'], body_link).first
-        ).to include('provider' => 'auth0', 'user_id' => primary_user['identities'].first['user_id'])
-      end
-
-      it do
-        expect(
-          client.unlink_users_account(primary_user['user_id'], 'auth0', link_user['user_id']).first
-        ).to include('provider' => 'auth0', 'user_id' => primary_user['identities'].first['user_id'])
-      end
-    end
   end
 
 end

--- a/spec/lib/auth0/api/v2/users_spec.rb
+++ b/spec/lib/auth0/api/v2/users_spec.rb
@@ -9,6 +9,7 @@ describe Auth0::Api::V2::Users do
   context '.users' do
     it { expect(@instance).to respond_to(:users) }
     it { expect(@instance).to respond_to(:get_users) }
+
     it 'is expected to call /api/v2/users' do
       expect(@instance).to receive(:get).with(
         '/api/v2/users',
@@ -19,9 +20,26 @@ describe Auth0::Api::V2::Users do
         connection: nil,
         fields: nil,
         include_fields: nil,
-        q: nil
+        q: nil,
+        search_engine: nil
       )
       expect { @instance.users }.not_to raise_error
+    end
+
+    it 'is expected to call /api/v2/users with a search engine' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/users',
+        per_page: nil,
+        page: nil,
+        include_totals: nil,
+        sort: nil,
+        connection: nil,
+        fields: nil,
+        include_fields: nil,
+        q: nil,
+        search_engine: 'v3'
+      )
+      expect { @instance.users(search_engine: 'v3') }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
- Replace the hard-coded search engine version `v2` with a modifiable one
- Improve docs for the method
- Add unit and integration tests
- Remove skipped user test