### PR TITLE
Explicitly require JSON dependency

### DIFF
--- a/lib/auth0/mixins/initializer.rb
+++ b/lib/auth0/mixins/initializer.rb
@@ -1,3 +1,5 @@
+require 'json'
+
 module Auth0
   module Mixins
     # Help class where Auth0::Client initialization described


### PR DESCRIPTION
This module depends on JSON but doesn't load it. This commit makes that dependency explicit so the application doesn't have to load it.

In all fairness, it's pretty likely that the app _does_ load the `json` gem/stdlib (which is why this has been able to go unnoticed), but we should always load our own dependencies. :-)