### PR TITLE
Add pagination and tests for Client Grants

### DIFF
--- a/lib/auth0/api/v2/client_grants.rb
+++ b/lib/auth0/api/v2/client_grants.rb
@@ -7,10 +7,15 @@ module Auth0
 
         # Retrieves a list of all client grants.
         # @see https://auth0.com/docs/api/management/v2#!/client_grants/get_client_grants
-        #
+        # @param page [int] Page number to get, 0-based.
+        # @param per_page [int] Results per page if also passing a page number.
         # @return [json] Returns the client grants.
-        def client_grants
-          get(client_grants_path)
+        def client_grants (page: nil, per_page: nil)
+          request_params = {
+            page: !page.nil? ? page.to_i : nil,
+            per_page: !page.nil? && !per_page.nil? ? per_page.to_i : nil
+          }
+          get(client_grants_path, request_params)
         end
         alias get_all_client_grants client_grants
 

--- a/lib/auth0/api/v2/client_grants.rb
+++ b/lib/auth0/api/v2/client_grants.rb
@@ -12,8 +12,8 @@ module Auth0
         # @return [json] Returns the client grants.
         def client_grants (page: nil, per_page: nil)
           request_params = {
-            page: !page.nil? ? page.to_i : nil,
-            per_page: !page.nil? && !per_page.nil? ? per_page.to_i : nil
+            page: page,
+            per_page: per_page
           }
           get(client_grants_path, request_params)
         end

--- a/spec/integration/lib/auth0/api/v2/api_client_grants_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_client_grants_spec.rb
@@ -5,45 +5,49 @@ describe Auth0::Api::V2::ClientGrants do
   before(:all) do
     @client = Auth0Client.new(v2_creds)
     @client_id = v2_creds[:client_id]
-    sleep 1
-    @existing_client = client.create_client("client#{entity_suffix}")
-    sleep 1
+    @existing_client = client.create_client("client-grant-test-#{entity_suffix}")
     @audience = "https://#{client.clients[0]['tenant']}.auth0.com/api/v2/"
     @scope = [Faker::Lorem.word]
-    sleep 1
-    @existing_grant = client.create_client_grant('client_id' => existing_client['client_id'],
-                                                 'audience' => audience,
-                                                 'scope' => scope)
+    @existing_grant = client.create_client_grant(
+      'client_id' => existing_client['client_id'],
+      'audience' => audience,
+      'scope' => scope
+    )
   end
 
   after(:all) do
     grants = client.client_grants
     grants.each do |grant|
-      sleep 1
       client.delete_client_grant(grant['id'])
     end
   end
 
   describe '.client_grants' do
     let(:client_grants) do
-      sleep 1
       client.client_grants
     end
 
-    it do
-      sleep 1
+    it 'is expected to have a result' do
       expect(client_grants.size).to be > 0
     end
-    it do
-      sleep 1
+
+    it 'is expected to match the created grant' do
       expect(client_grants).to include(existing_grant)
+    end
+
+    it 'is expected to return the first page of one result' do
+      results = client.client_grants(
+        page: 0,
+        per_page: 1
+      )
+      expect(results.first).to equal(results.last)
+      expect(results.first).to eq(existing_grant)
     end
   end
 
   describe '.patch_client_grant' do
     let(:new_scope) { [Faker::Lorem.word] }
     it do
-      sleep 1
       expect(
         client.patch_client_grant(
           existing_grant['id'],
@@ -55,7 +59,6 @@ describe Auth0::Api::V2::ClientGrants do
 
   describe '.delete_client_grant' do
     it do
-      sleep 1
       expect { client.delete_client_grant(existing_grant['id']) }.to_not raise_error
     end
   end

--- a/spec/lib/auth0/api/v2/client_grants_spec.rb
+++ b/spec/lib/auth0/api/v2/client_grants_spec.rb
@@ -5,12 +5,27 @@ describe Auth0::Api::V2::ClientGrants do
     dummy_instance.extend(Auth0::Api::V2::ClientGrants)
     @instance = dummy_instance
   end
+
   context '.client_grants' do
     it { expect(@instance).to respond_to(:client_grants) }
     it { expect(@instance).to respond_to(:get_all_client_grants) }
-    it 'is expected to send get request to /api/v2/client_grants/' do
-      expect(@instance).to receive(:get).with('/api/v2/client-grants')
+
+    it 'is expected to get /api/v2/client-grants/' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/client-grants',
+        page: nil,
+        per_page: nil
+      )
       expect { @instance.client_grants }.not_to raise_error
+    end
+
+    it 'is expected to send get /api/v2/client-grants/ with pagination' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/client-grants',
+        page: 1,
+        per_page: 2
+      )
+      expect { @instance.client_grants(page: 1, per_page: 2) }.not_to raise_error
     end
   end
 


### PR DESCRIPTION
- Add `page` and `per_page` parameters to `Auth0::Api::V2::ClientGrants::client_grants` endpoint
- Add unit and integration tests for this change
- Remove `sleep` directives from the client grant integration tests