### PR TITLE
Add pagination and tests for Rules endpoint

### DIFF
--- a/lib/auth0/api/v2/rules.rb
+++ b/lib/auth0/api/v2/rules.rb
@@ -14,14 +14,18 @@ module Auth0
         # @param fields [string] A comma separated list of fields to include or exclude from the result.
         # @param include_fields [boolean] True if the fields specified are to be included in the result, false otherwise.
         # @param stage [string] Retrieves rules that match the execution stage (defaults to login_success).
+        # @param page [int] Page number to get, 0-based.
+        # @param per_page [int] Results per page if also passing a page number.
         #
         # @return [json] Returns the existing rules.
-        def rules(enabled: nil, fields: nil, include_fields: nil, stage: nil)
+        def rules(enabled: nil, fields: nil, include_fields: nil, stage: nil, page: nil, per_page: nil)
           request_params = {
             enabled:          enabled,
             fields:           fields,
             include_fields:   include_fields,
-            stage:            stage
+            stage:            stage,
+            page:             !page.nil? ? page.to_i : nil,
+            per_page:         !page.nil? && !per_page.nil? ? per_page.to_i : nil
           }
           get(rules_path, request_params)
         end

--- a/lib/auth0/api/v2/rules.rb
+++ b/lib/auth0/api/v2/rules.rb
@@ -24,8 +24,8 @@ module Auth0
             fields:           fields,
             include_fields:   include_fields,
             stage:            stage,
-            page:             !page.nil? ? page.to_i : nil,
-            per_page:         !page.nil? && !per_page.nil? ? per_page.to_i : nil
+            page:             page,
+            per_page:         per_page
           }
           get(rules_path, request_params)
         end

--- a/spec/integration/lib/auth0/api/v2/api_rules_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_rules_spec.rb
@@ -31,23 +31,29 @@ describe Auth0::Api::V2::Rules do
 
     context '#filters' do
       it do
+        sleep 0.5
         expect(client.rules(enabled: true).size).to be >= 1
       end
 
       it do
+        sleep 0.5
         expect(client.rules(enabled: false).size).to be >= 1
       end
 
       it do
+        sleep 0.5
         expect(client.rules(enabled: true, fields: [:script, :order].join(',')).first).to(include('script', 'order'))
       end
 
       it do
+        sleep 0.5
         expect(client.rules(enabled: true, fields: [:script].join(',')).first).to_not(include('order', 'name'))
       end
 
       it do
+        sleep 0.5
         rule_1 = client.rules(fields: :name, page: 0, per_page: 2)
+        sleep 0.5
         rule_2 = client.rules(fields: :name, page: 1, per_page: 1)
         expect(rule_1.last).to eq(rule_2.first)
       end

--- a/spec/integration/lib/auth0/api/v2/api_rules_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_rules_spec.rb
@@ -16,47 +16,46 @@ describe Auth0::Api::V2::Rules do
   after(:all) do
     rules = client.rules
     rules.each do |rule|
-      sleep 1
       client.delete_rule(rule['id'])
     end
   end
 
   describe '.rules' do
     let(:rules) do
-      sleep 1
       client.rules
     end
 
     it do
-      sleep 1
       expect(rules.size).to be > 0
     end
 
     context '#filters' do
       it do
-        sleep 1
         expect(client.rules(enabled: true).size).to be >= 1
       end
 
       it do
-        sleep 1
         expect(client.rules(enabled: false).size).to be >= 1
       end
 
       it do
-        sleep 1
         expect(client.rules(enabled: true, fields: [:script, :order].join(',')).first).to(include('script', 'order'))
       end
+
       it do
-        sleep 1
         expect(client.rules(enabled: true, fields: [:script].join(',')).first).to_not(include('order', 'name'))
+      end
+
+      it do
+        rule_1 = client.rules(fields: :name, page: 0, per_page: 2)
+        rule_2 = client.rules(fields: :name, page: 1, per_page: 1)
+        expect(rule_1.last).to eq(rule_2.first)
       end
     end
   end
 
   describe '.rule' do
     it do
-      sleep 1
       expect(client.rule(enabled_rule['id'])).to(
         include('stage' => enabled_rule['stage'], 'order' => enabled_rule['order'], 'script' => enabled_rule['script'])
       )
@@ -64,21 +63,17 @@ describe Auth0::Api::V2::Rules do
 
     context '#filters' do
       let(:rule_include) do
-        sleep 1
         client.rule(enabled_rule['id'], fields: [:stage, :order, :script].join(','))
       end
       let(:rule_not_include) do
-        sleep 1
         client.rule(enabled_rule['id'], fields: :stage, include_fields: false)
       end
 
       it do
-        sleep 1
         expect(rule_include).to(include('stage', 'order', 'script'))
       end
 
       it do
-        sleep 1
         expect(rule_not_include).to(include('order', 'script'))
         expect(rule_not_include).to_not(include('stage'))
       end
@@ -91,29 +86,24 @@ describe Auth0::Api::V2::Rules do
     let(:script) { 'function(test)' }
     let(:enabled) { false }
     let!(:rule) do
-      sleep 1
       client.create_rule(name, script, nil, enabled, stage)
     end
     it do
-      sleep 1
       expect(rule).to include('name' => name, 'stage' => stage, 'script' => script)
     end
   end
 
   describe '.delete_rule' do
     it do
-      sleep 1
       expect { client.delete_rule(enabled_rule['id']) }.to_not raise_error
     end
     it do
-      sleep 1
       expect { client.delete_rule '' }.to raise_error(Auth0::InvalidParameter)
     end
   end
 
   describe '.update_rule' do
     it do
-      sleep 1
       expect(client.update_rule(disabled_rule['id'], enabled: true)).to(include('enabled' => true))
     end
   end

--- a/spec/lib/auth0/api/v2/rules_spec.rb
+++ b/spec/lib/auth0/api/v2/rules_spec.rb
@@ -9,11 +9,33 @@ describe Auth0::Api::V2::Rules do
 
   context '.rules' do
     it { expect(@instance).to respond_to(:rules) }
+
     it 'is expected to call get /api/v2/rules' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/rules', enabled: nil, fields: nil, include_fields: nil, stage: nil
+        '/api/v2/rules',
+        enabled: nil,
+        fields: nil,
+        include_fields: nil,
+        stage: nil,
+        page: nil,
+        per_page: nil
       )
       expect { @instance.rules }.not_to raise_error
+    end
+
+    it 'is expected to call get /api/v2/rules with pagination' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/rules',
+        enabled: nil,
+        fields: nil,
+        include_fields: nil,
+        stage: nil,
+        page: 1,
+        per_page: 2
+      )
+      expect {
+        @instance.rules(page: 1, per_page: 2)
+      }.not_to raise_error
     end
   end
 

--- a/spec/spec_helper_full.rb
+++ b/spec/spec_helper_full.rb
@@ -28,7 +28,7 @@ RSpec.configure do |config|
     v2_client
       .users(q: "email:#{entity_suffix}*", fields: 'user_id', page: 0, per_page: 50)
       .each { |user|
-        sleep 0.6
+        sleep 1
         v2_client.delete_user(user['user_id'])
       }
     puts "Finished cleaning up for #{entity_suffix}"


### PR DESCRIPTION
- Add `page` and `per_page` parameters to `Auth0::Api::V2::Rules::rules` endpoint
- Add unit and integration tests for this change
- Remove `sleep` directives from the rules integration tests