### PR TITLE
Add VCR to and improve all integration tests

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,3 +1,4 @@
 ---
-BUNDLE_JOBS: '4'
-BUNDLE_BIN: bin
+BUNDLE_JOBS: "3"
+BUNDLE_BIN: "bin"
+BUNDLE_RETRY: "3"

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ end
 
 group :test do
   gem 'webmock', require: false
+  gem 'vcr', require: false
 end

--- a/lib/auth0/api/v2/resource_servers.rb
+++ b/lib/auth0/api/v2/resource_servers.rb
@@ -32,7 +32,7 @@ module Auth0
         # @return [json] Returns the resource server.
         def create_resource_server(identifier, options = {})
           raise Auth0::InvalidParameter, 'Must supply a valid resource server id' if identifier.to_s.empty?
-          if ['<', '>'].include?(options.fetch(:name, ''))
+          if options.fetch(:name, '').index(/[<>]/)
             raise Auth0::InvalidParameter, 'Name must contain at least one character. Does not allow "<" or ">"'
           end
           request_params = Hash[options.map { |(k, v)| [k.to_sym, v] }]

--- a/lib/auth0/api/v2/users.rb
+++ b/lib/auth0/api/v2/users.rb
@@ -101,7 +101,7 @@ module Auth0
         # @return [json] Returns the updated user.
         def patch_user(user_id, body)
           raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
-          raise Auth0::InvalidParameter, 'Must supply a valid body' if body.to_s.empty?
+          raise Auth0::InvalidParameter, 'Must supply a valid body' if body.to_s.empty? || body.empty?
           path = "#{users_path}/#{user_id}"
           patch(path, body)
         end

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_AuthenticationEndpoints/_change_password/should_trigger_a_password_reset.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_AuthenticationEndpoints/_change_password/should_trigger_a_password_reset.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/dbconnections/change_password
+    body:
+      encoding: UTF-8
+      string: '{"email":"rubytest-username-1}@auth0.com","password":"","connection":"Username-Password-Authentication","client_id":"B4oPHl007Va1GBdZXiSHaECUqVWkd9Xk"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '151'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 21:58:59 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Auth0-Requestid:
+      - 3b4d73940e32fd67bfac
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538776800'
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAwtPVS9LVcgqLS5RKE7NK1GozC9VSMxTSM1NzMxRKMlXKEot
+        TgWLFikUJBYXl+cXpegBAKHKLwA0AAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 21:58:59 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_AuthenticationEndpoints/_saml_metadata/should_retrieve_SAML_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_AuthenticationEndpoints/_saml_metadata/should_retrieve_SAML_metadata.yml
@@ -1,0 +1,88 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/samlp/metadata/B4oPHl007Va1GBdZXiSHaECUqVWkd9Xk
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 21:59:00 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Auth0-Requestid:
+      - 5cd424042afbb657d575
+      Content-Disposition:
+      - attachment; filename="auth0-sdk-tests_auth0_com-metadata.xml"
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA81X25KiSBB9368weh+NbgoVUaOnI4qLitwbVOStBIRSBKUK
+        UL9+UbtndzpiJvbSu7MRPuAh81QeMuOQPMsZxfQsRSQo8IHmRSu6AYr05aEs
+        shEqaQIeSbh7pBGh5On2/ynI9w+t0z7NyD0qRwSTUYb2ERnRYORAXRt1nsBo
+        H1EUIooeXn5ptZ4VyXIc8w9HHYqc5kGeOuXhkBdUzsp9VCCK8+zHtO95N9qG
+        WI3+KKAk0ZcHguMMZ/FbxD1GyTb5e9UJpYcRw9R1/VR3n/IiZjoAAAYMmSYg
+        bLJ//ZraJHscGEqNjt+hN1CMCoo3OEA0etEVRZJcUYSbZQxrRYCxMltz6/AI
+        JC00KK9DMBGd48RR1l3JlgWxnkNdtE/KFsZCbCwEqLuT5ZgNJ3GtecYOnVng
+        ewYIzlwSeq+5LnLbdQfU0yQwdDc46VvI6q5dm5ICllfsIjfXMviKbeFOd5Ra
+        gStpYduSfErfeNiLPyE0nCwu4VQvV94CIAmWq86QNhqEph5DiHfHZIcnwxoI
+        0JbHEJoitAfwel+M1eZahsVRSIdysqaKxsTonLIJNJA2n6nOtNQPoKpWJ5uf
+        kC7KBbGz2CQMGZ/lVyBONSVNfeyv3bUMouCw70/PuW2cOh0pQulmfOqzp73H
+        i687P96OD0W3u1+yZMeVuy6qGcwul0Ky3i/2CWLOZeDUyVjYdis47hFFdLLF
+        dCOH3pBdilQLz3m5CHs7oBjWoabUCsesxMz7wvTSh5XSCXmwdJhBR+UQK7tW
+        yVa+4Pf8IdW4/baaCio7SGb7wA5SwwrQOrI5nuDyeLK0nVa106NlluTSsQM8
+        E+p6PHUszDiHtXgBokuX2HNW510QO5iKXNebnV/JNJurmd/plaY/bHtwpRdb
+        0XBXgWn5nrx1PTxc2ooEbSjkQKltCVrXuZi+6gLcDGTBhc29KaMLYALZeSjF
+        9lIQXCG5BDrtW/66l1gLBgh8pWazbIaxBM1bvj245zfTBnO7luzVTM19JakC
+        o+mjJthQiuPm9ljm/Wws4jYaW2pJqo1vxVx7UHkLVtJM/ZTupJDhgcAZc+T1
+        D7xRem2A6DxbwbY9tPqcDOfmubDrZSQ7HaDBElf2gA96bNs49jxT5Tc7NfVS
+        0/RZeqkwgVstUgSiDSl181XltnvrA8uqdTaU3LEntPkzgHvPEB1XEVxeOjF5
+        ggaes0Svh0G6IpcC8cuTWpiz41bm+kh2nXTWofrxDCpwFLeKXClWeztQc3ao
+        Wit2hqt5WpVqd8YIAjHYGDmaOTTMPqgyhy9R7oQ4LbjqMu/mDq97l8zqZheu
+        kvtuJpftgsGJOMHiwpg7ar6eKpJY9LmLFtZ6BRiBntJoR0xXGgPSoW1opxGe
+        +dnqyzPz0Sl+Nxbmo7M8M29G9WZtzDfe9gY6jbOlkZbHeUmdqKhwELUEnIUN
+        /GPjXN+DyGjqutbjaxTiIgroQ0vLgzfbvfoiaYzxu77PELRPD4zQy61pCgC/
+        QOxECH0PO1Mki/PjYrkLh96OSW/VPTCfW7JlOu5/Ua7R1KFI47zYI/ryvfLY
+        J/aG4PBxc4scRXuEUxiGRUTIM/MNyV/gvcr+lvcQFU0YbV7Nn8lKC5QR/D3S
+        e8ec5j1qZv/TIfswXf+41n9rur7WCSkt8LqkUev6wL9uISRImskhT83qQXJ0
+        uK0jNbluJBzT/HB438mYIEV4T5jblKH7lD3cmO6N+7FU1Jx9Rd+7Xxb4oTUu
+        mv6H6flejvyoN8wt+E79JzY8RMjV2PLskzXGuIqy63GfKnByZb0R/lRxn67r
+        pysiZfHpopx3zp/cqTu2wVHx6T1rKdLfkffMfPyUevnlmfn4JffyGyVf1lHc
+        DQAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 21:59:00 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_AuthenticationEndpoints/_wsfed_metadata/should_retrieve_WSFED_metadata.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_AuthenticationEndpoints/_wsfed_metadata/should_retrieve_WSFED_metadata.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/wsfed/FederationMetadata/2007-06/FederationMetadata.xml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 21:59:00 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      X-Auth0-Requestid:
+      - 5e4a4db7d8e139300664
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA81Ya4+qyhL9K2bul3tiZgAdn3FMmoeKCoKgot9aQGhFQLoB
+        9defRp3Xnjk7d3ZycjVqoLuqetXqTq2CjhQSRE6ii+0ExSRKSu5lQBZfHtIk
+        bMOU+Ozl7xE7u0fiYoIfSsd9EOKrQQQxwu0Q7l3cJnbbAMq4XXli23uXQAcS
+        +NAtlTrTKHA/LHHEqE1OsfvysHGdtuHaaUKXNKOdGxpukiHbNensQ+nrJ04i
+        EtlRYKRxHCVECtO9m0CCovDlwSckbjOME9n46YLqMYrd8ClKPCbHdCGG/m7G
+        TIVlG2z9uxVuAESE4wCeVJrX74j4+rlQ06YZvgHK8/wpr15w0GU5xlLGhu27
+        e/iIQkxgaH+b6TUOhfxHiXWLEJ2R+3FjU0xTwcgLUehdDa4mcriJXnf0W8gs
+        w7YYauBQ5/+8elJfq8a2RLrF3XfUlzHBTQjaIBsSt6vIsiiaggA2Cw/kMg88
+        ebiurZ0DK44dlTQUwPYF49A35HVV1CVeyGdAEfSjvAUe76lzHihmf9HjnL6X
+        jy11B08cu7JU1j7VfMeaRopQ264rbD7wbVUx7aOyBZxi6vlElNlFMXaW6LXE
+        vo1twU4x5FwGS3Gu66J0DG5xuPOqj4nTn5+dgZIurTkLRZAuKy1Cc+ApHpX3
+        dgd/h/qtnOWBLvUAmAhAb4JiXvBG9FoCyYEPWpK/JvKY8eAp4HygwvFsODIG
+        qRKzWbY86o0+rsKIFyrzjc/g3kmassJgLAfBCq3W5lpiXTve1wenSFePlYro
+        wmDTO9a5495qCNPdytv24qRa3S84vKuluyrMGcQtFry/3s/3PmROqW3kfo/f
+        VjPQe8ayYITzwUZyrBa3EMjYOUXp3HnesbKqxTkhmtPjRGZW5wfnOsjkitNg
+        FwbTrIxqkJNMLeWyFb96XrXIuLbfZgN+xDX94d7W7UDVbLh29VoDo/Rw1Ma7
+        cVYODtokxeeKbqMhn+e9gaEhxojXwpkVTLJAlrE87WzPQESoVa3haYoH4WwU
+        rirP6WTVKltgqSRbQTWX9kRbWdLWtFBrocsi0AEfsXKui0ArzsVgqvBg05R4
+        E9C5AaPwbB9wM0f09AXPm7x/thVS11brZ1+bMyzfyEbhMBwiJILJxV9vXv3p
+        aQORnov6cjiKVrKf2SrdxzGvA9Hz6HRPaqzCnoDKsKeNUpxtVppXKzcza86J
+        44lyDHaiwzRYvqbOoFWPG2pqlVlIZuESlPWWVq9JYDY5JXq+cCWjwo5BijK9
+        2bCfubJ6eLYmo8ZmNwqsYDJZceScIQy2Y1fm8bhFiBktM7P8vI45bpSHLdHs
+        WXy5cWLB3lIFw5R5syEemciHTctYwGncDJb4nMDG4jhKJsPDVqrVoWQawbBC
+        lMOJzdiDsJWlTNbK2+Yo4lojbckNUTYLsnRUHTI8j1XOg8Z40lIndTYLjUYK
+        I8NBQVLLzrNqZDQU6xxq1fBcy6S6GUppOWGQL/SRMFdnxihaD2RRSOq189jJ
+        lYxleHIM3B2emGKPxRVSBnrgouEqXL50mF8rxVsJYX6pKx3mVqS6b3fvVe06
+        VsjIRT4K3cCTzcZNXOfV/dNkaZag3wsXxLhAFYUPzB9E4L6J0GH+Gd8lthBA
+        tP8G+m35QnXebT7MXJDcSja+SAp+onUaRzC+qUNRvmsM/SLnquuMXcTBDLVF
+        AXScxMWfZGwSF8Bh8PJAkvSTMF0FqcDyPyhSYRYl6PxVlN4z+iCxXelRoXhK
+        4Aqow3wx+MX1tv80eNf03ZL7WKRTuuVTijYlQkep4CWvoT44vJ6qz7T++5R7
+        KHPD4rTcAd/9AkupuPwx15c0SkUed8rznVD8R+SmITqk7j2zi2nluw+CjSuS
+        H3N8y+BO+S2gXcc2yE3ugObirySLP6a5kMPrQX5P5045T+PwDoieaerP6wUl
+        kj4Uo9BGMQyudP+XBvrr/8n0jdV+EqXxHfB6wfEjZkHJK3wogZC8sVhCuARL
+        e3e/vpzjPyH12gj+c7d3aQY12j5SiZ26VAgw7XCl0IkjFJLX8K/3U7dwDm33
+        t8/u9Lw3mVtfdHnu79x6rG5hjqn9L+80ni73T3a0v9LdYV4dOsyXpT+0t7+B
+        3WE+v/+5RPr81qn7N0Xyx92IEgAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 21:59:00 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_AuthenticationEndpoints/create_test_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_AuthenticationEndpoints/create_test_user.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/dbconnections/signup
+    body:
+      encoding: UTF-8
+      string: '{"email":"rubytest-username-1}@auth0.com","password":"Ng8oDgOiLn387a90","connection":"Username-Password-Authentication","client_id":"B4oPHl007Va1GBdZXiSHaECUqVWkd9Xk"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '167'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 21:58:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '98'
+      Connection:
+      - keep-alive
+      X-Auth0-Requestid:
+      - d7b9e5b781775101652a
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1538776741'
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: '{"_id":"5bb7dea35e09334d7789a19d","email_verified":false,"email":"rubytest-username-1}@auth0.com"}'
+    http_version:
+  recorded_at: Fri, 05 Oct 2018 21:58:59 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_AuthenticationEndpoints/delete_test_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_AuthenticationEndpoints/delete_test_user.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C5bb7dea35e09334d7789a19d
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 21:59:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538776741'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 21:59:00 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Blacklists/_add_token_to_blacklist/should_add_a_token_to_the_blacklist.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Blacklists/_add_token_to_blacklist/should_add_a_token_to_the_blacklist.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/blacklists/tokens
+    body:
+      encoding: UTF-8
+      string: '{"jti":"faketoken","aud":"B4oPHl007Va1GBdZXiSHaECUqVWkd9Xk"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '60'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:22:47 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538770969'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:22:47 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Blacklists/_blacklisted_tokens/should_get_the_added_token_from_the_blacklist.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Blacklists/_blacklisted_tokens/should_get_the_added_token_from_the_blacklist.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/blacklists/tokens
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:22:48 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538770970'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4uuVkosTVGyUnIyyQ/wyDEwMA9LNHR3SomKyAz2SHR1Di0M
+        C89OsYzIVtJRyirJBCpMS8xOLcnPTs1TqtWBaQ4vqipNLk1PK/ZMMs6PyDHw
+        yEu2yC40dorIDnArMPdIwaY5FgCMVXWTewAAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:22:48 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/_client_grants/should_return_at_least_1_result.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/_client_grants/should_return_at_least_1_result.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/client-grants
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 21:12:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538773951'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAyXL0QqCMBhA4Xf5r9OlBLFdViOYkAXRxURkbSOnqaPNiKJ3
+        b9rlge8UHzAKCMjbo2rYvj+yJDE5vjYyNbAAeTe699VM6uzV4PeGC3XIOsYz
+        3G5Xu3zN6enS5vRMAxejCl7qSXtvHUFIjL5eRk61kdfOu3juWA4dEtagZ4rC
+        5uRgw1PARMi/ym/5A8+rwz2cAAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 21:12:29 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/_client_grants/should_return_the_first_page_of_one_result.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/_client_grants/should_return_the_first_page_of_one_result.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/client-grants?page=0&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 21:12:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Link:
+      - <http://auth0-sdk-tests.auth0.com/api/v2/client-grants?page=0&per_page=1>;
+        rel="first", <http://auth0-sdk-tests.auth0.com/api/v2/client-grants?page=0&per_page=1>;
+        rel="last"
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1538773952'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAyXL0QqCMBhA4Xf5r9OlBLFdViOYkAXRxURkbSOnqaPNiKJ3
+        b9rlge8UHzAKCMjbo2rYvj+yJDE5vjYyNbAAeTe699VM6uzV4PeGC3XIOsYz
+        3G5Xu3zN6enS5vRMAxejCl7qSXtvHUFIjL5eRk61kdfOu3juWA4dEtagZ4rC
+        5uRgw1PARMi/ym/5A8+rwz2cAAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 21:12:29 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/_client_grants/should_return_the_test_client_grant.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/_client_grants/should_return_the_test_client_grant.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/client-grants
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 21:12:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1538773951'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAyXL0QqCMBhA4Xf5r9OlBLFdViOYkAXRxURkbSOnqaPNiKJ3
+        b9rlge8UHzAKCMjbo2rYvj+yJDE5vjYyNbAAeTe699VM6uzV4PeGC3XIOsYz
+        3G5Xu3zN6enS5vRMAxejCl7qSXtvHUFIjL5eRk61kdfOu3juWA4dEtagZ4rC
+        5uRgw1PARMi/ym/5A8+rwz2cAAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 21:12:29 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/_delete_client_grant/should_delete_the_test_client_grant.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/_delete_client_grant/should_delete_the_test_client_grant.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/client-grants/cgr_jJGnPJ11iO9bjc2i
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 21:12:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '5'
+      X-Ratelimit-Reset:
+      - '1538773953'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 21:12:29 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/_patch_client_grant/should_update_the_test_client_grant.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/_patch_client_grant/should_update_the_test_client_grant.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/client-grants/cgr_jJGnPJ11iO9bjc2i?page=0&per_page=1
+    body:
+      encoding: UTF-8
+      string: '{"scope":["new:scope"]}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '23'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 21:12:29 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1538773952'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAyXL0QqCMBSA4XfZdbqUIOZlNQIHWRBdGCHrbORc6mjHiqJ3
+        b9nlD9//JkaRjMDlVjX5utvmSWIKdm4gNWRC4Gp0h9VIavFs2GtRSrURbV4K
+        ZpezVTEv+e5gC77ngctBBQ/6pxGdzyiVA9bTyCsbofbo47Fj6FsqnaH3lIbN
+        Q+/CcySdfmT/OH2+8RXsgJkAAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 21:12:29 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/create_test_client.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/create_test_client.yml
@@ -1,0 +1,118 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients
+    body:
+      encoding: UTF-8
+      string: '{"name":"ClientGrantTestClient-rubytest"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '41'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 21:12:28 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538773950'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6WYWdOi2B2Hv8qUt05HFhHtqrk4LCr7LkiSsthEdmQTmZrv
+        Hg491elOJvVW5fVG2Z6zwHl++P991UWlV3arryuv7x7IlzbMvnRR27WrX1dx
+        Xvlevvp69/I2+nWVtLeuyqLyFpVhXSVld0vq2yPywqi5dU3fdlH4/dzSK6KZ
+        SedJVHanZm7BnKHfNr80vf+GbawW5j1p2u5We033Xn2dOfPVbVvdwqT1/PwH
+        ZNBUbXurmiROyhvs7PcjVRIGt6Aq71VTLGP5c39UBs27Xrr1JzeJy6SMb1n0
+        bldf//77av4x9/IL/FDsiZN/0Q3wi6pzF2CyvwjsdTnyj+YfpcRxbA04CgCB
+        BhoLmieVH9iH33HiJvbeOfoAsidavGCce6lGhuE6auSpxb2KorHL/QEZm/b4
+        ZnWEPotcnruJ65s+i0RBXezO70qTRwxjIi+/H8cdOhYOSeuZG6fHusHxwkbb
+        jICMPsO91yZBbZt6+MWleHibdx8Yr8eRSvEBHLctRxvl5XxnQ+eA2nQnhu+q
+        v4TbDOFktX5BRtep4RFlNtaOOk87MHBYSCK2sdljAuGhrKn26OBS7tY9dCJR
+        pMOZEtD9gy8CLchlNfAgw480gmyT/jmqYiYO6/ypKn07YVqQ8NTrdTwbarIx
+        ap+eENrs7MQxru8siI2kownc4d+Qobfn0hJKF9v2intYO+AqNSktm9dAUV2H
+        TU0nOdgaxwANUKCa514DXJO/UyHFEMx1FcjgYtZ6mOoxaJ/Me7ieogeOh0ed
+        TznxPZQnyzprjxbEaO3aZ2M3FPX9+KwrKroMhZbq9X6Z02cW2DKPvvqO49bI
+        NGVyIQ4XYhSn/Vm/SDlDWXeBuASkA1Rf97T6teWNTCfGw/nCb2jIuOKPs0+c
+        HvndJyahqtAtWm/L6RQcjeB+8ammeV/8p+hqZTxqiX2dEh+INJYSDq5Uu+0y
+        pzu1o5vJEfD6vJPZdRGn5X1jVCF+Wl+pu15fr6y6I4frRPe8lZ6cML8Y+5MR
+        PHPxJbanCTLy95p3t+rUN43+QkWulHy30C23JUuaTe/6GtS60GFXeXscM0sJ
+        8Ri5kumwr32HHoSIX8ZCULvsYj1AdaKAEhprr74Hd9/IppRSe4DH2n4Ijzl2
+        xJ54oI7OvbZU4XoCmhpgWXUdIQN/D2uE1alHa281ApAbvhYNcoOeD7WCq+6l
+        yMl3JObwlrCHw5vjws1jpz2nZohAxTMUZISKQhnFqXH69FBhymY4lbEqXbHn
+        y24Ig5WmKJxKKTkp9yOBIM2AObIvn6Vu6bd0XBjnenIYTd2FOW3E7VoeVT2/
+        oxo98Lvw1PBXzbqQgsW2ma5STPLklPf9cC4F9LG+5ulJQiFD5FPPraxNPqlC
+        mnVDxZShygMF54xE3+Mcrsn5wLQj9kL0FyVO3aEQ06keB+ueT5v98qybo4yV
+        OmIHxI6xpwDZseFohxw+D886dTb12raUkxLh3HcQ8KMlpm+uTNfZ8zCWDr7O
+        l3V7JI+1FeJ41/cPozBQH2vQYb+tDEo9sJoJxHvjIeSO1JwCT6nLkw02kS6R
+        adFeiNw+QsZeFV02JxtdQmxHuFQYY1B4rnq9zbNvRs6tQ7dfZ3tj1AskE5+F
+        U+iN5EqNX4b3/cEvIYOITNrMX3xh6Bcb2I38QDRjy9LxlQVP9+wLu1MKtKgE
+        yNm3gbWPnIofuRGTB4mSu2sDGePu3W+tymuK/nnFbXX9PBVSR3KyTqVX0j6/
+        LJl4E1He7iWfK1QSFA3WJVN2PuQ8He2ThdFdYix4ASUVTtShzYzQzrRaYrP1
+        jihO5yboIkt57tCi0Y694Ap4hqxz+nDitd0D0QGAjNpttt0BmfsOLqZlafR+
+        umd5VGm1OXEi5coKGZopOXFbtX9hRNev+e3kmZlHXJ6WnC1rH/NxYqx1RYm8
+        tDAnoqDVWM739JvjNRcLE06Q4iZcA07oaLAOhdGVFP1eUiiRggNmLP1A5igJ
+        tnIuajg2Cd1+GpPeOd7PmMUQcfYizUGnvHyiMVKgG+Uhm2FxtOPffoPXLiHF
+        ysz/DK85Z4Oo6X5OOprVTe7I0fPJP6Ycw5g0De52DF6zcWOO9wk/fCKMGMod
+        KQHkRBvPk8H5OKOxFP2ygERrI5eCmIrlC2TMS8882Uc0PMUv0ZEz740iriMj
+        wZt4hI5eSTSR+hjyOj8CWTKDUUoBKpnaS2E4xJ73Lf2Y2HmbRb7vT0EmGdyL
+        A1fmomkMO+Z/stDJPbVdeLpM4Vnqr84F8RjQLxbDDt08Hmrum0zF2fORJafD
+        C5lThD0CoMwpvgfwOB3/daJDxkep/lGiL0/HB6n+UaJDxkep/lGiQ8ZHqf5R
+        oi82/SDVP0r0xYQ/pHqFcC+NASp8ds66RIH7nqVMMB87byQKOQHUCplYsynK
+        pB5TIHU71V3ePrYP9bJBKHIQSr7kk4QBysLQ9t8Y81MJKu3FaFdeqFzuMQTy
+        fI9FSgNMHLNLMoAjS7rlkU7W3lEV+na4u2pMrPeDc0EZUZHGPGPCDYlQhGx5
+        zq4m5d5ZI15nlVew1g7qktgECyzl3WgvO2INDBFBnwzangy26Fp+bh1FIO+Z
+        kDu5orhoNw1JC1Ix4qhWPHSdWV0hYzDXW79GUeFVHhjz6FBr8o2AwpFpw+Qo
+        k2TGTfXw9o5he/P7Sn5tp8Yj7VFoFP6ZssQOMjzWNHIe66TnGxmQJ51y7MCp
+        63QvVOhBUK8onwxWPvQCzm8oqpXR2DNE5SArO2QoDXJZL15lhEneEMNk4ZVB
+        Ss5Uqng5EQO7M0u2Xzeb5EGfEvoiW4ZQ+WeOoZsdMYnhSxqQDdUtRs6jrFVM
+        5oi0WLcGWh4lvFtef7bUX4lnNlSdBS35s6JUgTbIn+Skxj/e0ICu5n3iNAvr
+        3cJFPM6PjvjjYqdepziOJR1eCxmfkRsUG2R8Rm5QbJDxGblBsf05H/+33KDY
+        lpv+CblBsS2MT8gNig0yPiM3KDbI+IzcoNiWv2ifkBsUG2R8Rm5QbJDxGblB
+        sS3z8Qm5QbFBxmfkBsW2yPoTcoNiW/7WfEJuUGyQ8Rm5QbFBxn/LzXsA5ttc
+        fRfcz9qa1db2fhoF8P1rQ8u//Ued5W/L9t+Cqlj98c/5RW0pkdyScD77IYzp
+        YaJcL5SFgneFQ0ZvGYV0We2SKazJwvc6L899L8hufZPfuqioc6+L/l0y+QZr
+        o6CJYPPk+KXP5LNd8nxn758d8Noxfg46st+Lfs1g52NfJEz9uu3fI3u8dHZa
+        hfdn8+WBZgfEfd/mBtNXt5RakrhvvC6pytXX31d5co+6pIhuSQkbq8qwXX3F
+        dwiCzINfGr9FZVCF36s5f/y6imFR6Na96wiWYpbqU9Uk08K8wXNhdWgeTxIk
+        sFDURPcmah/fKlCr70Ob2eH8nczQFZy9vu2q4pZXsEZUe3F0gx2ExZ8//gW3
+        Q0qh6hIAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 21:12:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/create_test_client_grant.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/create_test_client_grant.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/client-grants
+    body:
+      encoding: UTF-8
+      string: '{"client_id":"hKxj9zBZadNKmJZK9kC4DO7ZEQVkOETE","audience":"https://auth0-sdk-tests.auth0.com/api/v2/","scope":["test:scope"]}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '126'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 21:12:28 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538773950'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAyXLwQrCIACA4Xfx3GYbQbhjJYFCFkQHI4apNLVtki6i6N1z
+        6/jD93+AUaAC8vaoLdl2e1IUhqGrlaUBMyDvRnexnkhDXxa9V1yoHW0Jp8it
+        Fxu25PhwcgwfceJiUMlLPeoYfaggFENs5llQLos6xJBPncu+hcIb+Cxh2oLs
+        fXrOYCTVvy7fHwplPteaAAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 21:12:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/delete_test_client.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/delete_test_client.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients/hKxj9zBZadNKmJZK9kC4DO7ZEQVkOETE
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 21:12:30 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '5'
+      X-Ratelimit-Reset:
+      - '1538773953'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 21:12:30 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/delete_test_client_grant.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ClientGrants/delete_test_client_grant.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/client-grants/cgr_jJGnPJ11iO9bjc2i
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 21:12:30 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '4'
+      X-Ratelimit-Reset:
+      - '1538773954'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 21:12:30 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_client/_filters/should_exclude_and_include_fields_properly.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_client/_filters/should_exclude_and_include_fields_properly.yml
@@ -1,0 +1,91 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients/9mhyX7O1EokZmaEwtSSmDsBEj352cSlX?fields=jwt_configuration&include_fields=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:40:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1538772057'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6WWW7OqNhiG/0rHW/eqoCK6Z3oRDipyXqAibYcJByGCoISD
+        0Ol/L3HtWd277VX1RvkiT74E8sz7x6iKcphXo68jWFcJ9YbD9K2KcIVHX0Zx
+        VvgwG309wwxHX0YIe1WRRrkX5eGtQHnloZuXRDCMSq8qa1xF4ed/wwgHJbpV
+        qMgHNJ+hKK9++r74ZZTDazSM2cNkH+NvZe13ZO7Rc64zKnHl3WBZdaOvA3+g
+        Ylx4IcLQz76bKigLjL2iRDHKPbKIz5EChYEXFPm5KK/PNX6rYxTnKI+9NOrw
+        6Ouvf4yCqCQ78EY+nLiRtJ948d2W1hIPbPFZ/a38LVclSRBsngfnYwxaiQOx
+        tPMZP7xTghJqFasCasNb940l+TPBFDm+3QOVNx/SBcRcrB0IgwOqvTmu6XAT
+        t4qjpbCjKdfRqKBjktB5L1SeufhTqt0mgabawUO9AFq1zVYXJOo41J599OJw
+        LVKf9QtIVUtqJXASDqYpiI/sG4vu3Q2uws2hD7dqfXIOFBRATRin6aoa1sMN
+        vWlcnN6TFG1WLcUBU1wDoPPAXAIyzsfy8FsE5Z3LVmLiV5IyiWGXEQadAA0q
+        +51sbWv1RjXN6WGyGzyDBcdPD+dkgted+E7xW0XKMhe5vu2LVBTcrottV5ja
+        gzCmUyGC2Xn9WNCPq8Py76kbX9a3cja7HmmcMnU6g+0E0ccjl/jXwzWBk64O
+        rDZZc5dZA9aEMccSb+WH7VkMnRV95Csl7Ir6EM5TStKMW1tVRrimhcl+wW37
+        BWikachSR2uynMoMpEWbMIyablzOnburSmGul2bLyfQy2V0DM8g0I4B+ZDIs
+        RvX9YSip0oyzu6HXuJ+aAdpxbfvsY2sZaGLdfL6neLs6Isc6dWkQW6jimZmz
+        697xNt/LuTud17q7GjvgpJYXXrNPgW64jnghDNtBq6MpCcAEXEFJrSkAg7w7
+        23eVA+elyNlgGNtOVI7aAHofCrF55DibS/pArRaGSxj+PDEOE4pjGznf5TuE
+        BKA/GebygzG8laAwW8E87eTClZIm0IZnrHAmEOJY5AgDrEXWzdc8GsO1Ide4
+        ObtGzIyXjXOgBUVXH1kqhBOW4hhtD53FjdVqZ0zBap+fwNhcGYSxYESw17vS
+        bI+RaE0pBdSoMZdsMKfH2n3u6DJ7TuXMyXTdpau+QRhclEjisLKqKrs4EUZj
+        j+f+jablNl8J9trhxmxHgauj8ZYtcTYrPCZFApeOdYTvt2V2wn0J2eNDLvXd
+        /SIyC8KAom1lu2ml3juqoe78RRIbyRhflnJBr2TjRO9Qs8+aWp7tJhyHNTqG
+        lqKvNH1BNbnFPs8LLKwQZSXT9PtZYbGq0+fGLO+ZRlzYuViPywlK+A3iD9re
+        kgt/Kwl8uWB6JWzVhppwFWE8sijFui2sKTytxsDMIrRz89MvZOwpGVET/lM8
+        gw9vaYDZHxVlyLzF/iAnI/7+gQZ8MdSUfhBWh8khfgyvjvL9YefaTRzH6ju5
+        lzBekRsRG2G8IjciNsJ4RW5EbN/243/LjYjt+dBfkBsR25PxgtyI2AjjFbkR
+        sRHGK3IjYiOMV+RGxEYYr8iNiI0wXpEbEdtzP16QGxEbYbwiNyK2p6xfkBsR
+        G2G8IjciNsJ4RW5EbITxb7nBBAgfe/UpuB+1NagN1/4lCkj+mvDaL/9IoT8/
+        r38Oiuvoz9+HrPcMih4a0t9odU06h9VpsUjdKxTbyrKuAubEy4yZBlbmDOgA
+        ZpkPg9Sry8yroustg1X0d3D8gOEoKCMyvbvOUSgcMgijs3NYZHp0Svq5rFvX
+        zbGEU0ZKvfLtYfqzZCiGx4XGFLbcv+3e/FrYYqcnibkccqZXdbeIBMtnpB6C
+        aQ9J5B2SaBiRaDu0gQJEUm4ZncsIJx+xevTZ0dBPOHyjoc0RWfQQrYurlxUk
+        4N5gHHkkVD8X8edfRrM9OMALAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:40:55 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_client/_filters/should_include_the_specified_fields.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_client/_filters/should_include_the_specified_fields.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients/9mhyX7O1EokZmaEwtSSmDsBEj352cSlX?fields=name,client_secret,jwt_configuration&include_fields=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:40:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1538772057'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAyWNywrCMBBF/2XWBoqPLrpVfIIiiq9NSJupjaYTSKaoFf/d
+        VJf3HO69b2AkRQwZqIarRAR9F4yBA/SAVI1R7GMcW4PEwjf5q7NRFj8iAxYe
+        u/plSkZPDlYpLE+H1G7wXLXD1WZXz45e9UeLu/Tiuc0HVYT6mK5Hbr9qxVLk
+        zWQeTm2cvD1YFo5Kc228YuMIsjdYUyKbGqWh7syRDpAN0iRJevA/l0iF06gh
+        K5UN+Pl8ASz50SfVAAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:40:55 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_client/should_get_the_test_client.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_client/should_get_the_test_client.yml
@@ -1,0 +1,92 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients/9mhyX7O1EokZmaEwtSSmDsBEj352cSlX
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:40:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538772057'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6WWW7OiuBqG/8qUt/YawRPaVXMRDioipwUqsmcXFQ5CBEFJ
+        ALGr//sQVtea7pl9tfVG+YLPlwTy1PttQKIc5mTwdQArkjBvOEzfSIQJHnwZ
+        xFnhw2zw9QwzHH0ZIOyRIo1yL8rDW4Fy4qGbl0QwjEqPlBUmUfh5bxjhoEQ3
+        goq8QwsZinLy28/FL4McXqNuzO6afYy/lZXf0t6DvtcZlZh4N1iSdvC143dU
+        jAsvRBj62U+tgrLA2CtKFKPco4v4HClQGHhBkZ+L8tqv8UcdozhHeeylUYsH
+        X//zbRBEJd2BN/rhpbWs/SZI77a8kgVgS331z/LPXJVlUbQFAZyPMWhkHsTy
+        1p/54Z0Rd6FGOBUwa8G6ry3Zn4imxAvNHqiC+ZAvIOZj7UAZPFDt9XHFhuu4
+        2TlaCluWcR2NCdpZEjrvhSrMLv6YaTZJoKl28FAvgFVts9FFmTl2tX4eT6m7
+        lpjP+gWkqiU3MjiJB9MUpUf2g8U+3TUm4frwDDdqdXIODBRBRRmn8ZJ06+G7
+        uWl8nN6TFK2XDcMDU1oBoAvAXAA6LsRK91sC5Z3PllLiE3k3imGbUQabAA3u
+        9lvF2lTqjanr08Pk1ngCC14YH87JCK9a6Z0RNjs5y1zk+rYvMVFwu843bWFq
+        D8oYj8UIZufVY84+rg4nvKdufFndysnkemRxOqvSCWxGiD0e+cS/Hq4JHLVV
+        YDXJir9MarCijCmWBSs/bM5S6CzZo0B2YVtUh3CaMrJm3BpCjHDFiqP9nN88
+        56CWxyHHHK3RYqzMICvZlGFUbO3y7tRdkt3seqk3vMIuku01MINMMwLoR+aM
+        w6i6P4xduquH2d3QK/wcmwHa8k3Tz2NjGWhk3XzhyQg2OSLHOrVpEFuICLOJ
+        s23f8SbfK7k7nla6uxw64KSWF0GzT4FuuI50oQzbQcujKYvABHzByI0pAoO+
+        O5t3lQfnhcTboBvbjFSeWQN2H4qxeeR5m0+egUrmhksZ/jQxDiOG52ol3+Zb
+        hESg9wxz8cHo3kpQmI1onrZK4cpJHWjdM97xJhDjWOIpA6wkzs1XAhrClaFU
+        uD67RjwbLmrnwIo7XX1kqRiOOIafaXvozG+cVjlDBpJ9fgJDc2lQxnwmgb3e
+        lmZzjCRrzOxAhWpzwQVTdqjdp46ucOdUyZxM112WPGuEwWUXyTzeLQmxixNl
+        1PZw6t9YVmnypWivHH7ItQy4Oppg2TJvc+JjVCRw4VhH+H5bZCf8LCF3fCil
+        vr1fpNmcMqBkW9l2TNR7y9TMXbjIUi0bw8tCKdilYpzYLar3WV0pk+2I57HG
+        xtDa6UtNnzN1bnH9eYGFFaKsnNXP/aSwONV55sYkf85qaW7nUjUsRygR1kg4
+        aHtLKfyNLArlfPbchY1aMyOeUMYji1Ks2+KKwWMyBGYWoa2bn/6gY71kJE38
+        n+LpfHhLA8z9qihDESzuFzkZ8c8PNBCKrrZ7dsJqMT3Ej+7V2f182PlmHcex
+        +k7/SxmvyI2KjTJekRsVG2W8Ijcqth/78X/LjYqtf+gvyI2KrWe8IDcqNsp4
+        RW5UbJTxityo2CjjFblRsVHGK3KjYqOMV+RGxdbvxwtyo2KjjFfkRsXWy/oF
+        uVGxUcYrcqNio4xX5EbFRhn/lhtMgPixV5+C+1Vbndpw5V+igOavkaD98Y8U
+        +nt//XtQXAff/9tlvT4oeqhLf4PlNWkdTmelInWvUGqIZV1FzEuXyWwcWJnT
+        oQOYZT4MUq8qM49E11sGSfR3cPyA4SgoI9reXeUoFA8ZhNHZOcwzPTolz6mi
+        W9f1sYTjmZx65dvD9CdJVwyPc21W2MrzbfvmV+IGO8+u4aUhfeBEcVXCj/D7
+        bZChc0TQNfK6fNo1K/KwS52TOcMw3eL75l2iDorwM9N+76J32QVWj7S3iCbU
+        Ppt3CffZMz16L83I3XpQgGhcLqNzGeHkI58PPpfWscPuG3XQAd29LqMXVy8r
+        aFK+wTjy6AQ/Wv4FzWP1LgkMAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:40:55 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_clients/_filters/should_exclude_fields_not_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_clients/_filters/should_exclude_fields_not_specified.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients?fields=callbacks&include_fields=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:32:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1538771574'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4uuVipJzUvMK1GyUkosLckw0C1OydYtSS0uKVbSUUpOzMlJ
+        SkzOLlayyivNyanVwaN60EmiOD86lmpqB4NfYgHz8oyvuAEAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:32:52 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_clients/_filters/should_exclude_the_specified_fields.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_clients/_filters/should_exclude_the_specified_fields.yml
@@ -1,0 +1,132 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients?fields=callbacks&include_fields=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:32:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1538771575'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+2da3OiWAKG/0oqXzO2gAraVVu1XAVBBAFFZ6YsbgJyv6uz
+        +9+XY9KZdLpnZzLZufTWyZfEc+A9F/Ct9xHPyfc/3ddeaqX1/cd7q6kDZFC5
+        0aD2qrq6/+4+tRKvr2C8o9XE9R2Z532hH2e2Fd9/PFpx5X13b8Vx1nnuwYlD
+        L+3P+pg2cfxzcZz5WVMfmjJ+rgqrwzEsq/qQW2V9uf9Yl02vk4Wuc3Cy9JiV
+        ya0/j8VV6Kdh6h8i79ILfP/TveOVoLMD8EOxc0G+o9m1LnACTersrfSH8od0
+        KQgMo9M0edz6ZCdQpC8s7IntFggjuXJNLElkTmvFXBPsEaOyFN0Z5JJWz8KJ
+        9Clf3gANilzq8y2HunO/k0w5si4osjdlxLlMAtdcZ0t6crIxpOMDR17qznl5
+        ItGlrnYrRkC2fdmtH1e2f80iz+UnMlpqQieQO2ajqgx7jp+00Ot+XtXufHN1
+        +WWzMzeIxZAN0Nhhs7ofD9X3Tab8qAiicD7rEIpUWY4kVzSpTklQT/ti/zdL
+        lgUVz9jArgVp6FuXGGigASlbkrEQNb5Z5kjb7s4qMa9GVkbR2OYYDCvuwq4R
+        mpeEON6He1u3WcRz8gTnL5kqn4EGhjGeFR+5M46eE5Og19HeP3F5ORolW7SK
+        Jk00srphiG63VGAnmySwhpfG0bqAo06jluSAxrgSaC3d8EfWNWfolq4l95I1
+        G3ccIYKs5F1dKy6HMkMDp/grTrYC5hLIVhtOMXFioawONJQGbffUfryf1dIk
+        ObU8JaLTYJE4qhPLimPZnjohqrApzooUSe1DXCirprpiqhMuqK679YPXlHCo
+        5TZ9RWi93oamtrtEjq+FNT0ZmYvLuuJTQ0z32LhZ7WcPJrlblida1nfOStmb
+        7Alo6GY426oCQ6oklSFCpzKkAu4dfr2kyOOUpXSyr+OHSwqZk6jhMr66pSid
+        Cq7OssaVPdCwx4GyGSIU0YrpIl2EIUOubhrq9FGjvyvJTO0YdbcQs70QtI7c
+        X2OJUknG91kKaJAcS+xTjg4fLE4Rm6o97hV/8jBtzQ3KSKvlOY4Yd0gg1EQ2
+        LBPPCbkxHxCrNtId+aDOFKCBT1jSWF1Ktdt6rIYhEtmErTolnDH6IBdjcyUS
+        x0iMzXi12qP1tQ0r8iR5AlVJs7rWsx3QaPWHsZ2jqNilM0bnTOqBuCBkYsq0
+        pguUTjDnYRZYU1PbWut8Gu+qa2kR27NYrhbFiZ3gQMNidS1eYPWyuCAtUtAn
+        gW0F5eE0FTN0Jio7dBG2Rtw24mgxpKhKRn1Lk1YzeYUjbaoRt/eLlWluGJeT
+        9mqMMo1YmtdUGaXXScvieso2D+UwDOh5SG9kQxMzmxcYusQnV8ntli0ypGqg
+        cY69qFrpDIdUWP1AqrEXLvbp7h+g7mYyrMx81Xh6g8wjpyI+tyhFpDXiM3NS
+        /JcX1KGzvky69oZ1qcCb+NzfOtLLNzvVzX3fX67BuUDjPeYGjA1ovMfcgLEB
+        jfeYGzC2p/n43eYGjO120d9hbsDYbhrvMDdgbEDjPeYGjA1ovMfcgLEBjfeY
+        GzA2oPEecwPGBjTeY27A2G7z8Q5zA8YGNN5jbsDYbmb9DnMDxgY03mNuwNiA
+        xnvMDRgb0PjS3KyAZB7n6tngPret3tqqxj55DshfQ1r+x6vA+OH2+oOTJff/
+        /vHnBJiVoR+mz+nvMSceQrcXGdGdOsUu3dEttnKIKqh1JHHr5PLcbh6MBRBB
+        nV7GtpwIJMhD7SV5bNXec/gEeTH0D2UfMb1XDVSeU3qgp0wtCHG04OQLg5PX
+        025VM3ubVY6XMBCXnVWWUnDRThReIxOR3x9mO7cq+Q0+WtKLeD9uqb4Tp64+
+        PDbVlFYdZun9x5/68fm9+lrDJnh/SBwevTpMvEOYgqaz1O1HPMIRBOln7daV
+        g5c6meu5T53/d5+kyz7oHupL7oFoex/2gwudsO7VwEz283a9NXYAp90/D6zX
+        cvvfYS/SF5besfSq4FBnkZfe99PuNFWdJSB39z3JLd87gO4+Nflf0/6rYN/H
+        9Jto3283z0JwzfJD4FmuVx76bF7Vz0N5BgVSEe7Ycx5npVfe0bfu9rquVzll
+        mD/O273et/ZUd9dn/buX53y4/yU6qKrs4IaVZccvWnXKrKqe7q8DGM9zzRcw
+        8VQOaQLSBKQJSBOQJiBNQJqANAFp4luhiZfY4DCLwvF5WpnmWbG/MMcdGiCi
+        wQl4e1X02fHXseEVIlioJDkXTF1e5MMsWSy3ottgO3sQJ44QrDupw8/1am8W
+        ljyfZHVJK4mRL3m+8UqDWSrT4JcQ4fdAgZXnNyTou5X22b/P3V5pOXXYAgR4
+        RQxfxYQXGPE5HHyVIH6RGEDu/sOBYXl5eqjwtmcCb4MBGPph6IehH4Z+GPph
+        6IehH4Z+GPq/xdA/X8qmhtD1McHHi3yjbsXFlcBoOTD4cE6q9ptDv17t+ZXp
+        lMZhcsKXc7INT+fFRbeN+OAQ+ixMCTU+4SIymXmTYhMv8gOdXFJNw0TfGEzq
+        7R/3XOBVigZzcki8Puq7j1AAUv5LTLD+F3QAQQCCAAQBCAIQBCAIQBCAIABB
+        AILA3xIErmuFcqxjY3Dy0hoX1WKnno6uuDeQ2T4mtOLNIECvtZTxBysOzfWC
+        klk8wBqFo65n19vpNbXTRocyHXVZUE+SRBuvrJOtjdxmu09bR1h19B8HAvBZ
+        AEQAiAAQASACQASACAARACIARACIAB/vi6vNjKrFpdF3NGaOBLLAWmc3ImLF
+        cWc6Yr4ZAcjdotp5M5JZSO1KORobNvMb342otVmLiWdFB3IcJQm+GknURuPt
+        0cLPVyfJR4+0uBmx7Z+CAKXnN7FVHjrP/r+N/3fyp4cZkAIgBUAKgBQAKQBS
+        AKQASAGQAiAFvFo9XJCCEU/nS3duoq1jl/t9hAkudpUMztoSszdTwCm74lfJ
+        HHssgsi0ss5QpwWeZ53iAYVi0WY1vm7UXDAQq7DcnB/MmirN1Em8nHHuORnB
+        bwR9a48DPl+aDC5O5mf9zRI+vurVPgl/dT+j73/8yv5HoBACBgQMCBgQMCBg
+        QMCAgAEBAwLGtwIYX+xa9P0r6ti4C2TiIy16oRDDLUJGpCTyaJzlAqUwhx+/
+        mTpwj1IG2wXllCrd7o5ZkxKbdSgdu4gVtZ22P2vnZdiut8mMolUxOOuybzMR
+        JxqcOSW6sfj/Rx2dZ7+a/78OQ9aNfbnTGPFOSGvPf5zdO/1J/q9Ck6Cu8+rj
+        cGi1Vm2VFfbBD+ugsZvKK/t2+/mowf08bIYYiozRMSQZSDKQZCDJQJKBJANJ
+        BpIMJBlIMr0ENc4UPkYQYmOhc8rdm6HGWyxtFJtt5M7M6O3PTxQXdRF9a/tE
+        Ls9CxTHdelezgjAno8k1SOhQnhYcJ3RyiCDuIRdwsPOqxFI1LxoHcfEXkcxn
+        wzjkWVXf/9nfu/o7Ec9nm7iSORjJ45X46k6uLw6A27lCOIFwAuEEwgmEEwgn
+        EE4gnEA4+S3f40pzhF03xJznMhnZhluJtDnhKJ+0607kKuTyZg4pyEPZaUqj
+        IwoybutBHbXSoioGc7ede6h2OSMlobfsmd81RMeJ53lmzC1qInClspfXzgFu
+        5wrRAaIDRAeIDhAdIDpAdIDoANEBosPfER3oyhijI2laH41QLHxrRdEhS2Y7
+        C6nVNY2M3owOhjAoCgyXhGS/CYPopEUr5CS79KoZRM1a2XqKhrE8O5Fba++H
+        uIldwjF/RJPFVVsiKYZCdIDoANEBogNEB4gOEB0gOkB0gOgA0eHviA5TJPd2
+        V4/cW3i8rs+slikIyxmmEekFG802b0YHIlEN9oit2rKgEWYiGJi0SGWFWeN2
+        GKon8kLtprO1dN3Mx/0M2oNowGYZc9asFCs0iRhAdPid6PD4z6Q3WNnYF6AK
+        8z/M/zD/w/wP8z/M/zD/w/wP8z/M/1/m/9Cct+fZOUaREsHrQM+9sXvlOCkO
+        uyA8Wumb8z9HrM/OZDWot4d1vqLCeZOMZj6OZ964CLaCtUn4KhQq5eLV/Drw
+        ponLitxaNut2x9sTGvtf5v8/MeI/NflfM/6nz/jj+OUn9y/T/+dLk59XIKdN
+        HP/CiuXHqt+4AvtTou9Sr7zNiJ9lfuwNek6q/mWlbj/6D5bfhFb5z5/vmO8+
+        HZWBMuxfKIqPEQzHxxNsNpsgxGg6mhI/H3XTOmVV8MFpUgAIgZW8UINrqSE4
+        QHCA4ADBAYIDBAcIDhAcviFw+GIt9WP6fMkT2/LaOI1/rHqjyswY4VNnGhUj
+        yowULid499d54hb8D2Ufcb1XDTwzRm88guwbgZKe28539vpysybxNhCVc5df
+        HVsmV7of1iPlop5RdpVlE2dVFGUQrQZ4wqnbLz/9f0EBX6WEr6DAb94n9hEN
+        fvwP/IycemSeAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:32:52 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_clients/_filters/should_include_the_specified_fields.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_clients/_filters/should_include_the_specified_fields.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients?fields=name,callbacks&include_fields=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:32:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1538771574'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4uuVipJzUvMK1GyUkosLckw0C1OydYtSS0uKVbSUcpLzE0F
+        SrikpiWW5pQoOBYUAAWTE3NykhKTs4uVrPJKc3JqdYgxwjHAU8G1oiAnvyi1
+        SME5JzMVqJw4nb6VYHsHh2IFv8SSzLJU0ixACbLoWOL0BpUmVSoEu3greOaV
+        pKYXAa3Nz1MIgaohwzyUCAC6KiczGWwmkV4ZWO2QBBNmVAQMFJAUsbbm5CBb
+        hhlysQDd784+/wIAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:32:51 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_clients/_filters/should_paginate_results.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_clients/_filters/should_paginate_results.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients?fields=name&include_fields=true&page=0&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:32:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Link:
+      - <http://auth0-sdk-tests.auth0.com/api/v2/clients?fields=name&include_fields=true&page=0&per_page=1>;
+        rel="first", <http://auth0-sdk-tests.auth0.com/api/v2/clients?fields=name&include_fields=true&page=1&per_page=1>;
+        rel="next", <http://auth0-sdk-tests.auth0.com/api/v2/clients?fields=name&include_fields=true&page=12&per_page=1>;
+        rel="last"
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1538771575'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4uuVipJzUvMK1GyUkosLckw0C1OydYtSS0uKVbSUcpLzE0F
+        SrikpiWW5pQoOBYUKNXGAgCnBsxOMwAAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:32:52 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_clients/should_get_at_least_one_client.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_clients/should_get_at_least_one_client.yml
@@ -1,0 +1,132 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:32:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538771573'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+2da3OiyAKG/0rKr1lHQAWdqlN1uCqCCAKK7tmyuAkIcr+I
+        u/vfD20y2Uwyc85ms7fZ6vmSsRvfvoBvvU/a7nz/Y690YzMuex97ZlX6SL9w
+        wn7pFmXR+64Xm2e3q2Dco1lF5R2Zpl2hbUaRZdph0fsYV1H0Xc+LEsuMeh+P
+        ZlS43/W66qRxnYMdBW5cPl31qThKvKQqD1UePVUFxeEY5EV5SM28bHsfy7zq
+        dJLAsQ92Eh+T/Hzr4ENxEXhxEHuH0G07ge9/7NluDnrfB/8odsZLdzS71niO
+        p0mNvZX+J/9PvOR5htFomjxuPbLhKdLjF9bYcjKEER2pJJYkMqPVbKby1pBR
+        WIpudHJJKxf+RHqUJ22ABkUutdmWQ52Z14iGFJotiuwNCbHbse8Y62RJj08W
+        hjRz35aWmn1Znkh0qSnNiuGRbVd268eV7V6zyFP5iQyXKt/w5I7ZKArDXqJH
+        LfS6nxWlM9tcnfmy2hkbxGTICmjssGnZjYfq+iZRXpj5YTCbNghFKixHkiua
+        VCYkqKc9ofs/S+YZFU1Z3yp5ceCZbQQ0UJ+UTFFfCOq8WqZIXe8uCjErhmZC
+        0djm6A8KrmXXCD0X+SjaB3tLs1jEtdMzPm8TRboADQxjXDM6chccvZwNgl6H
+        e+/EpflweN6iRTiuwqHZDAJ0u6V867w5++agrWy18TnqNKxJDmiMCp5W4838
+        yDrGFN3Spei0SbVxRiHCS3LalKXscCgz0HFqfsXJmsccAtmqgwkmjE2U1YCG
+        XKH1ntqP9tNSHJ9P9ZwS0Im/ONuKHUmybVquMiaKoMoushiK9X2UyauquGKK
+        HSyoprn1Y67KwUBNLfqK0Fq5DQx114a2pwYlPR4ai3ZdzGNdiPfYqFrtp/cG
+        uVvmJ1rSdvZK3hvsCWhoRjDdKjxDKiSVIHyjMKQMnp35ekmRxwlLaWRXNx8s
+        KWRGorrDeMqWojTKv9rLEpf3QMMa+fJmgFBELcSLeBEEDLm6aSiTB43uqSQT
+        pWGU3UJI9rxf21J3j0VKIRnPYymgQXIssY85Org3OVmoivq4l73x/aQ2Nigj
+        rpaXKGScAYFQY0k3DTwlpMq4R8xSj3fkvTKVgQY+Zkl91eZKs3VZFUNEsgpq
+        ZULYI/ReykbGSiCOoRAZ0Wq1R8trHRTkSXR5qhCnZaklO6BRa/cjK0VRoYmn
+        jMYZ1D3RIuTZkGhV4ymNYC6DxDcnhro11+kk2hXX3CS2FyFfLbITO8aBhslq
+        arTAymXWIjWS0SeerXn5/jQREnQqyDt0EdR6VFfCcDGgqEJCPVMVV1NphSN1
+        rBK3z4uZqE4Q5eP6qg8TlVga11gextdxzeJazFb3+SDw6VlAbyRdFRJrzjN0
+        jo+votMsa2RAlUDjErlhsdIYDimw8p5UIjdY7OPdv0DdzWRYifmi8XSOmYZ2
+        QXxuUbJAq8Rn5iR7z2+oTSddmXjtDKstwIf40j064vMPO9XMPM9brsF7gcZ7
+        zA0YG9B4j7kBYwMa7zE3YGyP8/GbzQ0Y2+2mv8PcgLHdNN5hbsDYgMZ7zA0Y
+        G9B4j7kBYwMa7zE3YGxA4z3mBowNaLzH3ICx3ebjHeYGjA1ovMfcgLHdzPod
+        5gaMDWi8x9yAsQGN95gbMDag8drcTJ9kHubqyeA+t63O2orKOrk2yF8DWvrX
+        iwT54fb6g52cez//8EsCTPLAC+Kn9PeQEw+B04kM6UaZYG1zdLKtFKAyah5J
+        3Dw5c24380d88Sx+ggR5KN1zGpml+xQ+QV4MvEPeRUz3RQOFa+cu6ClT8nwU
+        LjipZXDyetqtSmZvsfKxDXxh2Zh5LvqteqLwEhkL8/1hunOKfL7Bh0t6Ee1H
+        NdV14tSUh4emqtwsgyTuffyxG5/Xqa9VbIx3l0TB0S2Ds3sIYtB0EjvdiIc4
+        giDdrN26cnBjO3Fc57HzP3dJOu+C7qFsUxdE217QDS6wg7JTAzPZzdv11tgB
+        vK33NLBOy+l+Bp1IV5i7x9wt/EOZhG7c66bdrooyOYPc3fUkNT33ALr72OT/
+        jP8vgn0X02+iXb+dNAnAPUsPvms6bn7osnlRPg3liRxImb9jL2mU5G5+R9+6
+        2+k6bmHnQfowbz2ta+2x7q7L+nfP3/Oh9zU6KIrk4ASFaUXPWrXzpCgen68D
+        GM9TzSuYeCyHNAFpAtIEpAlIE5AmIE1AmoA08a3QxHNssJlFZntzWp6kSbZv
+        meMO9RFB53i8vsra9Pj/seEFIpioKNotpixb6TA9L5ZbwamwndWPzjbvrxux
+        wS/lam9kpjQbJ2VOy2c9Xc7nlZvrzFKe+F9DhN8CBWaa3pCg61bcZf8ud7u5
+        aZdBDRDgBTF8EROeYcTncPBFgvgqMYDc/YcDw7J9XGV425rA22AAhn4Y+mHo
+        h6Efhn4Y+mHoh6Efhv5vMfTPlpKhInR5POOjRbpRtsLiSmC05OvzYEYq1ptD
+        v1bs5yvDzvXD+IQvZ2QdnC6LVrP06GAT2jSICSU64QIynrrjbBMt0gN9bmNV
+        xQRP74/L7R+3LvAiRYM5OZzdLuo7D1AAUv5zTDB/DzqAIABBAIIABAEIAhAE
+        IAhAEIAgAEHgbwkC17VM2eax0jlpaY6yYrFTTkdH2OvIdB8RavZmEKDXasx4
+        /RWHplpGSSzuY5XMUdeL4+60ktqpw0MeD5vEL8fnszpamSdLHTrVdh/XNr9q
+        6D8OBOBaAEQAiAAQASACQASACAARACIARACIAB972dVihsWirbQdjRlDnsyw
+        2t4NiUi2namGGG9GAHK3KHbulGQWYr2Sj/qGTbzKc0JqbZTC2TXDAzkKz2d8
+        NRSpjTq3hgsvXZ1EDz3SwmbI1n8KAuSuV0Vmfmhc6x8b/++kT4sZkAIgBUAK
+        gBQAKQBSAKQASAGQAiAFvNg9nJG8Hk1mS2dmoLVt5ft9iPEOdhV1ztwS0zdT
+        wCm54lfRGLksgki0vE5QuwaeZ56iPoVi4WY1um6UlNcRMzOddN6fVkWcKONo
+        OeWcy3kIvxH0rS0HfL41GdycxEu6hyV4eNWpfRJ+dgzS9z985Xij5xVPxyGB
+        QsgbkDcgb0DegLwBeQPyBuQNyBvfCm+8OsTo+xcQsnEWyNhDarSlEN3JAkag
+        RPKoX6QMpTB7PnozhOAuJfe3C8rOFbreHZMqJjbrQDw2ISuoO3V/US/LoF5v
+        z1OKVgT/okmexYScoHPGhGhGwj8PQhrXejH/fx2VrCurvVMZ4Y6PS9d7mN07
+        7VH+ryIVvyzT4uNgYNZmaeYF9sELSr+yqsLNu3a7+SjB8zyoBhiKjNARBBsI
+        NhBsINhAsIFgA8EGgg0EGwg2r8GGGiXyPEIQYmOiM8rZG4E6N1lazzbb0Jka
+        4dtXV2QHdRBta3lEKk0D2TaccleyPD8jw/HVP9OBNMk4jm+kAEGcQ8rj4FxW
+        kaXKuaAfhMVfBDafDeOQJkXZ+7O/lfV3AqDPjnglUzCShzvxxXNen10AD3uF
+        cALhBMIJhBMIJxBOIJxAOIFw8mu+5RWnCLuuiNmcSyRkG2xF0uL4o3RSrzuB
+        K5D2zRySkYe8UeVKQ2RkVJf9MqzFRZH1Z049c1G1vSA5odXsZb6riIYTLrNE
+        n5nUmOdyeS+t7QM87BWiA0QHiA4QHSA6QHSA6ADRAaIDRIe/IzrQhT5Ch+Kk
+        POqBkHnmiqIDlkx2JlIqaxoZvhkddL6fZRgu8uf9JvDDkxqukJPk0KuqH1Zr
+        eevKKsbO2bFUm3svwA2sDUbzI3peXNUlEmMoRAeIDhAdIDpAdIDoANEBogNE
+        B4gOEB3+jugwQVJ3d3XJvYlH6/LCqomMsJxu6KGWseF082Z0IM6Kzh6xVZ1n
+        NMKMeR0TF7EkM2vcCgLlRLbUbjJdi9fNbNTNoNUP+2ySMBfVjLFMFYk+RIff
+        iA4Pf2p6g+WV1QJVmP9h/of5H+Z/mP9h/of5H+Z/mP9h/n+d/wNjVl+mlwhF
+        cgQvfS11R86V48QoaPzgaMZvzv8csb7Y41W/3B7W6YoKZtV5OPVwPHFHmb/l
+        zc15XgR8IbduOV/77uTssAK3loyy3s2tMY39nvn/T4z4j03+z4z/6Xf8UfT8
+        N/dF79Xe5E8w8JDXX21Ijqso+soG5oeqX7k/+1PAb2I3v02QlyRe5PY7bCp+
+        MmOnm4wPplcFZv7vXx6g7z5dlYAy7CcUxUcIhuOjMTadjhFiOBlOiF+uummd
+        ksL/YFcx4AXfPD9Tg1urIUdAjoAcATkCcgTkCMgRkCO+IY54tbX6IX0+x4tt
+        fq3syjsWnVElRoTMY3sSZkPKCGUuJebO/8eLGwcc8i7iui8aeEKOznh4ydN9
+        Ob7UjWfvteVmTeK1L8iXJr3alkSuNC8oh3KrXFB2lSRje5VluR+u+viZU7av
+        FwOeQcEXoeELZPCrD5V9IIUf/gt2Sqwiop4AAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:32:51 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_delete_client/should_delete_the_test_client_without_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_delete_client/should_delete_the_test_client_without_an_error.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients/9mhyX7O1EokZmaEwtSSmDsBEj352cSlX
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:40:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1538772058'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:40:55 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_patch_client/should_update_the_client_with_the_correct_attributes.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_patch_client/should_update_the_client_with_the_correct_attributes.yml
@@ -1,0 +1,94 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients/9mhyX7O1EokZmaEwtSSmDsBEj352cSlX?fields=jwt_configuration&include_fields=false
+    body:
+      encoding: UTF-8
+      string: '{"custom_login_page_on":false,"sso":true}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '41'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:40:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1538772058'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6WWW7OiuBqG/8qUt/YawRPaVXMRDioipwUqsmcXFQ5CBEEh
+        gNjV/30SVtea7pl9tfVG+YLPlwTy1PttgKMc5njwdQBrnDBvVZi+4ajC1eDL
+        IM4KH2aDr2eYVdGXAao8XKRR7kV5eCtQjj1085IIhlHp4bKucBR+3htGVVCi
+        G0ZFTtBChqIc//Zz8csgh9eIjNmk2cf4W1n7He096HudUVlh7wZL3A2+Ej6h
+        VlXhhaiCfvZTq6AsqsorShSj3KOL+BwpUBh4QZGfi/Lar/FHnWA+iSjOUR57
+        adRVg6//+TYIopJuxhv98NJa1n4TpHdbXskCsKW++mf5Z67KsijaggDOxxi0
+        Mg9ieevP/PDOiLtQw5wKmLVg3deW7E9EU+KFdg9UwXzIFxDzsXagDB6o9vq4
+        YsN13O4cLYUdy7iOxgTdLAmd90IVZhd/zLSbJNBUO3ioF8CqttnqoswcSa2f
+        x1Mi1xLzWb+AVLXkVgYn8WCaovTIfrDYp7uucLg+PMONWp+cAwNFUFPGabzE
+        ZD08mZvGx+k9SdF62TI8MKUVALoAzAWg40KskN8SKO98tpQSH8u7UQy7jDLY
+        BGhwt98q1qZWb0zTnB4mt64msOCF8eGcjKpVJ70zwmYnZ5mLXN/2JSYKbtf5
+        pitM7UEZ47EYwey8eszZx9XhhPfUjS+rWzmZXI9slc7qdALbEWKPRz7xr4dr
+        AkddHVhtsuIvkwasKGNayYKVHzZnKXSW7FHAu7Ar6kM4TRlZM24txka4YsXR
+        fs5vnnPQyOOQY47WaDFWZpCVbMowarZxeXfqLvFudr00G15hF8n2GphBphkB
+        9CNzxlWovj+MXbprhtnd0OvqOTYDtOXbtp/HxjLQyLr5wpMRbHxEjnXq0iC2
+        EBZmE2fbvVebfK/k7nha6+5y6ICTWl4EzT4FuuE60oUybActj6YsAhPwBSO3
+        pggM+u5s3lUenBcSbwMythmpPLMG7D4UY/PI8zafPAMVzw2XMvxpYhxGDM81
+        Sr7NtwiJQO8Z5uKDQd5KUJitaJ62SuHKSRNo5BnveBOIcSzxlAFWEufmKwEN
+        4cpQ6qo5u0Y8Gy4a58CKO119ZKkYjjiGn2l76MxvnFY7QwbifX4CQ3NpUMZ8
+        JoG93pVme4wka8zsQI0ac8EFU3ao3aeOrnDnVMmcTNddFj8bVIHLLpL5arfE
+        2C5OlNHYw6l/Y1mlzZeivXL4Idcx4OpogmXLvM2Jj1GRwIVjHeH7bZGdqmcJ
+        ueNDKfXt/SLN5pQBJdvKtmOs3jumYe7CRZYa2RheFkrBLhXjxG5Rs8+aWpls
+        RzxfaWwMrZ2+1PQ50+QW158XWFghyspZ89xPCotTnWduTPLnrJHmdi7Vw3KE
+        EmGNhIO2t5TC38iiUM5nz13Yqg0z4jFlPLIorXRbXDHVGA+BmUVo6+anP+hY
+        LxlJE/+neIgab2lQcb8qylAEi/tFTkb88wMNhILUdk8irK6ih/hBXp3dz4ed
+        b9dxHKvv9L+U8YrcqNgo4xW5UbFRxityo2L7sR//t9yo2PqH/oLcqNh6xgty
+        o2KjjFfkRsVGGa/IjYqNMl6RGxUbZbwiNyo2ynhFblRs/X68IDcqNsp4RW5U
+        bL2sX5AbFRtlvCI3KjbKeEVuVGyU8W+5wQSIH3v1KbhftUXUVtX+JQpo/hoJ
+        2h//CKS/99e/B8V18P2/JPb1mdFDJAgOltekczidlYrUvUKpxZZ1FSteukxm
+        48DKHIIOYJb5MEi9usw8HF1vGcTR3xnyA1ZFQRnR9u4qR6F4yCCMzs5hnunR
+        KXlOFd26ro8lHM/k1CvfHqY/SUgxPM61WWErz7ftm1+Lm8p5koaXFvfZE8V1
+        CT9y8LdBhs4RRtfII1GVNCvykKTOyZxhGLL4vjkJ10ERfsbb7ySFlyS7eri7
+        RTSh9jGdhN1nz/TovTQuk/WgANHkXEbnMqqSj6g++FwaYYfkGxHogO4eievF
+        1csKGppvMI48OsGPln8B25Ei2BQMAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:40:55 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/create_test_client.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/create_test_client.yml
@@ -1,0 +1,118 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients
+    body:
+      encoding: UTF-8
+      string: '{"custom_login_page_on":false,"description":"Client description","name":"TestClient-rubytest"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '94'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:40:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538772056'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6WYV6/iSBqG/8qIW6YHB4yhpbkoB8A5Y+OdFXLCOeAEeLT/
+        fV3uUW/3Bh1pz7nhUDZPBbue1/7+XPVR5VX96uvKG/oE+dKF+Zc+6vpu9esq
+        LmrfK1Zf717RRb+u0u7W13lU3aIqbOq06m9pc0siL4zaW98OXR+F388Noy5o
+        06ZP62pG00UaVf0vPzb+uqq8MpqPmXNn345/aQf/DfteLX3d07brb43X9u/V
+        15k/U7uuvoVp5/nFD10Fbd11t7pN47S6wUl8P1KnYXAL6upet+Uyx7/aoypo
+        380y3L+4aVylVXzLo3e3+vq3P1fzP/PQvsA/ij1x8i+6AX5Rde4CTPYXgb0u
+        R/5o/6gkjmMbwFEACDTQWNA+qOLAJn7PiZvYexdoAmRPtHjBOA9Sg4zj9aWR
+        pw73aorGLvcEMjbd8c3qCH0WuaJwU9c3fRaJgqbcnd+1Jr8wjIm84n587dBX
+        6ZC0nrtxdmxaHC9ttMsJyBhy3HtuUtS2qcQvL2Xibd5DYDyTI5XhIzhuO442
+        qsv5zobOAbXpXgzf9XAJtznCyWrzhIy+V8MjymysHXWedmDksJBEbGOzxwTC
+        Q1lTHdDRpdyte+hFoszGMyWg+4QvAy0oZDXwIMOPNILs0uHxUsVcHNfFQ1WG
+        bsK0IOWp5/N4NtR0YzQ+PSG02dupY1zfeRAbaU8TuMO/IUPvzpUlVC62HRT3
+        sHbAVWozWjavgaK6DpuZTnqwNY4BGqBAPa+9Bri2eGdChiGY6yqQwcWslZjq
+        MegezHu8nqIEx8Ojzmec+B6rk2WdtaQDMdq49tnYjWVzPz6amoouY6llerNf
+        1vSRB7bMo8+h57g1Mk25XIrjhXiJ0/6sX6SCoay7QFwC0gGqr3ta89zyRq4T
+        r8P5wm9oyLjiydknTklx94lJqGt0izbbajoFRyO4X3yqbd8X/yG6WhW/tNS+
+        TqkPRBrLCAdX6t12WdOd2tPt5Ah4c97J7LqMs+q+MeoQP62v1F1vrldW3ZHj
+        daIH3spOTlhcjP3JCB6F+BS70wQZxXvNu1t1GtpWf6IiV0m+W+qW25EVzWZ3
+        fQ0aXeixq7w9vnJLCfEYuZLZuG98hx6FiF/mQlC7/GIloD5RQAmNtdfcg7tv
+        5FNGqQPAY20/hscCO2IPPFBfzr2xVOF6ApoaYHl9fUEG/h7XCKtTSWdvNQKQ
+        G74RDXKDng+NgqvupSzIdyQW8JKwh8Ob48JNstMeUztGoOYZCjJCRaGM8tQ6
+        Q3aoMWUznqpYla7Y42m3hMFKUxROlZSelPuRQJB2xBzZl89Sv4xbOi6MczM5
+        jKbuwoI24m4tv1S9uKMaPfK78NTyV826kILFdrmuUkz64JT3/XCuBDRZX4vs
+        JKGQIfKZ59bWpphUIcv7sWaqUOWBgnNGqu9xDtfkYmS6F/ZE9CclTv2hFLOp
+        eY3WvZg2++VeN18yVumIHRA7xp4CZMeGLzvk8Hl61qm3qee2o5yMCOexg4B/
+        WWL25qpsnT8Or8rB18Wyb4/ksbFCHO+HITFKA/WxFh3329qg1AOrmUC8tx5C
+        7kjNKfGMujzYYBPpEpmV3YUo7CNk7FXRZQuy1SXEdoRLjTEGhReqN9g8+2bk
+        wjr0+3W+N156ieTio3RKvZVcqfWr8L4/+BVkEJFJm8WTLw39YgO7lRNEM7Ys
+        HV9Z8HDPvrA7ZUCLKoCcfRtY+8ip+Rf3wuRRouT+2kLGa/cetlbtteXwuOK2
+        un6cSqknOVmnsitpn5+WTLyJqOj2ks+VKgnKFuvTKT8fCp6O9unC6C8xFjyB
+        kgkn6tDlRmjnWiOx+XpHlKdzG/SRpTx2aNlqx0FwBTxH1gV9OPHaLkF0ACCj
+        cdttf0DmsYOLaVkavZ/ueRHVWmNOnEi5skKGZkZO3FYdnhjRD2t+O3lm7hGX
+        hyXny97HfJx4NbqiRF5WmhNR0mosF3v6zfGai4UpJ0hxG64BJ/Q0WIfCy5UU
+        /V5RKJGBA2Ys40DmKAm2ciFqODYJ/X56pYNzvJ8xiyHi/Emao055xURjpEC3
+        SiKbYXm0499/h79dQoqVmf8ZXnPOBlHb/5x0NKub3JGj55N/TDmGMWka3O0Y
+        PGfjxhzvE374QBgxlHtSAsiJNh4ng/NxRmMp+mkBidZeXAZiKpYvkDFvPfNk
+        H9HwFD9FR869N4q4jowEbyIJHb2WaCLzMeR5TgJZMoOXlAFUMrWnwnCIPbct
+        45jY+TuLfG/PQC4Z3JMDV+aiaQz7Kv5ioZN76vrwdJnCszRcnQviMWBYLIYd
+        +nk+1Dw2mYrzR5Knp8MTmVOEPQKgzCm+B/A4Hf/3RIeMj1L9o0Rf7o4PUv2j
+        RIeMj1L9o0SHjI9S/aNEX2z6Qap/lOiLCX9I9RrhnhoDVHjvnHWJAvc9S5lg
+        PnbeSBRyAqgVMrFmU5RJJVMg9TvVXZ4+tol62SAUOQoVX/FpygBlYWj7b4z5
+        rgS19mS0Ky/ULpeMgTxfY5HSABPH7JIM4MiSbnWk07V3VIWhG++uGhPr/ehc
+        UEZUpFeRM+GGRChCtjxn15Dy4KwRr7eqK1hrB3VJbIIFlvJutacdsQaGiGBI
+        R21PBlt0LT+2jiKQ91wonEJRXLSfxrQDmRhxVCce+t6sr5Axmuut36Co8KwO
+        jHl0qDX5RkDpyLRhcpRJMq9NnXh7x7C9+XmluHZT65H2S2gV/pGxxA4yPNY0
+        Ch7rpccbGZEHnXHsyKnrbC/U6EFQryifjlYxDgLObyiqk9HYM0TlICs7ZKwM
+        ctkvXm2EadES42ThtUFKzlSpeDURI7szK3ZYt5s0oU8pfZEtQ6j9M8fQ7Y6Y
+        xPApjciG6hcjF1HeKSZzRDqsXwOtiFLera4/W+q/iWc2VJMHHfmzolSBNsif
+        5KTGP17QgK7nNnGahfXu4CZ+zbeO+ONmp56nOI4lHf4WMj4jNyg2yPiM3KDY
+        IOMzcoNi+2s9/m+5QbEtF/0TcoNiWxifkBsUG2R8Rm5QbJDxGblBsS2vaJ+Q
+        GxQbZHxGblBskPEZuUGxLevxCblBsUHGZ+QGxbbI+hNyg2JbXms+ITcoNsj4
+        jNyg2CDjP+XmJYD5tlbfBfeztma1dYOfRQF8/trQ8u//Vn/5bfn+W1CXq3/8
+        fX5QW0oktzSczz6UydshFZStc7f02GdvGCXTUWyGE1hgFA58rvOKwveC/Da0
+        xa2Pyqbw+uhfJZNvsC4K2gh27x6rNGQuhedFd+eyK5TomkxbQZnfsuzWwwgu
+        v7VfXpqPJ3NjaO9kojaF6Qv/xR+Yc+dMc4fZs19KLWk8tN63ss+fqyK9R31a
+        Rre0gp3VVditvuI7BEHmyS+d36IqqMPv1Zx//LqKW28eWv9uIliKWapSdZtO
+        C/MGz4XVoXk+aZDCQlEb3duoS75Vplbfpzazw/kznaEruHpD19flrahhjajx
+        4ugGB/ity38CnTBy9wMTAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:40:54 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connection/_filters/should_exclude_the_fields_indicated.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connection/_filters/should_exclude_the_fields_indicated.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_LW7vB80FsVmRF4fN?fields=name,id&include_fields=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:17:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1538770639'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA0WOQQrCQAxF75J1BXHZrRdw4U5kSKdpHZgmJckoRXp3p4q6
+        SnifvPwnyOxJ2KB9wjTgNjB6uhO0roUaUPKiHIhVcg5G7olH+6RrAzOaPUT7
+        k+QUF2hhFOmhgU6LUxhEI4VZxSlub75Sc0WncQl3Unvzw/qn1YLFb/uqSRZ6
+        mTBxiML8lQyYrVqIscvUh5gTsddOl+vWF/O07XAm8+PvaqelW7wiuK4ve7Zv
+        I/YAAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:17:17 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connection/_filters/should_include_the_fields_indicated.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connection/_filters/should_include_the_fields_indicated.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_LW7vB80FsVmRF4fN?fields=name,id&include_fields=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:17:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538770639'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWykxRslJKzs+L9wk3L3OyMHArDssNcjNJ81PSUcpLzE0F
+        yoakFpc45+flpSaXZObn6RaVJlWWAIWACjKL41PycxMz8+KT4fJKVmmJOcWp
+        tQCC/XfpWwAAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:17:17 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connection/should_find_the_correct_connection.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connection/should_find_the_correct_connection.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_LW7vB80FsVmRF4fN?include_fields=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:17:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538770638'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA3WPQUvEQAyF/0vOFRYRlB4V9iQii+hhWYbpNK0DM0lJMl3K
+        0v/u1EU9eUp4L3zv5QKxhxYCk3v+uJ8fH3Z7fc+H/d3wAg3wZJFJob1AHvw2
+        fLA4I7QmBRsQtCLkkIRTcopmkUa9umsDk1c9s/SvnGJYaszI3FdsJ8XQDSwB
+        3SRsGLaYH6iaeMNxcTOKfuu3659aKb7Y565iyOfaBN5Q7YmJrpQbKd1iVaoH
+        UV3P2Udy4deHdvBJawyS7xL2LqSIZLX08bQ95FPe9n+pp/ULPGRgtDMBAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:17:16 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/_filters/should_include_previously-created_connection_when_filtered.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/_filters/should_include_previously-created_connection_when_filtered.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections?strategy=auth0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.5.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 15:41:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '5'
+      X-Ratelimit-Reset:
+      - '1538667669'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA62SXZOaMBSG/0uu3Znw0VX3DlBRUYsfKLjjMIEEzS4SSQIu7vjfG2237UU77Ux7lcw5b97zJnme3wHF4AmkrIjDN9PjFUMJNM91HoWgBdhJUlYI8PQOjhm6LSiVtCbgSfKKtAAnsuJFTArO8jwWREpa7MXX7rUFEl5JEmeMpyQ+cSZJerP7OCwkR5Lsm7gmXNzr+vVHVYVClTxAlaJARzURBILw2/bBR0KcGccPlhKQQtIU3X1bgIoYsyOiRawuVHyMy1Au7mFRflThnv/stGsBUqAkJzhOc6oa92OGc5539Oac4XIzo5qvocx6RC94OIjcgzkSKoBRWqMg77hT7IZanSZ8u33VR1i/TIIB2rS7SmKbzB/mELbXSHNtvA3pcoj6TlCuN6+4G74qiSMCUzMmHZkF1Cv36LPt0L7FIgTlfOFAQ0nc6SxcQkdmx0dzfFrPN9740tad2SEYUteaJ0qyxmP4aQ9rrbFhgEva8+yJlQVvs1Kz9XRoKknaG5fpfuj4nRMrt00vi7QD9ILB6LG++Ktudnv8E+wvqrY7HLAZ3NDNxEoGo2z2srxE3kDARknKS9IzxLipVpGjh8bIKvU6jYx27qe4u4I3kC4L305RVgWD2RSZpRhH85cMe9sAdrd5e1mC3bX1E4oenLp9g4YrTNDUO5n/juLp20/7LKfpDa49Yxj8b0RXREjnO3kPvEoaqUp/T+bvDH4J5O66+wKG5I4YwAMAAA==
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 15:41:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/_filters/should_should_exclude_the_fields_indicated_from_filtered_results.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/_filters/should_should_exclude_the_fields_indicated_from_filtered_results.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections?fields=name&include_fields=false&strategy=auth0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.5.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 15:41:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1538667671'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA72SX4+iMBTFvwvPTlL+7KjzBiigKIujKDgxpNCinUEqbcHBid99qruzuw/7tsk+NTn3d25Pcs/Lh0KQ8qTktErjd8NnDYUZMM5tmcRKT6EnQWjFlacP5VjA2wNzQVqsPAnW4J7CsGhYleKK0bJMORaCVHv+Y3rtKRlrBE4LynKcnhgVOL+t+zJzwaDA+y5tMeN3Xbv+VmUo2IgDkCkITxE9QlKlMmb1taSAJb9HgOVRfvmiRByzCh7xQwg5P1OGHky5AFeC5PBu2fUUXMGsxCjNSyIHd5tunxcDrTsXqN4ERA1VWJiP8BV5TuIejAmXAfTanETlwJ0jN1bbPGPb7Zs2QdplFjlw0x9KxDJo6JUA9NdQdS20jcnSg2M7qtebNzSM3yRi88hQ9dlAFBHx6z38btlkbNIEArF4toEuEXcexEtgi+L4aExP68XGn176mh0cIo+45iKTyBpNwbc9aNXOAhGqyci3ZmYRvQe1amm5Z0gkH03rfO/Z4eBE6203KhL1APzImTy2l3A1LCRSncD4uem7nkMDsCGbmZk5kyJ4XV4S3+Ggk0h9yUY6n3bNKrG1WJ+Ytdbmid4vwxwNV+BWj8tzaOWwaCInmEOj5tNk8VogfxuB4bbsL2tld+39UTAfzN2xTuIVwnDun4x/L9jp56VDWpL8Vpk9pUj538VbYS7sX8ADa7JOSOnvfdtdd58RXtJxdQMAAA==
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 15:41:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/_filters/should_should_include_the_fields_indicated_from_filtered_results.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/_filters/should_should_include_the_fields_indicated_from_filtered_results.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections?fields=name&include_fields=true&strategy=auth0
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.5.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 15:41:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '4'
+      X-Ratelimit-Reset:
+      - '1538667670'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4uuVspMUbJSSs7Pi4+oMPEuKs1PTDIwKS/LiYxQ0lHKS8xNBcqGFqcWgZi6AYnFxeX5RSm6jqUlGal5JZnJiSWZ+XlAlZnF8Sn5uYmZefFAo/JSk8HCVmmJOcWptTpIlngb+Lq7GmdGhKSkJvp6F5ggLAlJLS5xhuvVLSpNqiwBChEwOxYAA7Uw2cIAAAA=
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 15:41:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/should_include_the_previously_created_connection.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/should_include_the_previously_created_connection.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.5.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 15:41:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '5'
+      X-Ratelimit-Reset:
+      - '1538667669'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+2TXXOaQBSG/wvXZmb5qF93iIqKWoyiYMZhlmXBTZAFdsFgJv+9S9IktdNOO9NOr3oFc87Lu4f3PHv3JJFQ6kuIpr4FFuZIJe4mxHBhZZrUkmjGCU2Z1H+SThFsHhBxUmGpz4sSt6QC87JIfZwWNEl8hjknacxeu88tKYOMnWkR2jQhqBbHxJSGwjYoSo79iBYI+1lBOUbNMW+mjBeQ47j2K1ywl7ry/FEVLrDkRyBsUngSk0gbzLhB0/TV5aYog5qLkhAQ5of0BEnqo/e+1I9gwl5mh8lJzHr3U4NDS8IpDBIc+ighOOWN+vDc+iYz91GzipLCAGjnKvHcP8/s72bjMFw0rzf211Xc6EIgfoUg+OL72yH90umHaUmqcV51lfochfluSWRbhpHehvfhZOyZR23KxABqrk+dpGsuQtOVKxQU+/2DMg2Vy9wZw12nJyQDjdqTBIDOFsrmINy7ZD2BI8PJt7uHsOc+CInBHE1W510eOcTKY/h5YJCRTj0I+OrWAKqQmIuluwYGj05tbZZtVztrdukoxvLoTIiprwIh2YYz8CkGlVwPgBPmZGgN5nrkPC5zeaCgSXMn0HCWo3hi2N2M5vt6GHnyEVjOeNquLvamFzXhZ2B0W3bMyZguwY7s5nownkbL+/XFs8YM1EKSX4KhymZ1ufEMxVWneq5UyFM7iY3C3gY0IF1u7QGCUemMlwuo5Wzmre6j0No7oLdPOutcukbR7sENaI/iagM6eIp21yhiseHkjSLBVUSSdyIZohlulvUq+ugfrtkStzdO8A1tGFM+GPu+/JtAXX/2n55/T8/hC1zkMgH+BQAA
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 15:41:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/should_not_be_empty.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/should_not_be_empty.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.5.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 15:41:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1538667668'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+2TXXOaQBSG/wvXZmb5qF93iIqKWoyiYMZhlmXBTZAFdsFgJv+9S9IktdNOO9NOr3oFc87Lu4f3PHv3JJFQ6kuIpr4FFuZIJe4mxHBhZZrUkmjGCU2Z1H+SThFsHhBxUmGpz4sSt6QC87JIfZwWNEl8hjknacxeu88tKYOMnWkR2jQhqBbHxJSGwjYoSo79iBYI+1lBOUbNMW+mjBeQ47j2K1ywl7ry/FEVLrDkRyBsUngSk0gbzLhB0/TV5aYog5qLkhAQ5of0BEnqo/e+1I9gwl5mh8lJzHr3U4NDS8IpDBIc+ighOOWN+vDc+iYz91GzipLCAGjnKvHcP8/s72bjMFw0rzf211Xc6EIgfoUg+OL72yH90umHaUmqcV51lfochfluSWRbhpHehvfhZOyZR23KxABqrk+dpGsuQtOVKxQU+/2DMg2Vy9wZw12nJyQDjdqTBIDOFsrmINy7ZD2BI8PJt7uHsOc+CInBHE1W510eOcTKY/h5YJCRTj0I+OrWAKqQmIuluwYGj05tbZZtVztrdukoxvLoTIiprwIh2YYz8CkGlVwPgBPmZGgN5nrkPC5zeaCgSXMn0HCWo3hi2N2M5vt6GHnyEVjOeNquLvamFzXhZ2B0W3bMyZguwY7s5nownkbL+/XFs8YM1EKSX4KhymZ1ufEMxVWneq5UyFM7iY3C3gY0IF1u7QGCUemMlwuo5Wzmre6j0No7oLdPOutcukbR7sENaI/iagM6eIp21yhiseHkjSLBVUSSdyIZohlulvUq+ugfrtkStzdO8A1tGFM+GPu+/JtAXX/2n55/T8/hC1zkMgH+BQAA
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 15:41:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_delete_connection/should_delete_the_connection.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_delete_connection/should_delete_the_connection.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_LW7vB80FsVmRF4fN
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:17:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1538770640'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:17:17 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_delete_connection_user/should_delete_the_user_created.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_delete_connection_user/should_delete_the_user_created.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.5.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 15:41:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1538667671'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+2TXXOaQBSG/wvXZmb5qF93iIqKWoyiYMZhlmXBTZAFdsFgJv+9S9IktdNOO9NOr3oFc87Lu4f3PHv3JJFQ6kuIpr4FFuZIJe4mxHBhZZrUkmjGCU2Z1H+SThFsHhBxUmGpz4sSt6QC87JIfZwWNEl8hjknacxeu88tKYOMnWkR2jQhqBbHxJSGwjYoSo79iBYI+1lBOUbNMW+mjBeQ47j2K1ywl7ry/FEVLrDkRyBsUngSk0gbzLhB0/TV5aYog5qLkhAQ5of0BEnqo/e+1I9gwl5mh8lJzHr3U4NDS8IpDBIc+ighOOWN+vDc+iYz91GzipLCAGjnKvHcP8/s72bjMFw0rzf211Xc6EIgfoUg+OL72yH90umHaUmqcV51lfochfluSWRbhpHehvfhZOyZR23KxABqrk+dpGsuQtOVKxQU+/2DMg2Vy9wZw12nJyQDjdqTBIDOFsrmINy7ZD2BI8PJt7uHsOc+CInBHE1W510eOcTKY/h5YJCRTj0I+OrWAKqQmIuluwYGj05tbZZtVztrdukoxvLoTIiprwIh2YYz8CkGlVwPgBPmZGgN5nrkPC5zeaCgSXMn0HCWo3hi2N2M5vt6GHnyEVjOeNquLvamFzXhZ2B0W3bMyZguwY7s5nownkbL+/XFs8YM1EKSX4KhymZ1ufEMxVWneq5UyFM7iY3C3gY0IF1u7QGCUemMlwuo5Wzmre6j0No7oLdPOutcukbR7sENaI/iagM6eIp21yhiseHkjSLBVUSSdyIZohlulvUq+ugfrtkStzdO8A1tGFM+GPu+/JtAXX/2n55/T8/hC1zkMgH+BQAA
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 15:41:06 GMT
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_Xx4Kruoab04wvlYX/users?email=rubytest-rubytest-username@auth0.com
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.5.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 15:41:07 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '2'
+      X-Ratelimit-Reset:
+      - '1538667672'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 15:41:07 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_update_connection/should_update_the_connection.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_update_connection/should_update_the_connection.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_LW7vB80FsVmRF4fN
+    body:
+      encoding: UTF-8
+      string: '{"options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"excellent","brute_force_protection":true,"strategy_version":2}}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '145'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:17:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1538770640'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA3WPQUvEQAyF/0vOFRYRlB4V9iQiInqQZUin6Towk5QkrZal
+        /92pi3rylPBe+N7LCVIPLUThcP96Pd/e7Pb2Up72V8MDNCCjJ2GD9gRlwG1g
+        9DQTtK4TNaDkk3IgVsk5GLknPtrZXRsY0exDtH+UnOJSY+gzUs7EXtmdTk5h
+        EI0URhWnuGX9kM0VnY5LmEntW79c/9SKwsnfdxXDWGodeCbzO2E+Uy506hav
+        Uj1IFnopmDjEXx/aAbPVGGLsMvUh5lRb1eZvh+0rzGXb/6Ue1i8UuRaiOAEA
+        AA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:17:17 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/create_test_connection.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/create_test_connection.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections
+    body:
+      encoding: UTF-8
+      string: '{"name":"TestConnection-rubytest","strategy":"auth0"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '53'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:16:25 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538770587'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA3WPQUvEQAyF/0vOFRYRlB4V9iQii+hhWYbpNK0DM0lJMl3K
+        0v/u1EU9eUp4L3zv5QKxhxYCk3v+uJ8fH3Z7fc+H/d3wAg3wZJFJob1AHvw2
+        fLA4I7QmBRsQtCLkkIRTcopmkUa9umsDk1c9s/SvnGJYaszI3FdsJ8XQDSwB
+        3SRsGLaYH6iaeMNxcTOKfuu3659aKb7Y565iyOfaBN5Q7YmJrpQbKd1iVaoH
+        UV3P2Udy4deHdvBJawyS7xL2LqSIZLX08bQ95FPe9n+pp/ULPGRgtDMBAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:16:25 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/create_test_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/create_test_user.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users
+    body:
+      encoding: UTF-8
+      string: '{"email":"rubytest-rubytest-username@auth0.com","password":"7oGmRnT8Bp3vVhNe","connection":"Username-Password-Authentication","name":"rubytest-username"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '153'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:16:26 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538770588'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA41Ry27CMBD8F0twIoltiPOQUMul50ptL60qtNgbsApOZDtU
+        FeXfa4eHOKFKPozt2ZnZ3QPBHegtqYntVz8enU+uoHdoDezwEXq/oalsd2RC
+        4sMt+0IKX4PSco9WNxoVqRvYOpyQvlPgUS3BhzpOWZkwmtD8ldOaiZqLdEr5
+        eyjvtPS9jeIb7ztXZ5lL1xb24MFG8+wEMy6mkmLDZjmWjCkuCsFkEQCrqllZ
+        Ng9uPivp2M679VjNB63RdDHiT+FIZdJrN+F+knQB2T7tzDrEiA0tdYhPBuJv
+        vloVUlQgBOS0YqUsCwZKsTgLLb/uzEMrNF57jY7UHwciW2NQet2awH8705Jn
+        cO67tSpZBLfIlzBQboPcidDZdh987CVutHUvrdSwPS/g+Dkh0uI/VnD8A8xz
+        JRwNAgAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:16:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/_delete_device_credential/should_delete_the_test_credential_without_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/_delete_device_credential/should_delete_the_test_credential_without_an_error.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/device-credentials/dcr_GppmjtmDWWY7RRS5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Basic VXNlcm5hbWUtUGFzc3dvcmQtQXV0aGVudGljYXRpb25ccnVieXRlc3QtcnVieXRlc3QtdXNlcm5hbWVAYXV0aDAuY29tOlN3R3pFeEozWjkwa0kwSTA=
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 18:16:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538763419'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 18:16:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/_device_credentials/_filter_by_type/should_exclude_the_test_credential.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/_device_credentials/_filter_by_type/should_exclude_the_test_credential.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/device-credentials?client_id=B4oPHl007Va1GBdZXiSHaECUqVWkd9Xk&type=refresh_token
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Basic VXNlcm5hbWUtUGFzc3dvcmQtQXV0aGVudGljYXRpb25ccnVieXRlc3QtcnVieXRlc3QtdXNlcm5hbWVAYXV0aDAuY29tOlN3R3pFeEozWjkwa0kwSTA=
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 18:16:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538763418'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4uOBQApu0wNAgAAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 18:16:56 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/_device_credentials/should_have_at_least_1_entry.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/_device_credentials/should_have_at_least_1_entry.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/device-credentials?client_id=B4oPHl007Va1GBdZXiSHaECUqVWkd9Xk
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Basic VXNlcm5hbWUtUGFzc3dvcmQtQXV0aGVudGljYXRpb25ccnVieXRlc3QtcnVieXRlc3QtdXNlcm5hbWVAYXV0aDAuY29tOlN3R3pFeEozWjkwa0kwSTA=
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 18:16:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538763416'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA0WOyw6CMBQF/6Vrm1xqH+LOgLrHBTHGNC3cBFSwgdaEqP8u
+        1YXbk5nJOT1JW5M1qatB753rLr7Ly/KoiuIgyILU+Ggr1L3pcIaGYCePo6dh
+        xCFu2jX3HnXyJ78xuVJiueGc8lzuaMKYpGkmgQII2PIMAKSalVj5CSb4Bl7C
+        WmVMytBwyTkoZhNjESLqJxcPuGBvbaWvOJH3+QNVhWe1uwAAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 18:16:54 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/_device_credentials/should_include_the_test_credential.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/_device_credentials/should_include_the_test_credential.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/device-credentials?client_id=B4oPHl007Va1GBdZXiSHaECUqVWkd9Xk
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Basic VXNlcm5hbWUtUGFzc3dvcmQtQXV0aGVudGljYXRpb25ccnVieXRlc3QtcnVieXRlc3QtdXNlcm5hbWVAYXV0aDAuY29tOlN3R3pFeEozWjkwa0kwSTA=
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 18:16:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538763417'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA0WOyw6CMBQF/6Vrm1xqH+LOgLrHBTHGNC3cBFSwgdaEqP8u
+        1YXbk5nJOT1JW5M1qatB753rLr7Ly/KoiuIgyILU+Ggr1L3pcIaGYCePo6dh
+        xCFu2jX3HnXyJ78xuVJiueGc8lzuaMKYpGkmgQII2PIMAKSalVj5CSb4Bl7C
+        WmVMytBwyTkoZhNjESLqJxcPuGBvbaWvOJH3+QNVhWe1uwAAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 18:16:56 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/create_test_credential.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/create_test_credential.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/device-credentials
+    body:
+      encoding: UTF-8
+      string: '{"device_name":"rubytest-username_phone_1","type":"public_key","value":"dmFsdWU=","device_id":"68753A44-4D6F-1226-9C60-0050E4C00067","client_id":"B4oPHl007Va1GBdZXiSHaECUqVWkd9Xk"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Basic VXNlcm5hbWUtUGFzc3dvcmQtQXV0aGVudGljYXRpb25ccnVieXRlc3QtcnVieXRlc3QtdXNlcm5hbWVAYXV0aDAuY29tOlN3R3pFeEozWjkwa0kwSTA=
+      Content-Length:
+      - '180'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 18:16:51 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538763412'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWykxRslJKSS6Kdy8oyM0qyXUJD480DwoKNlWqBQCXwWsq
+        HQAAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 18:16:51 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/create_test_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/create_test_user.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users
+    body:
+      encoding: UTF-8
+      string: '{"email":"rubytest-rubytest-username@auth0.com","password":"SwGzExJ3Z90kI0I0","email_verified":true,"connection":"Username-Password-Authentication","name":"rubytest-username"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '175'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 18:16:50 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538763411'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA42RS2vDMBCE/4sgPcW25HcMoc2l50LbS0sJa2mdiCay0SOl
+        pPnvXSdNyCkUdBjBtzOz7J7hFvSGNcyG9tuj89FFBIfWwBYfIPg1j2W/ZdMT
+        vtyh1Z1GxRpvA07ZiF17nEdpIAwKPKoleAJSLupI8IgXL6JuRNkUPM6y4o24
+        QUsf7Oiy9n5wTZK4eGVhBx7smJ2cZJKWmeTYibzAWgiVllUpZEVCzGZ5XXf3
+        bp7X/M7Oh9Wdmh+9Jtlikj7Sk8rEl2Xof7J0pGyIB7Ma61LzpabF2BH8Kdq2
+        ApilCHmZ57xKWwEt8opQo+XnjcW1QuO11+hY875nsjcGpde9If71D4uewLmv
+        3qpoQWkjL+GIXBe5UWGw/Y5y7LnuGOuee6mBTtrBxuHhY8qkxX+c4PALQO4v
+        MQwCAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 18:16:50 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/delete_test_credential.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/delete_test_credential.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/device-credentials/dcr_GppmjtmDWWY7RRS5
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 18:16:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538763420'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 18:16:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/delete_test_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_DeviceCredentials/delete_test_user.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C5bb7aa92ea4644072b1abe07
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 18:16:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538763419'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 18:16:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/_configure_provider/should_configure_a_new_email_provider.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/_configure_provider/should_configure_a_new_email_provider.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/emails/provider
+    body:
+      encoding: UTF-8
+      string: '{"name":"mandrill","enabled":true,"credentials":{"api_key":"api_key"},"settings":{"first_setting":"first_setting_set","second_setting":"second_setting_set"}}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '157'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 18:56:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538679364'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA1XLSwqAMAwE0LvMuifoZSTaKMEapY0LKb27HxTsKjPDS4HS
+        wvBYSEOSGOHASn3kAG9pZ4chcWA1oZjhC2iTbubjevlSdchsJjo9YJSUrXuX
+        izX9vrj9sGr4oXZ4VK0nUgTawp0AAAA=
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 18:56:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/_delete_provider/should_delete_the_existing_email_provider_without_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/_delete_provider/should_delete_the_existing_email_provider_without_an_error.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/emails/provider
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 18:56:05 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538679367'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 18:56:05 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/_delete_provider/should_throw_an_error_trying_to_get_the_email_provider.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/_delete_provider/should_throw_an_error_trying_to_get_the_email_provider.yml
@@ -1,0 +1,51 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/emails/provider
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 18:56:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAz3MsQrCUAxG4VcJmTs4dOoqOHZyLxfv3xqwiSS5Ikjf3aLi
+        fD7OiyNLtjhaBQ/9oe8Y7uY88GhJJ2taueMVEWXZBZ+vcJAE6Z4LXUxnWZqj
+        EtYiN7q7PaTC+Tf6jlkUT4mE5vRx099tby61Ak2DAAAA
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 18:56:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/_get_provider/_filters/should_get_the_existing_email_provider_with_specific_fields.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/_get_provider/_filters/should_get_the_existing_email_provider_with_specific_fields.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/emails/provider?fields=name,enabled,credentials&include_fields=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 18:56:03 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538679365'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWykvMTVWyUspNzEspyszJUdJRSs1LTMpJTVGyKikqTdVR
+        Si5KTUnNK8lMzClWsqpWSizIjM9OrQRqgbFqawH0szXrRgAAAA==
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 18:56:03 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/_get_provider/_filters/should_get_the_existing_email_provider_without_specific_fields.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/_get_provider/_filters/should_get_the_existing_email_provider_without_specific_fields.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/emails/provider?fields=enabled&include_fields=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 18:56:04 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538679365'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA1XKTQqAIBAF4Lu8tSfwMiI6xZBOoW5CvHsqBbl6P3wVYiNB
+        I1rxiUOAgkvkSQrbkKEr7MXmoLubrzWFTKWw7BNsnHIx79PZskdieHeK/6H1
+        mKq1BxyN2SaOAAAA
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 18:56:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/_get_provider/should_get_the_existing_email_provider.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/_get_provider/should_get_the_existing_email_provider.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/emails/provider
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 18:56:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538679364'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWykvMTVWyUspNzEspyszJUdJRSs1LTMpJTVGyKikqTdVR
+        Kk4tKcnMSy9WsqpWSsssKi6Jh4oAdaHwQbQSSH1yfl4KkiJUAbCq2loA41c7
+        6nkAAAA=
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 18:56:02 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/_update_provider/should_update_the_existing_email_provider.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/_update_provider/should_update_the_existing_email_provider.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/emails/provider?fields=enabled&include_fields=false
+    body:
+      encoding: UTF-8
+      string: '{"name":"sendgrid","settings":{"first_up_setting":"first_up_setting_set","second_up_setting":"second_up_setting_set","first_setting":"first_setting_set","second_setting":"second_setting_set"},"credentials":{"api_key":"api_key"}}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '228'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 18:56:04 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538679366'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA2WMyw2EMAxEe5lzKkgzKGAvsgAvSswBofRO+Gk34uTx05vZ
+        oGFieCRW6qMQHFhDOzLBW1zYoYtMrCZhTPAbwizNwGupPCm70jYT7U/hIzFZ
+        c5OiVf9xcfjdV+lPqsFtXc1lfo39UL1XqS92ujnvzgE4bPMAAAA=
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 18:56:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/delete_existing_provider.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Emails/delete_existing_provider.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/emails/provider
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:15:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538770513'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:15:12 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/_log/should_match_the_created_log_entry.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/_log/should_match_the_created_log_entry.yml
@@ -1,0 +1,265 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/logs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 16:54:08 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538758449'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+2dC3PbRpKA/wqLW07dbZnUvB+qcmVtWY4cJ7EuktePrRQL
+        BECJEUXQACnZ8fq/Xw8AiuAL5Fi0LcedOA4xABqDmZ7pr9GDxn8+NKNgHDf3
+        m4xQ06KkReQpVfuS7xPSZoK+ad5vjt+P3BFZMOrDVhRnYdofjfvJEAofx4N4
+        HDeCxiSLU9gbDvrxcNzpR7DvfDweZft7e8FkfE5aWXTRGsfZOGvn2+0wudwD
+        iXtXbG923jC4dJeCgv4I/q9pm1HWpky1mYFCd5FOcAZHws7n4/M4bZA2/NvY
+        a1S28kqOg/4ga+5/aKbx2wlc1v28jMfniatZlNcajhsF43PYnlbEyc+K+t7T
+        B7Lb1VbFRIiAK6vDiPaYCKWC80Bk+h5Efizq9LCs0u+T7vs91uZtCsd0kwgO
+        GU4GA7i982A4jAdwSNGIK+/OXddVM2/KXHY2TqF3zkBM88/rsWumNI7gUv2g
+        uLcsTEYx/PoP3GUQ7ZeNeJYGw3FWHA2nLxUXd79UPBlFq47OJecNMztmullK
+        mm6W15tuzs7sBKNRB1o/gLODBTGL+6oyF/dVL1CzrzPuhxfxrPbFLS3d41Jb
+        LLXZgoTORfx+uaXKwvlWLQvne6AsLCQmoBChG0VViXOFU4lzhVOJc4W5xDTO
+        kkkaxh1ogau57lqxp5S9Yk95gRV78qtE8VUfSquKeHOdlfvKK63cV15r5b7i
+        niaDuHoj5ea09uXmtMrl5uzMDjRTr3+2KKFSXJVUKc5FxJcwh3RGaXLVj/LJ
+        rZSxVF4KWSov67VU3h0E4cWgn433x8lFPOvBbBzMVG4cD2EEQvOPx/1h9RaW
+        d+THD5LZ7+y8Hw+iStPMCsq6zgqmUtP+2Vmlnxe3F2eP+fnhbBKkUT8YdnpB
+        OE6qurdiz/wZ8TBNBoPL+fG4Zm95Nyv2Lg75fBroR6POTQuX546CLLtO0gh6
+        +zwOL6AFO38m3dmV1+4vRu0kGyeXnSiBLp0bo4vl02G6WF5RrHF8ORrAQdmi
+        plR3zKncbMcfHz9+dMKyEUwAcW4KQHcm2UESwRYjYmp+PuQHFvbYEuKsPCVE
+        UiU5bAkmhbJSSsKUsdQKLayQgmouiDSSGCuEdPYUlOvWMvrZr0m3P4D69WCE
+        xx/v17MHNVX2iCZL6FF28X6jxk7Ppkk44QWc4ACjdVz2ceshWFw344RBfkj1
+        +OJ2Ybvz6p14lk6SoEvE9dXg9aup+aZMO9rIbf2ngEnZQc1iPDs0mOck7+p/
+        nHHJDHUeH/5yeHoIss4TB0GuJ/vDGYI5BkpS2CEEzxUqn/QdEg2SEofWNe9e
+        1E+hcq453IVepn9NwslZL3va5cmrATkahubiLX/06uL4yUgfRc2PJSwVLTtt
+        tBnxVWAnr16lqFOqgTP13SBz5LZOHamRjAlDFBecE8thLMAuwaFUKU4oF+7w
+        epXeWsbWKs32hWkTYTfh9EE+D3xrOD1yqrUapr1Y+UMzn+dgZwo73d21bn5M
+        Su3/V1V1fYd32R5LQt3QQURHREdER0RHREdE/xKITj/Z6q21YvcLSR2YDPq9
+        fhyVWDKtYtQJxmvRhDg0GfXD8SSNK7CRtUGLrmD6TgvCyH/uMcVDEveokLGh
+        NGJKKxpq+EGtFcb0fsweAD79kD4Ynf0QPchl3eMP77En8CeMKvgJ24XIDH6l
+        k/ZoeNasUmJ+4H9rAH8IOlXTHv18thr3cwv8wZsXZhWpqcLNrDHj1n52koQw
+        SU658I+p+mzqgrXemsNRSazVhsMG/NTUQBHj8EcBsFqulGEE9q9HWy8ZnmjL
+        VRVtsyWw/Xy+WBWRH4nk+GhAiP53QH96FL151T85Cg4PXrz998uLyL66WCJj
+        B6GNk8fPGk+HAHFpfunGael97dTL86xmjVPoOVtMZ0s445/unx1j87LHefz8
+        5PQ2/ua8W7mxrebdyo0TRtXp3LIFb++YupHHtYHxpqQGv1IR8CQZo8Ro8Col
+        1FExCz4mUfWjd2sZHqOXibYUHOM8XTmvLcJ4+a4Y50EnEp1IdCLRiUQn8ss5
+        kVvEeRgTEnwyyYzSwjDDiVYEbBGXmjNmweBpyzQ3rI49fGR4sgcjfnGelXYa
+        4zy7ivMsN+/di/M4dWTEOKUEpbOEW8GpUporQSwoKRwlXexRbFDprWV4qDSR
+        bc024jTGeTDOg4iOiI6IjoiOiP63RvS7E+dxaELZnY/zrAT8LxvnWVmFXcR5
+        pl2w3lsjEvBRA4ZyI7mAP9QV8ZxVuXARHK20NFrUoK2PDE+0JQbjPBjnuVtx
+        npWj9evEeWBkEQNDi0oFvoQQlBthpKTGGArFhihpmWaqzjH1kbHt6BXwx7Zh
+        7H/3cR6prIyJ5VxEWhtruj3q5btinAedSHQi0YlEJxKdyC/nRG6O8wglLJdE
+        OHwQBIBfaEM0ML4wnCv4P5AEY2D3FFvLHn4yPNmDCK84z2o7jXGeHcV5VjTv
+        nYvz5OpIJNdSGka5JZQDElsD7GuZ0G75kyXGRR/XL3r0k+Gh0py3QQbGeTDO
+        g4iOiI6IjoiOiP5dI/odifMUaKKkuutxntWA/0XjPKurcOs4T6UL1ntrnAM+
+        Sio4gQ1AVM20AC5VUCWgU8MkA6/LGlHnrfnI8ENbxTHOg3GeuxXnWT1av0ac
+        x408xa1gmgrD3SADZ9K43dJqoig3zEhNOKvJneInw2P0UtJWrJq37Xpp8J6e
+        xw2nJo2TOEjD88YVa8RD6Na40c8aUTyC/nJz2/3GaBBDIzjntXHFG/+T5Yd3
+        imMfXPH/bYCFHYN5bTeeJGnjbNKPgmEYN2DMnSfXjXHSmIxgEEZxo5cml+4y
+        UHTF7zeyON5vzPm/uTWKkjArlaa41N4V/8dl343juOVEtIriVlGD1hVrjZPW
+        Fb/trPG5/emzeAt3ujmCi43gas19SdzR7hf86BXUePN8zJ0CW/mssT9VdDcL
+        9IfhYBLFnekJ43QCqJDlo7NirvapG+bn0Gvu+qXv2wqWvfg6/35Fc83D0Vq7
+        R4li3C0Wl0aB8rtyZjQxhHBlOBVUSyElr1m66ydji5EjTqndp3Kfi7ZU7OtG
+        SKnQbS3b1EK7Kr5DHdw6RKqUCkhoFAsCSqQQWkRRr7mjEOnS7eEDGHwAgw9g
+        8AEMPoD5uz6AuWVoExxa6hYxgkeqDAXv1jIKvq5VYJgY59yCyRcGfFym6LrQ
+        prcMT2iQ3CO0uc6+YmhzJ6HNlc17t0KbU3WUHDw8qcDHs0C1mrmsLNRIIiUz
+        sJcI7p7e1Kv01jJ8VJq3Aa2Rg0GRulGkuz0WWdmNQsZ2lhICORg5GDkYORg5
+        GDnYh4O55i7EY7VRlGhrFTXMCu1SQlnGBSCtVFbVQ4OHDE9omF8PtQ0Hr7Cv
+        yMG74+DF5r2LHOximJxII0AVCQWVtG6lKRQySrnVBPYCIuk1kRRvGT4qzdqW
+        IAcrZXsLiqSRg5GDkYORg5GDkYO/BgczS7R7yd1FhK2QyrgMxoS7b9EADRAh
+        DRzCaC0He8jwgwZjtR8Hr7SvyMG74uDl5r2LHMyMNVIxA/ootLTautxjnCuh
+        iYbjBKWKKLpuXYS3DB+VpsBo23NwYei/fRIu8WfvKDz57eC3pHtx8DY6/O3/
+        Bmn852Xv8cvhn/rp8zfPhtKLhT+sezPl9iS8i3mVaqmkEEJa50IJC3+IFIZQ
+        7T55BP6UoTWvEHrL8FFCmK24RmdMhbEFbzbgnNFIMt6LGDpj6IyhM4bOGDpj
+        6Ix9DWeMUEGEkoCXYPu5YcQoKq018D9lOVPuI4pa1TtjHjI8oYFJP2dspX1F
+        Z2xXzthy895FZ8wlNxcS3CVBuLHAr9Rl4eLSSgPKqZX7oZWp5WAPGR4qzVwq
+        jY2L1G/yDkxnj4YjvrO4UcxK3w4Zr05FUM6te9O7axV35+eJOS2dDMadSToo
+        2wCa4PI9UFx+y2EwGHTBLDar2nbzOtLqieLzOXdI1kjWSNZI1kjWfxOyrqQL
+        KG3yNnYYYApExuMfi3Me9IKhPHyvHj3+OXj+5snVT4/f0V8fnh6cBz89++s8
+        uo7+sfoN9BxQmAWQUExrTYgxXLkPnHNJqNREuYUTQhvtlhWvyTTsLcMXcua+
+        CxOO0iXI+XxcXoWjjTy6yEQPB4PGw9FoUF412xXn5x3/4gZWdq0o97dyJDwb
+        xrN7Fl+FH8TJ8F/xu+ByNIhLL6OAthcbmW0YXx8vvilf6znUXHMHHoUbKEQx
+        6T7RSIg1btwIaSS3VllqjXAvoFC57gOQ3jJ8BptuW711JrNhI++kRpGTpOi5
+        v5lXkd9gq3qD6FigY4GOBToW6FigY/G3dSxyg/e+k2vaFBufZ4fy5yN+HR6o
+        307sL69N8Kz30/XJ+zfho96L5/xdrX+hrdaAKIxYJYmL+FP4LcDAgbMgDHgH
+        lGgj6/0LDxm+yDOXj/jqu3cvqrzj4WV8mtb8rZyNr+lWwPgQzFoNheABgFdg
+        uXJZcBhjhgg4SMGYUbTu7QkfGT5jTLWVrAYqesOlIXaa7DdqGui2w29Bh8LH
+        P78Nz44Ojs0oefvm/ePea3pOnr148lRd/XV8anvz46HM/1jUvarl7o6S+p6N
+        0zRx+QOhfo1i3naZtW5Mdhw1106aSoE/xwyTkmqqKBdMKyONZYIKJrgx1r28
+        xeoiTz4yFjp066ljU89vXqp1E6L6tpZqfb7c2Kv0aHX6T99xMefl5JUrW8td
+        En1L9C3Rt0TfEn1L9C1vkeN6e+tVtT3TbljMo1xFCeaVylp3aRwCAQU0UELE
+        XHY5ifOVOL1uoLj5tFTWcE9rU1mvWzNWSWVd3usus1evu+ptslcvtnqNb6+A
+        8DQxzGqex//AQWfUcqnBmeBAn5IScCDWfaXUW4an38HIXchevYW/seDaHz9t
+        HL4bDZIUePRg+hrNZ0tbvUX9PNJWr5gAVqSq3hHRzo+rKtt+gRTWG9ttTQrr
+        dUP2Cz4ucEF5Zan79pGyxkhqtDVWuIdrTDMNrr+B/zZ5l1vL8Bm2sq3oxijk
+        zfs9Doi+Hadx3fs9Oda5vzvnp8OX9vBET168fzk4Pr/y8iXxnR504tCJQycO
+        nTh04nbzTg+TLhOuoYwrLmEb3CeXY4loQ4zgQlNOOSdK1r3T4yPDDxTgrO8W
+        FN68eDd6+UxOUqUu1JtHLxEUEBQQFBAUEBQQFL4KKIAx5loLF1Z2Lz1KCkZe
+        SLccWeff5rFUK7LuQ1jeMnxAQbSV3pi25kWuGN8cKAAfhOefjRM+NGFUdwfu
+        AZ37ihRGiJEZkBmQGZAZkBk2MANZY0JuQjaP+1le3PgdFPZm8d9VMpiMQFDs
+        Ah257V1jw+C+nGlhzrLkX0gsojmdbBKGcZbVhSwF0IBQ3AgFYMGNe3kKmEMy
+        ZRSTLh26lEKu/eCutww/UuGKfLePNEYXx78fHMlDPgjHB0/fjLxQBR9pIJ4g
+        niCeIJ4gnuzokYYAY8wk11QrTqiU7uPccAjYdWWh0EqlXFE9KGwvww8UiNgI
+        Cjcr678tUFi9sn4659ws6rn5HnYBgMvfvW7mzVj7+eolRJ1fmngVD6Zgiqvj
+        ES4QLhAuEC4QLnxWx282LJXnHCsW/5XPOfinPOcAROBKUeFysVvBiQLg4FIJ
+        owWTVnLDtTEb8GV7GR74QnVbCvpd48stqGTjkzNEFUQVRBVEFUQVRJVbo8pX
+        i9NQDYygKHXZCjRhRhHlPkjLgEEYkcwllzTScl63osRHhg+/qLZm2+fe/u75
+        ZS7wdzhEekF6QXpBekF6QXrZOb142ZoKu6xYfFCyC/0EdlHAB8Ilw1YuDy8R
+        VhfvxboMvRqQhBHhVovUZfn1keHDLrJtzPbfz5vOa41iXvt2MGbtcpPyhlrl
+        RF1+jqYb0V7IYsmh5WOpA8q9YAdXnyC3ILcgtyC3ILfsZvUJlWCmrTSMuk/m
+        MiOM1EpwQd1nyo11X8hzMRlZl1nHR4YfQpDNL9QgQiBCIEIgQiBCIEIgQnwd
+        hCBg7gnlylLKFOFawV+WUcKlhBIhpOaW2NoIiocMH4QQbabwKcQiQoR0ASEE
+        IgQiBCIEIgQiBCLE10AIwZSxnFnGwdZzSZXlRhGhrNCwA4iAUWPrP4DuI8MH
+        IXhbSI9FGN8qQqxZj7EAEF6c8GEaH4vfNafZqHv9Ile0YjKKRdTqii5tCRvF
+        rSAkvGXjqKcEdFLxWCPrnw2dtgaDMzjp6IRJF4bK1b8z6Pficd/Jh+6muJwD
+        gQSBBIEEgQSBZPvlHNWvG6zyib+c/Vos7fSStHMdd5v7Os9yEgwGyXUn6fUG
+        /WHcCYqVISW9rMcqDuhCqeZUcMIJMdx9lUsrC38z96yFKQolqharPGT4YBVr
+        Qzvhk5nF4E4vCKgVUgTdQNFYd4kXceGTGQQhBCEEIQQhBKEdPZlhyqUQgYO1
+        tsrlHBPAI0QpS7UWRFMJZULzuszsPjJ8EIK2ORf4ZOY2T2ZCpxlvJ6AV6SLi
+        hronwii0LW5I1BLAJC3Xc62QyF4AWBj1jN0acV0efnxEg2SCZIJkgmSCZPJJ
+        j2hWOsdfwZB9nmc1lHMpiNSwbTgR0rivUjJihCSUEq2MIdqK2nyxPjI8QIvY
+        tiYIWp8GWnOqSFWP6tCErUiQoCVk1G11aahbYRT0wpCQiLIuvpmMnISchJyE
+        nISc9ImctOoNEX87tIhEv69BIqOEo57PwETEAndwZbmATWW1oVxqwwBopISL
+        aimNBMqpjV/5yPBhItM2dvv4VW6ivxkQWhe0yu1oUeF7+qBQtiDuRpHu9lhk
+        ZTcKGYu9AAkjVsg7yDvIO8g7yDu7iVgRY6xb5+tePHY57yWj1jBJwOxzsPvM
+        fU+HUk3r3mj2keEJDfNJUaLJEjOUPbPfqLGvs9kNTngBJzgyaB2XXdN6CIbS
+        TRRhkB9SPb64XdjuvHonnqWTJOgScX01eP3qxuwy7Sght9GfAhRTIC2GoTPp
+        84DjXf2PlWz8N4jy+PCXw9NDkHXuHtqUKXNm7OTYJUlhhxA8V6h8rnYoM0hK
+        jFnXvHtRP4XKNcukPS/Tvybh5KyXPe3y5NWAHA1Dc/GWP3p1cfxkpI+i5scS
+        coqWnTbaDNUqjJJXr1LUKdXAWehukLmeXaeO+Qv23GoK8Kq4YJozoQUX3ApC
+        rQTMNbr2JX0fGVurtNiXoq3Zxjfsbp4NflscvPqB4BTfvHIUOhPXdCmgiuRQ
+        53H8r/hdcDkaxO1h7C5SGEEgCeejzdJj+o70OejL61Y2FlwRnywiaSNpI2kj
+        aSNp++Q8/FTbVbE8006IOsF4HUZQ7jBi1A/HkzSugEHWhh6+gqk1LWgg/7kX
+        94iUvYDEkerpLgN40zwyMaUxZaYnzY/ZA2HID+mD0dkP0YNc1j3+8B57An/C
+        qIKKsF2IzODXedweDc+aVaLLD/xvDYwPob/nbrV41Dru5/bwg7cJn1265qI3
+        Y3hGlf3sJAlhyppS2x/Tvt/U6Gt9KSEFwJ2kUsGWFtpIagjTykjlFu4RqrS0
+        llNTk2DSS4YneJK5B7DZEnZ+Pk+pCrDh45/fhmdHB8dmlLx98/5x7zU9J89e
+        PHmqrv46PrW9JW59ePy0cfhuNEhSQNGDfNeunS/P+tX4aptH/3SegoP+6f7Z
+        HczOjaoq1a50CY+fn5zexiGc9/s2ttq837dxlqh6hevb8vbOohtvxOZZXA1T
+        3LqVH0ZQcPs010yC90eskhz8v/oxu7UMnzHLwc3YuJDkewiaSGXgv1CEknIS
+        aUu9/EkMmqArh64cunLoyqErt5OgiZBcg0kCSGcGoFyBVWKSCG2N4NIoyahg
+        VGrLalZaeMnwhAYhPIMmq+wrBk12FjRZat67FzRx6iikhgIJWki0slJRyRnP
+        P3cAeuqUFE6o52APGT4qzdqW8605uLBkjZkluztwW1StVTGye1GYdl4fPn9k
+        rl6Pjw+zXw/iP79YesF1Dtmq6WCa22FwGbThWvEqXxeK2+6AOS9tHqFBBfvh
+        ZoiepKnrr9KlmZJZpXQFra7bfWMGtt9dB1GbD1xV3cpDrvvL97hKjqed8ujK
+        1WOXwRiDgUpgwBLCuTGgMtxQrhWBIU3ztBVW1y0e9JKxOP7/+H+Cfvku7UgB
+        AA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 16:54:08 GMT
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/logs/90020181005165300242546955502689194749454173405850894450
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 16:54:08 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538758450'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6VVy46bMBT9lRFSdw0xBJPArpp+QdVVqwo52BM8MdjFJqNo
+        lH/vxZhiHtNNV3DPuT734Wv7PaDEsCAPYhSddhHaIfw9SnN8yBEK4yT6EXwO
+        zF31HpooDhZlumy5Mlw2AH5lghn2RJ46zVpgS8FZYwpOgauMUTrf70lnKrTT
+        9LozTBsdWjssZb0Hxf0t3k/rGlL3oQDgCr7HKIyjOIziNIxPAPZBCnIBTyC/
+        def7Pg4PYWSzMoQLHeTvQct+dxCn/62ZqWSfCrVpgp8ipgJ7jNwL6iHBT8dn
+        fD4fs5ShJCGHNDuWNHqJkxKnsA4k2ztIPoYkvmzlcJYUXJpOCKinIk3DBLgM
+        Xdssp4/bp2l7Z7W1aWE7LiATvL6Zvi8toxCKk6E2XUrF4O8nVElo7rp2aUlj
+        9OANy1fwUP0K7hTd8rbKtjGTz2g6pdF08UZzWlkQpQroPoHVZCGz5HzNJecH
+        +AdXGF5e2ZT9UNKqxlUvVj1bKBRXdl93yoHzrjpwvgMOHBQlDETZHxtfcQaO
+        ijNwVJyBVrFlWnZtyQrowG22XRuM095gXIANxkah7MYB9Qfxb5xNzkXa5Fys
+        TW6oqRPML8SZY/bOHFN25rSygDa98MtSwYN9JQ+2EqyGO6RQrbxxam8zp7HC
+        ncgKd3mt8LMg5VVwbXIjr2zaQW3INHKGNXACof3G8MYvYU1YfyGnf11xJqjX
+        mglwuU7AqNryy8Xb56W9vD3m98OlIy3lpCleSGmkP3sbzHwFa1opRD0/jx+w
+        rpoNdnnk7TXAqSr+dtitVUTrN9lS2O2KlVfoYPEqz1PkD/nh1HbayLqgErZ0
+        dkaX+HhMl7g3WIbVSoCTXk6KT8xGbiJ+PR6PXkwruACYfQpgdjr9LClYMUrG
+        5+fdOg4PcIZQ/6xHCOEoxQewkhgnaYYxRnF6yqIsOSZZgpPoeEgQPmF0ypIE
+        I0gDhus/NR5/AKll9JlbCAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 16:54:08 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/_log/should_not_be_empty.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/_log/should_not_be_empty.yml
@@ -1,0 +1,265 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/logs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 16:54:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538758447'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+2dC3PbRpKA/wqLW07dbZnUvB+qcmVtWY4cJ7EuktePrRQL
+        BECJEUXQACnZ8fq/Xw8AiuAL5Fi0LcedOA4xABqDmZ7pr9GDxn8+NKNgHDf3
+        m4xQ06KkReQpVfuS7xPSZoK+ad5vjt+P3BFZMOrDVhRnYdofjfvJEAofx4N4
+        HDeCxiSLU9gbDvrxcNzpR7DvfDweZft7e8FkfE5aWXTRGsfZOGvn2+0wudwD
+        iXtXbG923jC4dJeCgv4I/q9pm1HWpky1mYFCd5FOcAZHws7n4/M4bZA2/NvY
+        a1S28kqOg/4ga+5/aKbx2wlc1v28jMfniatZlNcajhsF43PYnlbEyc+K+t7T
+        B7Lb1VbFRIiAK6vDiPaYCKWC80Bk+h5Efizq9LCs0u+T7vs91uZtCsd0kwgO
+        GU4GA7i982A4jAdwSNGIK+/OXddVM2/KXHY2TqF3zkBM88/rsWumNI7gUv2g
+        uLcsTEYx/PoP3GUQ7ZeNeJYGw3FWHA2nLxUXd79UPBlFq47OJecNMztmullK
+        mm6W15tuzs7sBKNRB1o/gLODBTGL+6oyF/dVL1CzrzPuhxfxrPbFLS3d41Jb
+        LLXZgoTORfx+uaXKwvlWLQvne6AsLCQmoBChG0VViXOFU4lzhVOJc4W5xDTO
+        kkkaxh1ogau57lqxp5S9Yk95gRV78qtE8VUfSquKeHOdlfvKK63cV15r5b7i
+        niaDuHoj5ea09uXmtMrl5uzMDjRTr3+2KKFSXJVUKc5FxJcwh3RGaXLVj/LJ
+        rZSxVF4KWSov67VU3h0E4cWgn433x8lFPOvBbBzMVG4cD2EEQvOPx/1h9RaW
+        d+THD5LZ7+y8Hw+iStPMCsq6zgqmUtP+2Vmlnxe3F2eP+fnhbBKkUT8YdnpB
+        OE6qurdiz/wZ8TBNBoPL+fG4Zm95Nyv2Lg75fBroR6POTQuX546CLLtO0gh6
+        +zwOL6AFO38m3dmV1+4vRu0kGyeXnSiBLp0bo4vl02G6WF5RrHF8ORrAQdmi
+        plR3zKncbMcfHz9+dMKyEUwAcW4KQHcm2UESwRYjYmp+PuQHFvbYEuKsPCVE
+        UiU5bAkmhbJSSsKUsdQKLayQgmouiDSSGCuEdPYUlOvWMvrZr0m3P4D69WCE
+        xx/v17MHNVX2iCZL6FF28X6jxk7Ppkk44QWc4ACjdVz2ceshWFw344RBfkj1
+        +OJ2Ybvz6p14lk6SoEvE9dXg9aup+aZMO9rIbf2ngEnZQc1iPDs0mOck7+p/
+        nHHJDHUeH/5yeHoIss4TB0GuJ/vDGYI5BkpS2CEEzxUqn/QdEg2SEofWNe9e
+        1E+hcq453IVepn9NwslZL3va5cmrATkahubiLX/06uL4yUgfRc2PJSwVLTtt
+        tBnxVWAnr16lqFOqgTP13SBz5LZOHamRjAlDFBecE8thLMAuwaFUKU4oF+7w
+        epXeWsbWKs32hWkTYTfh9EE+D3xrOD1yqrUapr1Y+UMzn+dgZwo73d21bn5M
+        Su3/V1V1fYd32R5LQt3QQURHREdER0RHREdE/xKITj/Z6q21YvcLSR2YDPq9
+        fhyVWDKtYtQJxmvRhDg0GfXD8SSNK7CRtUGLrmD6TgvCyH/uMcVDEveokLGh
+        NGJKKxpq+EGtFcb0fsweAD79kD4Ynf0QPchl3eMP77En8CeMKvgJ24XIDH6l
+        k/ZoeNasUmJ+4H9rAH8IOlXTHv18thr3cwv8wZsXZhWpqcLNrDHj1n52koQw
+        SU658I+p+mzqgrXemsNRSazVhsMG/NTUQBHj8EcBsFqulGEE9q9HWy8ZnmjL
+        VRVtsyWw/Xy+WBWRH4nk+GhAiP53QH96FL151T85Cg4PXrz998uLyL66WCJj
+        B6GNk8fPGk+HAHFpfunGael97dTL86xmjVPoOVtMZ0s445/unx1j87LHefz8
+        5PQ2/ua8W7mxrebdyo0TRtXp3LIFb++YupHHtYHxpqQGv1IR8CQZo8Ro8Col
+        1FExCz4mUfWjd2sZHqOXibYUHOM8XTmvLcJ4+a4Y50EnEp1IdCLRiUQn8ss5
+        kVvEeRgTEnwyyYzSwjDDiVYEbBGXmjNmweBpyzQ3rI49fGR4sgcjfnGelXYa
+        4zy7ivMsN+/di/M4dWTEOKUEpbOEW8GpUporQSwoKRwlXexRbFDprWV4qDSR
+        bc024jTGeTDOg4iOiI6IjoiOiP63RvS7E+dxaELZnY/zrAT8LxvnWVmFXcR5
+        pl2w3lsjEvBRA4ZyI7mAP9QV8ZxVuXARHK20NFrUoK2PDE+0JQbjPBjnuVtx
+        npWj9evEeWBkEQNDi0oFvoQQlBthpKTGGArFhihpmWaqzjH1kbHt6BXwx7Zh
+        7H/3cR6prIyJ5VxEWhtruj3q5btinAedSHQi0YlEJxKdyC/nRG6O8wglLJdE
+        OHwQBIBfaEM0ML4wnCv4P5AEY2D3FFvLHn4yPNmDCK84z2o7jXGeHcV5VjTv
+        nYvz5OpIJNdSGka5JZQDElsD7GuZ0G75kyXGRR/XL3r0k+Gh0py3QQbGeTDO
+        g4iOiI6IjoiOiP5dI/odifMUaKKkuutxntWA/0XjPKurcOs4T6UL1ntrnAM+
+        Sio4gQ1AVM20AC5VUCWgU8MkA6/LGlHnrfnI8ENbxTHOg3GeuxXnWT1av0ac
+        x408xa1gmgrD3SADZ9K43dJqoig3zEhNOKvJneInw2P0UtJWrJq37Xpp8J6e
+        xw2nJo2TOEjD88YVa8RD6Na40c8aUTyC/nJz2/3GaBBDIzjntXHFG/+T5Yd3
+        imMfXPH/bYCFHYN5bTeeJGnjbNKPgmEYN2DMnSfXjXHSmIxgEEZxo5cml+4y
+        UHTF7zeyON5vzPm/uTWKkjArlaa41N4V/8dl343juOVEtIriVlGD1hVrjZPW
+        Fb/trPG5/emzeAt3ujmCi43gas19SdzR7hf86BXUePN8zJ0CW/mssT9VdDcL
+        9IfhYBLFnekJ43QCqJDlo7NirvapG+bn0Gvu+qXv2wqWvfg6/35Fc83D0Vq7
+        R4li3C0Wl0aB8rtyZjQxhHBlOBVUSyElr1m66ydji5EjTqndp3Kfi7ZU7OtG
+        SKnQbS3b1EK7Kr5DHdw6RKqUCkhoFAsCSqQQWkRRr7mjEOnS7eEDGHwAgw9g
+        8AEMPoD5uz6AuWVoExxa6hYxgkeqDAXv1jIKvq5VYJgY59yCyRcGfFym6LrQ
+        prcMT2iQ3CO0uc6+YmhzJ6HNlc17t0KbU3WUHDw8qcDHs0C1mrmsLNRIIiUz
+        sJcI7p7e1Kv01jJ8VJq3Aa2Rg0GRulGkuz0WWdmNQsZ2lhICORg5GDkYORg5
+        GDnYh4O55i7EY7VRlGhrFTXMCu1SQlnGBSCtVFbVQ4OHDE9omF8PtQ0Hr7Cv
+        yMG74+DF5r2LHOximJxII0AVCQWVtG6lKRQySrnVBPYCIuk1kRRvGT4qzdqW
+        IAcrZXsLiqSRg5GDkYORg5GDkYO/BgczS7R7yd1FhK2QyrgMxoS7b9EADRAh
+        DRzCaC0He8jwgwZjtR8Hr7SvyMG74uDl5r2LHMyMNVIxA/ootLTautxjnCuh
+        iYbjBKWKKLpuXYS3DB+VpsBo23NwYei/fRIu8WfvKDz57eC3pHtx8DY6/O3/
+        Bmn852Xv8cvhn/rp8zfPhtKLhT+sezPl9iS8i3mVaqmkEEJa50IJC3+IFIZQ
+        7T55BP6UoTWvEHrL8FFCmK24RmdMhbEFbzbgnNFIMt6LGDpj6IyhM4bOGDpj
+        6Ix9DWeMUEGEkoCXYPu5YcQoKq018D9lOVPuI4pa1TtjHjI8oYFJP2dspX1F
+        Z2xXzthy895FZ8wlNxcS3CVBuLHAr9Rl4eLSSgPKqZX7oZWp5WAPGR4qzVwq
+        jY2L1G/yDkxnj4YjvrO4UcxK3w4Zr05FUM6te9O7axV35+eJOS2dDMadSToo
+        2wCa4PI9UFx+y2EwGHTBLDar2nbzOtLqieLzOXdI1kjWSNZI1kjWfxOyrqQL
+        KG3yNnYYYApExuMfi3Me9IKhPHyvHj3+OXj+5snVT4/f0V8fnh6cBz89++s8
+        uo7+sfoN9BxQmAWQUExrTYgxXLkPnHNJqNREuYUTQhvtlhWvyTTsLcMXcua+
+        CxOO0iXI+XxcXoWjjTy6yEQPB4PGw9FoUF412xXn5x3/4gZWdq0o97dyJDwb
+        xrN7Fl+FH8TJ8F/xu+ByNIhLL6OAthcbmW0YXx8vvilf6znUXHMHHoUbKEQx
+        6T7RSIg1btwIaSS3VllqjXAvoFC57gOQ3jJ8BptuW711JrNhI++kRpGTpOi5
+        v5lXkd9gq3qD6FigY4GOBToW6FigY/G3dSxyg/e+k2vaFBufZ4fy5yN+HR6o
+        307sL69N8Kz30/XJ+zfho96L5/xdrX+hrdaAKIxYJYmL+FP4LcDAgbMgDHgH
+        lGgj6/0LDxm+yDOXj/jqu3cvqrzj4WV8mtb8rZyNr+lWwPgQzFoNheABgFdg
+        uXJZcBhjhgg4SMGYUbTu7QkfGT5jTLWVrAYqesOlIXaa7DdqGui2w29Bh8LH
+        P78Nz44Ojs0oefvm/ePea3pOnr148lRd/XV8anvz46HM/1jUvarl7o6S+p6N
+        0zRx+QOhfo1i3naZtW5Mdhw1106aSoE/xwyTkmqqKBdMKyONZYIKJrgx1r28
+        xeoiTz4yFjp066ljU89vXqp1E6L6tpZqfb7c2Kv0aHX6T99xMefl5JUrW8td
+        En1L9C3Rt0TfEn1L9C1vkeN6e+tVtT3TbljMo1xFCeaVylp3aRwCAQU0UELE
+        XHY5ifOVOL1uoLj5tFTWcE9rU1mvWzNWSWVd3usus1evu+ptslcvtnqNb6+A
+        8DQxzGqex//AQWfUcqnBmeBAn5IScCDWfaXUW4an38HIXchevYW/seDaHz9t
+        HL4bDZIUePRg+hrNZ0tbvUX9PNJWr5gAVqSq3hHRzo+rKtt+gRTWG9ttTQrr
+        dUP2Cz4ucEF5Zan79pGyxkhqtDVWuIdrTDMNrr+B/zZ5l1vL8Bm2sq3oxijk
+        zfs9Doi+Hadx3fs9Oda5vzvnp8OX9vBET168fzk4Pr/y8iXxnR504tCJQycO
+        nTh04nbzTg+TLhOuoYwrLmEb3CeXY4loQ4zgQlNOOSdK1r3T4yPDDxTgrO8W
+        FN68eDd6+UxOUqUu1JtHLxEUEBQQFBAUEBQQFL4KKIAx5loLF1Z2Lz1KCkZe
+        SLccWeff5rFUK7LuQ1jeMnxAQbSV3pi25kWuGN8cKAAfhOefjRM+NGFUdwfu
+        AZ37ihRGiJEZkBmQGZAZkBk2MANZY0JuQjaP+1le3PgdFPZm8d9VMpiMQFDs
+        Ah257V1jw+C+nGlhzrLkX0gsojmdbBKGcZbVhSwF0IBQ3AgFYMGNe3kKmEMy
+        ZRSTLh26lEKu/eCutww/UuGKfLePNEYXx78fHMlDPgjHB0/fjLxQBR9pIJ4g
+        niCeIJ4gnuzokYYAY8wk11QrTqiU7uPccAjYdWWh0EqlXFE9KGwvww8UiNgI
+        Cjcr678tUFi9sn4659ws6rn5HnYBgMvfvW7mzVj7+eolRJ1fmngVD6Zgiqvj
+        ES4QLhAuEC4QLnxWx282LJXnHCsW/5XPOfinPOcAROBKUeFysVvBiQLg4FIJ
+        owWTVnLDtTEb8GV7GR74QnVbCvpd48stqGTjkzNEFUQVRBVEFUQVRJVbo8pX
+        i9NQDYygKHXZCjRhRhHlPkjLgEEYkcwllzTScl63osRHhg+/qLZm2+fe/u75
+        ZS7wdzhEekF6QXpBekF6QXrZOb142ZoKu6xYfFCyC/0EdlHAB8Ilw1YuDy8R
+        VhfvxboMvRqQhBHhVovUZfn1keHDLrJtzPbfz5vOa41iXvt2MGbtcpPyhlrl
+        RF1+jqYb0V7IYsmh5WOpA8q9YAdXnyC3ILcgtyC3ILfsZvUJlWCmrTSMuk/m
+        MiOM1EpwQd1nyo11X8hzMRlZl1nHR4YfQpDNL9QgQiBCIEIgQiBCIEIgQnwd
+        hCBg7gnlylLKFOFawV+WUcKlhBIhpOaW2NoIiocMH4QQbabwKcQiQoR0ASEE
+        IgQiBCIEIgQiBCLE10AIwZSxnFnGwdZzSZXlRhGhrNCwA4iAUWPrP4DuI8MH
+        IXhbSI9FGN8qQqxZj7EAEF6c8GEaH4vfNafZqHv9Ile0YjKKRdTqii5tCRvF
+        rSAkvGXjqKcEdFLxWCPrnw2dtgaDMzjp6IRJF4bK1b8z6Pficd/Jh+6muJwD
+        gQSBBIEEgQSBZPvlHNWvG6zyib+c/Vos7fSStHMdd5v7Os9yEgwGyXUn6fUG
+        /WHcCYqVISW9rMcqDuhCqeZUcMIJMdx9lUsrC38z96yFKQolqharPGT4YBVr
+        Qzvhk5nF4E4vCKgVUgTdQNFYd4kXceGTGQQhBCEEIQQhBKEdPZlhyqUQgYO1
+        tsrlHBPAI0QpS7UWRFMJZULzuszsPjJ8EIK2ORf4ZOY2T2ZCpxlvJ6AV6SLi
+        hronwii0LW5I1BLAJC3Xc62QyF4AWBj1jN0acV0efnxEg2SCZIJkgmSCZPJJ
+        j2hWOsdfwZB9nmc1lHMpiNSwbTgR0rivUjJihCSUEq2MIdqK2nyxPjI8QIvY
+        tiYIWp8GWnOqSFWP6tCErUiQoCVk1G11aahbYRT0wpCQiLIuvpmMnISchJyE
+        nISc9ImctOoNEX87tIhEv69BIqOEo57PwETEAndwZbmATWW1oVxqwwBopISL
+        aimNBMqpjV/5yPBhItM2dvv4VW6ivxkQWhe0yu1oUeF7+qBQtiDuRpHu9lhk
+        ZTcKGYu9AAkjVsg7yDvIO8g7yDu7iVgRY6xb5+tePHY57yWj1jBJwOxzsPvM
+        fU+HUk3r3mj2keEJDfNJUaLJEjOUPbPfqLGvs9kNTngBJzgyaB2XXdN6CIbS
+        TRRhkB9SPb64XdjuvHonnqWTJOgScX01eP3qxuwy7Sght9GfAhRTIC2GoTPp
+        84DjXf2PlWz8N4jy+PCXw9NDkHXuHtqUKXNm7OTYJUlhhxA8V6h8rnYoM0hK
+        jFnXvHtRP4XKNcukPS/Tvybh5KyXPe3y5NWAHA1Dc/GWP3p1cfxkpI+i5scS
+        coqWnTbaDNUqjJJXr1LUKdXAWehukLmeXaeO+Qv23GoK8Kq4YJozoQUX3ApC
+        rQTMNbr2JX0fGVurtNiXoq3Zxjfsbp4NflscvPqB4BTfvHIUOhPXdCmgiuRQ
+        53H8r/hdcDkaxO1h7C5SGEEgCeejzdJj+o70OejL61Y2FlwRnywiaSNpI2kj
+        aSNp++Q8/FTbVbE8006IOsF4HUZQ7jBi1A/HkzSugEHWhh6+gqk1LWgg/7kX
+        94iUvYDEkerpLgN40zwyMaUxZaYnzY/ZA2HID+mD0dkP0YNc1j3+8B57An/C
+        qIKKsF2IzODXedweDc+aVaLLD/xvDYwPob/nbrV41Dru5/bwg7cJn1265qI3
+        Y3hGlf3sJAlhyppS2x/Tvt/U6Gt9KSEFwJ2kUsGWFtpIagjTykjlFu4RqrS0
+        llNTk2DSS4YneJK5B7DZEnZ+Pk+pCrDh45/fhmdHB8dmlLx98/5x7zU9J89e
+        PHmqrv46PrW9JW59ePy0cfhuNEhSQNGDfNeunS/P+tX4aptH/3SegoP+6f7Z
+        HczOjaoq1a50CY+fn5zexiGc9/s2ttq837dxlqh6hevb8vbOohtvxOZZXA1T
+        3LqVH0ZQcPs010yC90eskhz8v/oxu7UMnzHLwc3YuJDkewiaSGXgv1CEknIS
+        aUu9/EkMmqArh64cunLoyqErt5OgiZBcg0kCSGcGoFyBVWKSCG2N4NIoyahg
+        VGrLalZaeMnwhAYhPIMmq+wrBk12FjRZat67FzRx6iikhgIJWki0slJRyRnP
+        P3cAeuqUFE6o52APGT4qzdqW8605uLBkjZkluztwW1StVTGye1GYdl4fPn9k
+        rl6Pjw+zXw/iP79YesF1Dtmq6WCa22FwGbThWvEqXxeK2+6AOS9tHqFBBfvh
+        ZoiepKnrr9KlmZJZpXQFra7bfWMGtt9dB1GbD1xV3cpDrvvL97hKjqed8ujK
+        1WOXwRiDgUpgwBLCuTGgMtxQrhWBIU3ztBVW1y0e9JKxOP7/+H+Cfvku7UgB
+        AA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 16:54:06 GMT
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/logs/90020181005165300242546955502689194749454173405850894450
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 16:54:06 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538758448'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6VVy46bMBT9lRFSdw0xBJPArpp+QdVVqwo52BM8MdjFJqNo
+        lH/vxZhiHtNNV3DPuT734Wv7PaDEsCAPYhSddhHaIfw9SnN8yBEK4yT6EXwO
+        zF31HpooDhZlumy5Mlw2AH5lghn2RJ46zVpgS8FZYwpOgauMUTrf70lnKrTT
+        9LozTBsdWjssZb0Hxf0t3k/rGlL3oQDgCr7HKIyjOIziNIxPAPZBCnIBTyC/
+        def7Pg4PYWSzMoQLHeTvQct+dxCn/62ZqWSfCrVpgp8ipgJ7jNwL6iHBT8dn
+        fD4fs5ShJCGHNDuWNHqJkxKnsA4k2ztIPoYkvmzlcJYUXJpOCKinIk3DBLgM
+        Xdssp4/bp2l7Z7W1aWE7LiATvL6Zvi8toxCKk6E2XUrF4O8nVElo7rp2aUlj
+        9OANy1fwUP0K7hTd8rbKtjGTz2g6pdF08UZzWlkQpQroPoHVZCGz5HzNJecH
+        +AdXGF5e2ZT9UNKqxlUvVj1bKBRXdl93yoHzrjpwvgMOHBQlDETZHxtfcQaO
+        ijNwVJyBVrFlWnZtyQrowG22XRuM095gXIANxkah7MYB9Qfxb5xNzkXa5Fys
+        TW6oqRPML8SZY/bOHFN25rSygDa98MtSwYN9JQ+2EqyGO6RQrbxxam8zp7HC
+        ncgKd3mt8LMg5VVwbXIjr2zaQW3INHKGNXACof3G8MYvYU1YfyGnf11xJqjX
+        mglwuU7AqNryy8Xb56W9vD3m98OlIy3lpCleSGmkP3sbzHwFa1opRD0/jx+w
+        rpoNdnnk7TXAqSr+dtitVUTrN9lS2O2KlVfoYPEqz1PkD/nh1HbayLqgErZ0
+        dkaX+HhMl7g3WIbVSoCTXk6KT8xGbiJ+PR6PXkwruACYfQpgdjr9LClYMUrG
+        5+fdOg4PcIZQ/6xHCOEoxQewkhgnaYYxRnF6yqIsOSZZgpPoeEgQPmF0ypIE
+        I0gDhus/NR5/AKll9JlbCAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 16:54:06 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/_logs/_filters/should_exclude_fields_not_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/_logs/_filters/should_exclude_fields_not_specified.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/logs?fields=date&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 16:53:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538758439'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAxXKMQ6DMBAEwL9cHdCevWv7/A6qRAghkYKeLsrfMeVI8/nZ
+        sV9f65bgbXJM0OKlK3dgTvS3vWw7jxECeI4D8qI8xCSWkIRUWniwMih6zYSa
+        0IIU7L/efXGno2YAAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 16:53:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/_logs/_filters/should_exclude_the_specified_fields.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/_logs/_filters/should_exclude_the_specified_fields.yml
@@ -1,0 +1,75 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/logs?fields=date&include_fields=false&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 16:53:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538758440'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6VWS4+bMBD+KxFSb7sECCQht2p7rSr1ulohB0/AGwe72GQV
+        RfnvHYNZzGN7qXJhvs/zzcOPyevd46LIGPUOXhoEURDuwyBIwm2yQSuOknib
+        JkkSRNt9GqbxLk7jJA53mzhI9kmwT+M4Cbwnj0n034V+FEZ+GG39aI8gBZXX
+        TGomKmR/AAcNK7JqFNQtqwnjyjvcvRr+NKC0+ZREl7h4TSRbX6O1WavWpNFl
+        8G33khyPu3QLQRyTzTbd5TQ8RXGebFHtAroUpgjahkHEOBnFvAYKlWaki6Vy
+        IQG/XjEqoYecMySzoiaVVuiFq4mGGdypzuBG0qXVrXKb+rCmN61Sb9p4vTl4
+        ZkTKDKsi6E0mMlPO1ZxyboB/cJlm+RmG7LuSZjXOejHr2UQhO8Nt3ikLjrtq
+        wfEOWLBTFFUFuTlOruII7BVHYK84AlvFGpRo6hwy7MB1tF0LjNVeYGyABaaN
+        QuHKEHUP4mecRc5GWuRsrEWuq6nh4BZizT57a/YpW3PwzLBNJ1ZMFRzYVXLg
+        VgIueKczWYsro+0ttxoz3IrMcJvXDD9ykp85U/qgxRmGHVSaDEdOQ4U3ENuv
+        NavcEuZEux5fvkGoZMCp05oBsLkOQK9as6Jw9nlqT1+P8ftQNKSmjFTZieRa
+        uGdvgRl7QFULzi/j+/gFa6tZYKdXvn0GGJXZZ4etryRKfYia4m6XkJ+xg9m7
+        OA6Rv+S7W9soLS4ZFbilozs6xftrOsWdg6XhIjkuUtOT4hKjIzcQb48nT+ka
+        v4sbzon3D23Wmll0uD+QwxFU38z3F9MsLwm+HxwZnE3W9XuBfUTkd3O8rSN/
+        44fmqAqKOlXD+cMkryQ+OGBGT0fc2zyIbtSLoIhHQWzC//cI1jeJap7qsrPP
+        Z0UuBhyANkqptVSHdTdXnxU9P2ODtPJb28/FpR+/tsyM2Dp/6RLqVeDjb7Ve
+        OZb5C6B+iiPjGO6ErxE83v4C7IFqP1sIAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 16:53:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/_logs/_filters/should_have_one_log_entry.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/_logs/_filters/should_have_one_log_entry.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/logs?per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 16:53:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538758437'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6VVTY/bIBD9K5Gl3hoHO7YT51Ztr1WlqqeuVhYxJGZDDAWc
+        VbTKf+8Y4xp/bC9VDvG8N7z5YIDn94BgQ4NDEKNov47QGqU/o+yQbg8IhXES
+        /Qo+B+YuWw+NJQOLUF0qJg0TNYBfKaeGrvCq0VQBW3JGa1MwAlxljNSHzQY3
+        pkJrTS5rQ7XRobXDUlw3oLi5xZthXY2vbSgAmIT/XRTGURxGcRbGewDbIAU+
+        gyeQ301F1QqF8FttVp5lkzSYcR0c3gNFfzcQtv28UlOJNjNiswY/iU0Fdp9I
+        q6+7fD/tntLjcZdnFCUJ3mb5riTRKU7KNIN1IKnuIPnocvriUvrRHO+bONyG
+        EfgcBQGXuuEcyqtwXVMOLl0TF6tr47Zp2lZabW0U7M4ZZILXN9O2SVECoRju
+        atOlkBS+nqFKTA6uiWeFa6M7b1g+g7vqZ3AjyZK3VbaNGXx60yn1povXm8PK
+        AktZQPcxrMYTmSnna045P8A/uMKw8kKH7LuSZjXOejHr2UShuND7vFMOHHfV
+        geMdcGCnKGAgyvYU+YojsFccgb3iCLSKimrRqJIW0IHbaLsWGKe9wLgAC4yN
+        QuiNAeoP4t84i5yLtMi5WItcV1PDqV+IM/vsndmn7MxhZQFtOrHzVMGDfSUP
+        thL0CndIIZW4MWIvN6cxw53IDHd5zfAjx+WFM20ORlzosIPa4GHkDK3hBEL7
+        jWG1X8KcsP5cDN+6YpQTrzUD4HIdgF5VsfPZ2+epPb09xvfDucGKMFwXJ1wa
+        4c/eAjNeQWslOL+Oz+MHrKtmgZ0eeXsNMCKLvx12ayXW+k0oArtd0fICHSxe
+        xXGI/CHfndpGG3EtiIAtHZ3RKd4f0ynuDZahV8nBSU8nxSdGIzcQL4/HoxXT
+        Ei4Aap8CmJ1GPwkCVoyS/vl5t47de5wj1L7yEUJplKVbsJI4TbI8TVMUZ/s8
+        ypNdkidpEu22CUr3KdrnSZK27ykM139rMP1NHBmH/E5wwunj5Q+QpqdxfQgA
+        AA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 16:53:55 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/_logs/_filters/should_include_the_specified_fields.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/_logs/_filters/should_include_the_specified_fields.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/logs?fields=date,description,type&include_fields=true&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 16:53:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538758438'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAxXMzQoCIRQF4FcZXDdxrt7rqOseoVURIelCiJLRWUT07jnL
+        j/Nz/aoUe1ZBaZCbCTPkTDaICcBRM13UQaXcHmupvbxfo3jKz9zzFKet5XWk
+        /VP3fYu1DN1LGvDA/keAkBUzxFrYehGBts6T54U9C9NiGOIEzjML1O/2B0m2
+        T7+SAAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 16:53:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/_logs/_from/should_take_one_log_entry.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/_logs/_from/should_take_one_log_entry.yml
@@ -1,0 +1,258 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/logs
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 16:54:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538758442'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+2dC3PbRpKA/wqLW07dbZnUvB+qcmVtWY4cJ7EuktePrRQL
+        BECJEUXQACnZ8fq/Xw8AiuAL5Fi0LcedOA4xABqDmZ7pr9GDxn8+NKNgHDf3
+        m4xQ06KkReQpVfuS7xPSZoK+ad5vjt+P3BFZMOrDVhRnYdofjfvJEAofx4N4
+        HDeCxiSLU9gbDvrxcNzpR7DvfDweZft7e8FkfE5aWXTRGsfZOGvn2+0wudwD
+        iXtXbG923jC4dJeCgv4I/q9pm1HWpky1mYFCd5FOcAZHws7n4/M4bZA2/NvY
+        a1S28kqOg/4ga+5/aKbx2wlc1v28jMfniatZlNcajhsF43PYnlbEyc+K+t7T
+        B7Lb1VbFRIiAK6vDiPaYCKWC80Bk+h5Efizq9LCs0u+T7vs91uZtCsd0kwgO
+        GU4GA7i982A4jAdwSNGIK+/OXddVM2/KXHY2TqF3zkBM88/rsWumNI7gUv2g
+        uLcsTEYx/PoP3GUQ7ZeNeJYGw3FWHA2nLxUXd79UPBlFq47OJecNMztmullK
+        mm6W15tuzs7sBKNRB1o/gLODBTGL+6oyF/dVL1CzrzPuhxfxrPbFLS3d41Jb
+        LLXZgoTORfx+uaXKwvlWLQvne6AsLCQmoBChG0VViXOFU4lzhVOJc4W5xDTO
+        kkkaxh1ogau57lqxp5S9Yk95gRV78qtE8VUfSquKeHOdlfvKK63cV15r5b7i
+        niaDuHoj5ea09uXmtMrl5uzMDjRTr3+2KKFSXJVUKc5FxJcwh3RGaXLVj/LJ
+        rZSxVF4KWSov67VU3h0E4cWgn433x8lFPOvBbBzMVG4cD2EEQvOPx/1h9RaW
+        d+THD5LZ7+y8Hw+iStPMCsq6zgqmUtP+2Vmlnxe3F2eP+fnhbBKkUT8YdnpB
+        OE6qurdiz/wZ8TBNBoPL+fG4Zm95Nyv2Lg75fBroR6POTQuX546CLLtO0gh6
+        +zwOL6AFO38m3dmV1+4vRu0kGyeXnSiBLp0bo4vl02G6WF5RrHF8ORrAQdmi
+        plR3zKncbMcfHz9+dMKyEUwAcW4KQHcm2UESwRYjYmp+PuQHFvbYEuKsPCVE
+        UiU5bAkmhbJSSsKUsdQKLayQgmouiDSSGCuEdPYUlOvWMvrZr0m3P4D69WCE
+        xx/v17MHNVX2iCZL6FF28X6jxk7Ppkk44QWc4ACjdVz2ceshWFw344RBfkj1
+        +OJ2Ybvz6p14lk6SoEvE9dXg9aup+aZMO9rIbf2ngEnZQc1iPDs0mOck7+p/
+        nHHJDHUeH/5yeHoIss4TB0GuJ/vDGYI5BkpS2CEEzxUqn/QdEg2SEofWNe9e
+        1E+hcq453IVepn9NwslZL3va5cmrATkahubiLX/06uL4yUgfRc2PJSwVLTtt
+        tBnxVWAnr16lqFOqgTP13SBz5LZOHamRjAlDFBecE8thLMAuwaFUKU4oF+7w
+        epXeWsbWKs32hWkTYTfh9EE+D3xrOD1yqrUapr1Y+UMzn+dgZwo73d21bn5M
+        Su3/V1V1fYd32R5LQt3QQURHREdER0RHREdE/xKITj/Z6q21YvcLSR2YDPq9
+        fhyVWDKtYtQJxmvRhDg0GfXD8SSNK7CRtUGLrmD6TgvCyH/uMcVDEveokLGh
+        NGJKKxpq+EGtFcb0fsweAD79kD4Ynf0QPchl3eMP77En8CeMKvgJ24XIDH6l
+        k/ZoeNasUmJ+4H9rAH8IOlXTHv18thr3cwv8wZsXZhWpqcLNrDHj1n52koQw
+        SU658I+p+mzqgrXemsNRSazVhsMG/NTUQBHj8EcBsFqulGEE9q9HWy8ZnmjL
+        VRVtsyWw/Xy+WBWRH4nk+GhAiP53QH96FL151T85Cg4PXrz998uLyL66WCJj
+        B6GNk8fPGk+HAHFpfunGael97dTL86xmjVPoOVtMZ0s445/unx1j87LHefz8
+        5PQ2/ua8W7mxrebdyo0TRtXp3LIFb++YupHHtYHxpqQGv1IR8CQZo8Ro8Col
+        1FExCz4mUfWjd2sZHqOXibYUHOM8XTmvLcJ4+a4Y50EnEp1IdCLRiUQn8ss5
+        kVvEeRgTEnwyyYzSwjDDiVYEbBGXmjNmweBpyzQ3rI49fGR4sgcjfnGelXYa
+        4zy7ivMsN+/di/M4dWTEOKUEpbOEW8GpUporQSwoKRwlXexRbFDprWV4qDSR
+        bc024jTGeTDOg4iOiI6IjoiOiP63RvS7E+dxaELZnY/zrAT8LxvnWVmFXcR5
+        pl2w3lsjEvBRA4ZyI7mAP9QV8ZxVuXARHK20NFrUoK2PDE+0JQbjPBjnuVtx
+        npWj9evEeWBkEQNDi0oFvoQQlBthpKTGGArFhihpmWaqzjH1kbHt6BXwx7Zh
+        7H/3cR6prIyJ5VxEWhtruj3q5btinAedSHQi0YlEJxKdyC/nRG6O8wglLJdE
+        OHwQBIBfaEM0ML4wnCv4P5AEY2D3FFvLHn4yPNmDCK84z2o7jXGeHcV5VjTv
+        nYvz5OpIJNdSGka5JZQDElsD7GuZ0G75kyXGRR/XL3r0k+Gh0py3QQbGeTDO
+        g4iOiI6IjoiOiP5dI/odifMUaKKkuutxntWA/0XjPKurcOs4T6UL1ntrnAM+
+        Sio4gQ1AVM20AC5VUCWgU8MkA6/LGlHnrfnI8ENbxTHOg3GeuxXnWT1av0ac
+        x408xa1gmgrD3SADZ9K43dJqoig3zEhNOKvJneInw2P0UtJWrJq37Xpp8J6e
+        xw2nJo2TOEjD88YVa8RD6Na40c8aUTyC/nJz2/3GaBBDIzjntXHFG/+T5Yd3
+        imMfXPH/bYCFHYN5bTeeJGnjbNKPgmEYN2DMnSfXjXHSmIxgEEZxo5cml+4y
+        UHTF7zeyON5vzPm/uTWKkjArlaa41N4V/8dl343juOVEtIriVlGD1hVrjZPW
+        Fb/trPG5/emzeAt3ujmCi43gas19SdzR7hf86BXUePN8zJ0CW/mssT9VdDcL
+        9IfhYBLFnekJ43QCqJDlo7NirvapG+bn0Gvu+qXv2wqWvfg6/35Fc83D0Vq7
+        R4li3C0Wl0aB8rtyZjQxhHBlOBVUSyElr1m66ydji5EjTqndp3Kfi7ZU7OtG
+        SKnQbS3b1EK7Kr5DHdw6RKqUCkhoFAsCSqQQWkRRr7mjEOnS7eEDGHwAgw9g
+        8AEMPoD5uz6AuWVoExxa6hYxgkeqDAXv1jIKvq5VYJgY59yCyRcGfFym6LrQ
+        prcMT2iQ3CO0uc6+YmhzJ6HNlc17t0KbU3WUHDw8qcDHs0C1mrmsLNRIIiUz
+        sJcI7p7e1Kv01jJ8VJq3Aa2Rg0GRulGkuz0WWdmNQsZ2lhICORg5GDkYORg5
+        GDnYh4O55i7EY7VRlGhrFTXMCu1SQlnGBSCtVFbVQ4OHDE9omF8PtQ0Hr7Cv
+        yMG74+DF5r2LHOximJxII0AVCQWVtG6lKRQySrnVBPYCIuk1kRRvGT4qzdqW
+        IAcrZXsLiqSRg5GDkYORg5GDkYO/BgczS7R7yd1FhK2QyrgMxoS7b9EADRAh
+        DRzCaC0He8jwgwZjtR8Hr7SvyMG74uDl5r2LHMyMNVIxA/ootLTautxjnCuh
+        iYbjBKWKKLpuXYS3DB+VpsBo23NwYei/fRIu8WfvKDz57eC3pHtx8DY6/O3/
+        Bmn852Xv8cvhn/rp8zfPhtKLhT+sezPl9iS8i3mVaqmkEEJa50IJC3+IFIZQ
+        7T55BP6UoTWvEHrL8FFCmK24RmdMhbEFbzbgnNFIMt6LGDpj6IyhM4bOGDpj
+        6Ix9DWeMUEGEkoCXYPu5YcQoKq018D9lOVPuI4pa1TtjHjI8oYFJP2dspX1F
+        Z2xXzthy895FZ8wlNxcS3CVBuLHAr9Rl4eLSSgPKqZX7oZWp5WAPGR4qzVwq
+        jY2L1G/yDkxnj4YjvrO4UcxK3w4Zr05FUM6te9O7axV35+eJOS2dDMadSToo
+        2wCa4PI9UFx+y2EwGHTBLDar2nbzOtLqieLzOXdI1kjWSNZI1kjWfxOyrqQL
+        KG3yNnYYYApExuMfi3Me9IKhPHyvHj3+OXj+5snVT4/f0V8fnh6cBz89++s8
+        uo7+sfoN9BxQmAWQUExrTYgxXLkPnHNJqNREuYUTQhvtlhWvyTTsLcMXcua+
+        CxOO0iXI+XxcXoWjjTy6yEQPB4PGw9FoUF412xXn5x3/4gZWdq0o97dyJDwb
+        xrN7Fl+FH8TJ8F/xu+ByNIhLL6OAthcbmW0YXx8vvilf6znUXHMHHoUbKEQx
+        6T7RSIg1btwIaSS3VllqjXAvoFC57gOQ3jJ8BptuW711JrNhI++kRpGTpOi5
+        v5lXkd9gq3qD6FigY4GOBToW6FigY/G3dSxyg/e+k2vaFBufZ4fy5yN+HR6o
+        307sL69N8Kz30/XJ+zfho96L5/xdrX+hrdaAKIxYJYmL+FP4LcDAgbMgDHgH
+        lGgj6/0LDxm+yDOXj/jqu3cvqrzj4WV8mtb8rZyNr+lWwPgQzFoNheABgFdg
+        uXJZcBhjhgg4SMGYUbTu7QkfGT5jTLWVrAYqesOlIXaa7DdqGui2w29Bh8LH
+        P78Nz44Ojs0oefvm/ePea3pOnr148lRd/XV8anvz46HM/1jUvarl7o6S+p6N
+        0zRx+QOhfo1i3naZtW5Mdhw1106aSoE/xwyTkmqqKBdMKyONZYIKJrgx1r28
+        xeoiTz4yFjp066ljU89vXqp1E6L6tpZqfb7c2Kv0aHX6T99xMefl5JUrW8td
+        En1L9C3Rt0TfEn1L9C1vkeN6e+tVtT3TbljMo1xFCeaVylp3aRwCAQU0UELE
+        XHY5ifOVOL1uoLj5tFTWcE9rU1mvWzNWSWVd3usus1evu+ptslcvtnqNb6+A
+        8DQxzGqex//AQWfUcqnBmeBAn5IScCDWfaXUW4an38HIXchevYW/seDaHz9t
+        HL4bDZIUePRg+hrNZ0tbvUX9PNJWr5gAVqSq3hHRzo+rKtt+gRTWG9ttTQrr
+        dUP2Cz4ucEF5Zan79pGyxkhqtDVWuIdrTDMNrr+B/zZ5l1vL8Bm2sq3oxijk
+        zfs9Doi+Hadx3fs9Oda5vzvnp8OX9vBET168fzk4Pr/y8iXxnR504tCJQycO
+        nTh04nbzTg+TLhOuoYwrLmEb3CeXY4loQ4zgQlNOOSdK1r3T4yPDDxTgrO8W
+        FN68eDd6+UxOUqUu1JtHLxEUEBQQFBAUEBQQFL4KKIAx5loLF1Z2Lz1KCkZe
+        SLccWeff5rFUK7LuQ1jeMnxAQbSV3pi25kWuGN8cKAAfhOefjRM+NGFUdwfu
+        AZ37ihRGiJEZkBmQGZAZkBk2MANZY0JuQjaP+1le3PgdFPZm8d9VMpiMQFDs
+        Ah257V1jw+C+nGlhzrLkX0gsojmdbBKGcZbVhSwF0IBQ3AgFYMGNe3kKmEMy
+        ZRSTLh26lEKu/eCutww/UuGKfLePNEYXx78fHMlDPgjHB0/fjLxQBR9pIJ4g
+        niCeIJ4gnuzokYYAY8wk11QrTqiU7uPccAjYdWWh0EqlXFE9KGwvww8UiNgI
+        Cjcr678tUFi9sn4659ws6rn5HnYBgMvfvW7mzVj7+eolRJ1fmngVD6Zgiqvj
+        ES4QLhAuEC4QLnxWx282LJXnHCsW/5XPOfinPOcAROBKUeFysVvBiQLg4FIJ
+        owWTVnLDtTEb8GV7GR74QnVbCvpd48stqGTjkzNEFUQVRBVEFUQVRJVbo8pX
+        i9NQDYygKHXZCjRhRhHlPkjLgEEYkcwllzTScl63osRHhg+/qLZm2+fe/u75
+        ZS7wdzhEekF6QXpBekF6QXrZOb142ZoKu6xYfFCyC/0EdlHAB8Ilw1YuDy8R
+        VhfvxboMvRqQhBHhVovUZfn1keHDLrJtzPbfz5vOa41iXvt2MGbtcpPyhlrl
+        RF1+jqYb0V7IYsmh5WOpA8q9YAdXnyC3ILcgtyC3ILfsZvUJlWCmrTSMuk/m
+        MiOM1EpwQd1nyo11X8hzMRlZl1nHR4YfQpDNL9QgQiBCIEIgQiBCIEIgQnwd
+        hCBg7gnlylLKFOFawV+WUcKlhBIhpOaW2NoIiocMH4QQbabwKcQiQoR0ASEE
+        IgQiBCIEIgQiBCLE10AIwZSxnFnGwdZzSZXlRhGhrNCwA4iAUWPrP4DuI8MH
+        IXhbSI9FGN8qQqxZj7EAEF6c8GEaH4vfNafZqHv9Ile0YjKKRdTqii5tCRvF
+        rSAkvGXjqKcEdFLxWCPrnw2dtgaDMzjp6IRJF4bK1b8z6Pficd/Jh+6muJwD
+        gQSBBIEEgQSBZPvlHNWvG6zyib+c/Vos7fSStHMdd5v7Os9yEgwGyXUn6fUG
+        /WHcCYqVISW9rMcqDuhCqeZUcMIJMdx9lUsrC38z96yFKQolqharPGT4YBVr
+        Qzvhk5nF4E4vCKgVUgTdQNFYd4kXceGTGQQhBCEEIQQhBKEdPZlhyqUQgYO1
+        tsrlHBPAI0QpS7UWRFMJZULzuszsPjJ8EIK2ORf4ZOY2T2ZCpxlvJ6AV6SLi
+        hronwii0LW5I1BLAJC3Xc62QyF4AWBj1jN0acV0efnxEg2SCZIJkgmSCZPJJ
+        j2hWOsdfwZB9nmc1lHMpiNSwbTgR0rivUjJihCSUEq2MIdqK2nyxPjI8QIvY
+        tiYIWp8GWnOqSFWP6tCErUiQoCVk1G11aahbYRT0wpCQiLIuvpmMnISchJyE
+        nISc9ImctOoNEX87tIhEv69BIqOEo57PwETEAndwZbmATWW1oVxqwwBopISL
+        aimNBMqpjV/5yPBhItM2dvv4VW6ivxkQWhe0yu1oUeF7+qBQtiDuRpHu9lhk
+        ZTcKGYu9AAkjVsg7yDvIO8g7yDu7iVgRY6xb5+tePHY57yWj1jBJwOxzsPvM
+        fU+HUk3r3mj2keEJDfNJUaLJEjOUPbPfqLGvs9kNTngBJzgyaB2XXdN6CIbS
+        TRRhkB9SPb64XdjuvHonnqWTJOgScX01eP3qxuwy7Sght9GfAhRTIC2GoTPp
+        84DjXf2PlWz8N4jy+PCXw9NDkHXuHtqUKXNm7OTYJUlhhxA8V6h8rnYoM0hK
+        jFnXvHtRP4XKNcukPS/Tvybh5KyXPe3y5NWAHA1Dc/GWP3p1cfxkpI+i5scS
+        coqWnTbaDNUqjJJXr1LUKdXAWehukLmeXaeO+Qv23GoK8Kq4YJozoQUX3ApC
+        rQTMNbr2JX0fGVurtNiXoq3Zxjfsbp4NflscvPqB4BTfvHIUOhPXdCmgiuRQ
+        53H8r/hdcDkaxO1h7C5SGEEgCeejzdJj+o70OejL61Y2FlwRnywiaSNpI2kj
+        aSNp++Q8/FTbVbE8006IOsF4HUZQ7jBi1A/HkzSugEHWhh6+gqk1LWgg/7kX
+        94iUvYDEkerpLgN40zwyMaUxZaYnzY/ZA2HID+mD0dkP0YNc1j3+8B57An/C
+        qIKKsF2IzODXedweDc+aVaLLD/xvDYwPob/nbrV41Dru5/bwg7cJn1265qI3
+        Y3hGlf3sJAlhyppS2x/Tvt/U6Gt9KSEFwJ2kUsGWFtpIagjTykjlFu4RqrS0
+        llNTk2DSS4YneJK5B7DZEnZ+Pk+pCrDh45/fhmdHB8dmlLx98/5x7zU9J89e
+        PHmqrv46PrW9JW59ePy0cfhuNEhSQNGDfNeunS/P+tX4aptH/3SegoP+6f7Z
+        HczOjaoq1a50CY+fn5zexiGc9/s2ttq837dxlqh6hevb8vbOohtvxOZZXA1T
+        3LqVH0ZQcPs010yC90eskhz8v/oxu7UMnzHLwc3YuJDkewiaSGXgv1CEknIS
+        aUu9/EkMmqArh64cunLoyqErt5OgiZBcg0kCSGcGoFyBVWKSCG2N4NIoyahg
+        VGrLalZaeMnwhAYhPIMmq+wrBk12FjRZat67FzRx6iikhgIJWki0slJRyRnP
+        P3cAeuqUFE6o52APGT4qzdqW8605uLBkjZkluztwW1StVTGye1GYdl4fPn9k
+        rl6Pjw+zXw/iP79YesF1Dtmq6WCa22FwGbThWvEqXxeK2+6AOS9tHqFBBfvh
+        ZoiepKnrr9KlmZJZpXQFra7bfWMGtt9dB1GbD1xV3cpDrvvL97hKjqed8ujK
+        1WOXwRiDgUpgwBLCuTGgMtxQrhWBIU3ztBVW1y0e9JKxOP7/+H+Cfvku7UgB
+        AA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 16:54:02 GMT
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/logs?from=90020181004191452933722053200338816338137607011615899762&take=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 16:54:04 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538758444'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6VSwW7bMAz9lUDnOJYsybJ967AMHbZhPXRotqIIZElNhDiW
+        K8lrsyL/XsptgFx2KArDMMjH90g+8/YZaRkNalCBSZURnGF2TeqGsIbThWDs
+        D5qjeBhSRdAjBNoE5e0QreshNwbj11Y3M962ZVlKXlbwKqY4oViLmgBDub43
+        6o3wCwi93JvsSobw6LzOLsa4NX20Sk4l5/WgDBSI16sn9s2PTraYPf7tfq+g
+        zA6AkUIsMDypzzSL3IAWAD9B1M8ShGf57CyaVojSdgE1z6h1+pC+0fRy4kmY
+        BmdB77JoQgzvHv84Rw+j8ZPo3sStSxt8Xn5fXi9Ba+tCatK5je0XU6uFcnsA
+        BucBYIzOkTfBjV4lx/PO5WmrkP/P3lxbD8MlO1KjG/9vVOPmPnxtqVt1+LJX
+        1e6Bflrtrr4M4lKj43F++mdQfjItbfQahujhHDaHkxNnqfXbGcC9yFYGA9Cr
+        So1xOh6CMSM1YZwKxgUkOMcMi7LmJeG0oKIomCgrUgmWCJSBABjxYQ0bfrjW
+        djDaveyCOd69AC9TPI3UAgAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 16:54:04 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/create_test_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/create_test_user.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users
+    body:
+      encoding: UTF-8
+      string: '{"email":"rubytest-rubytest-username@auth0.com","password":"PlRp3bJ6Dx27","connection":"Username-Password-Authentication","name":"rubytest-username"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '149'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 22:01:38 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538776900'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA41Ry27DIBD8F6TkFNuA7Rhbstpceq7U9tKqijCsHdQEW4BT
+        VWn+veA8lFNUicMAszOzuwcEO662qEJmbH4cWBddwWjBaL6DRz66DY5Fv0ML
+        FB5u2ReS/5qU1nswqlUgUdXyrYUFGgfJHcg1d76OYsIigiOcv1JaYVKlLGY5
+        efflgxJuNEF849xgqySxcWf4njtugnlyggldpgJDS7IcGCGSLoslEYUHpCwz
+        xtoHW2cMz009dHNZT1qzdDWjT/4IqeNrN/5+krQemTEedOdjhIbWysdHE/E3
+        b5pCthnNAZdpmsmiYCUnIguzUOLrzjyUBO2UU2BR9XFAotcahFO99vy3My16
+        5tZ+90ZGK+8W+IJPlNsgdyIMpt97H3OJG2ztSy8U354XcPxcIGHgHys4/gFT
+        5h4bDQIAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 22:01:38 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/delete_test_disabled_rule.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/delete_test_disabled_rule.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules/rul_VEsZIAicOPoU52nz
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 22:01:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538776901'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 22:01:39 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/delete_test_enabled_rule.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/delete_test_enabled_rule.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules/rul_VEsZIAicOPoU52nz
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 22:01:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538776901'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 22:01:39 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/delete_test_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Logs/delete_test_user.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C5bb7df425e09334d7789a1c4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 22:01:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538776901'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 22:01:39 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/_delete_resource_server/should_delete_the_test_server_without_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/_delete_resource_server/should_delete_the_test_server_without_an_error.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers/5bb7c2988dfaba46c47a9918
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 19:59:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538769564'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 19:59:22 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/_resource_server/should_get_the_test_server.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/_resource_server/should_get_the_test_server.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers/5bb7c2988dfaba46c47a9918
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 19:59:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538769563'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA12Py07DMBBF/8VrIA+S5rGrEELdoIpWAlaW7YyTIa4d2UOr
+        gvh3pmwqsZyZc0fnfgscRC9qrRtTdm07WKVVtTJVo7quaMWN8OoATOwh0Q7i
+        EeJt/NRn4pGPOIAntAiRkYloSX2WuWCUm0KiuwuVqQWzY5ExnXD06EeZwEQg
+        Tnxsh2LI9696bJbnDrfmbaB3etxsntZz/TUdHpBTyrlwksFahx6kMgZSEr1V
+        LgG/nHGRJvjEHtKGKFmQfZR2IC3GRHJRkc7SOGTimqMwg5cOLRBe+hXlfVWv
+        /u//Pp5Ai74p8/xaQLmR7V92Zb0SP7/OQVooQwEAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 19:59:22 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/create_test_server.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/create_test_server.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers
+    body:
+      encoding: UTF-8
+      string: '{"name":"TestServer-rubytest","signing_alg":"RS256","signing_secret":"jPd1d0TWbg7pN9iPcXdtYtEIIGAk5zhmCi","token_lifetime":123456,"identifier":"https://localhost.test/api/v1/"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '176'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 19:59:20 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538769562'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA12Py07DMBBF/8VrIA+S5rGrEELdoIpWAlaW7YyTIa4d2UOr
+        gvh3pmwqsZyZc0fnfgscRC9qrRtTdm07WKVVtTJVo7quaMWN8OoATOwh0Q7i
+        EeJt/NRn4pGPOIAntAiRkYloSX2WuWCUm0KiuwuVqQWzY5ExnXD06EeZwEQg
+        Tnxsh2LI9696bJbnDrfmbaB3etxsntZz/TUdHpBTyrlwksFahx6kMgZSEr1V
+        LgG/nHGRJvjEHtKGKFmQfZR2IC3GRHJRkc7SOGTimqMwg5cOLRBe+hXlfVWv
+        /u//Pp5Ai74p8/xaQLmR7V92Zb0SP7/OQVooQwEAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 19:59:20 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/delete_test_server.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/delete_test_server.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers/5bb7c2988dfaba46c47a9918
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 19:59:23 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538769565'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 19:59:23 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_delete_rule/should_delete_the_test_disabled_rule_without_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_delete_rule/should_delete_the_test_disabled_rule_without_an_error.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules/rul_VEsZIAicOPoU52nz
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:29:00 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538760541'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:29:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_delete_rule/should_delete_the_test_enabled_rule_without_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_delete_rule/should_delete_the_test_enabled_rule_without_an_error.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules/rul_IJ6YEV0I9J0hYPv3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:59 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538760541'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:59 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rule/_filters/should_exclude_the_fields_not_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rule/_filters/should_exclude_the_fields_not_specified.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules/rul_IJ6YEV0I9J0hYPv3?fields=stage&include_fields=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1538760540'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWykxRslIqKs2J9/Qyi3QNM/C09DLIiAwoM1bSUUrNS0zK
+        SQUqKCkqTdVRKk4uyiwoASpPK81LLsnMz1PQKC1OLdJRSM7PK0mtKAEykjQV
+        qoGkRl5pTo6OAoqspnUt0Mi8xNxUsIVJlSWpxSUKugqufo5OPq4uQLn8opTU
+        IiUrk1oAz3RS75YAAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rule/_filters/should_exclude_the_specified_fields.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rule/_filters/should_exclude_the_specified_fields.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules/rul_IJ6YEV0I9J0hYPv3?fields=stage&include_fields=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1538760539'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWykxRslIqKs2J9/Qyi3QNM/C09DLIiAwoM1bSUUrNS0zK
+        SQUqKCkqTdVRKk4uyiwoASpPK81LLsnMz1PQKC1OLdJRSM7PK0mtKAEykjQV
+        qoGkRl5pTo6OAoqspnUt0Mi8xNxUsIVJlSWpxSUKugqufo5OPq4uQLn8opTU
+        IiUrk1oAz3RS75YAAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rule/_filters/should_include_the_specified_fields.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rule/_filters/should_include_the_specified_fields.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules/rul_IJ6YEV0I9J0hYPv3?fields=stage,order,script
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:57 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538760539'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA1WMMQrAIAwAvyKZFBw7tY8pbZqKIEkxEQri3+va5Tg4uA6K
+        NT8GK9yN0bKw802pRofCRq9NOYPrk55bKdH9atgGRJB6UYV1iaB2JJqzIinz
+        rg2RVGF8EAMyk2cAAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:57 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rule/should_get_a_specific_rule.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rule/should_get_a_specific_rule.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules/rul_IJ6YEV0I9J0hYPv3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538760538'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA1WNwQrCMBBEfyXsqYUIBUWwnhRzaBHxJPRU2nStgZhIshGl
+        9N9dvXkZBuYxbwIzQAkh2baq1426FNWmLm7N+bkECei63iIDFBJKiDqYBzF+
+        TU6T8U5kKWKQQntH+CIufS4mzswla6X4W/PtzJeuu+NP2L8JI4mFUKfd/qgO
+        vPkwYIByxSbqxi9m/WhcG5PWGCPMH2y13sCuAAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:56 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rules/_filters/should_exclude_fields_not_specified.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rules/_filters/should_exclude_fields_not_specified.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules?fields=script
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538760536'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4uuVipOLsosKFGyUkorzUsuyczP0yhJLS7RVKrVwSKnoFFa
+        nFqko5Ccn1eSWlECZCRpKlQDSY280pwcHQUUWU3rWmqZEgsAKaUH46kAAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:54 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rules/_filters/should_include_the_specified_fields.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rules/_filters/should_include_the_specified_fields.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules?fields=script,order
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:54 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538760535'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4uuVipOLsosKFGyUkorzUsuyczP0yhJLS7RVNJRyi9KSS1S
+        sjKu1cGiSkGjtDi1SEchOT+vJLWiBMhI0lSoBpIaeaU5OToKKLKa1rUI80yo
+        bJ5pbSwAPskeyccAAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:54 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rules/_filters/should_return_at_least_1_disabled_rule.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rules/_filters/should_return_at_least_1_disabled_rule.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules?enabled=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:53 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538760534'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA42OwQrCMBBEfyXk1EIEqRZBT2o9iEIF0YMiJY1bCcSkZBNQ
+        S//deJDqQfCyDDOzzDs2VJ7pmFqviuGqdklSZWk+Kuf9+4gyCpqXCkKh4gqB
+        URRW1i70K6+Fk0ZHDtDFoan5FYIP3Pry/jKDZ+wZLB0Pwp/jl1eszEXqAr0Q
+        gEhb9rG+X+BhOZUi35hdmujHP+sk8giWEWG0g5sLooxJE26kvVKMfKXxpO04
+        35SkR7LldjpbL7IOOP0JfHoCwcBxVzABAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:53 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rules/_filters/should_return_at_least_1_enabled_rule.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rules/_filters/should_return_at_least_1_enabled_rule.yml
@@ -1,0 +1,62 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules?enabled=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538760534'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA1WNwQrCMBBEfyXsqYUIBUWwnhR7aBHxJBSR0qZrDcREko0o
+        pf/u6s3LMDCPeecRdA85+GiaslrWxSkrV1V2q4/POUhA23YGGSAfUUJQXj+I
+        8Wu0irSzIokBvRTKWcIXcelSMXImNhojxd+arie+tO0df8LuTRhIzERx2Gz3
+        xY4353v0kC/YRO3wxYwbtG1CVApDgOnyATPrqYSwAAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:52 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rules/_filters/should_return_paginated_results.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rules/_filters/should_return_paginated_results.yml
@@ -1,0 +1,128 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules?fields=name&page=0&per_page=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:55 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Link:
+      - <http://auth0-sdk-tests.auth0.com/api/v2/rules?fields=name&page=0&per_page=2>;
+        rel="first", <http://auth0-sdk-tests.auth0.com/api/v2/rules?fields=name&page=1&per_page=2>;
+        rel="next", <http://auth0-sdk-tests.auth0.com/api/v2/rules?fields=name&page=1&per_page=2>;
+        rel="last"
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538760537'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4uuVspLzE1VslJKTSwqTaosSS0uUarVgYvCxBR0FVz9HJ18
+        XF2UamMBQcVG7jUAAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:55 GMT
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules?fields=name&page=1&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:56 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Link:
+      - <http://auth0-sdk-tests.auth0.com/api/v2/rules?fields=name&page=0&per_page=1>;
+        rel="first", <http://auth0-sdk-tests.auth0.com/api/v2/rules?fields=name&page=0&per_page=1>;
+        rel="prev", <http://auth0-sdk-tests.auth0.com/api/v2/rules?fields=name&page=2&per_page=1>;
+        rel="next", <http://auth0-sdk-tests.auth0.com/api/v2/rules?fields=name&page=2&per_page=1>;
+        rel="last"
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538760537'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4uuVspLzE1VslIqKk2qLEktLlHQVXD1c3TycXVRqo0FAOEA
+        ldYfAAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:56 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rules/should_return_at_least_1_rule.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_rules/should_return_at_least_1_rule.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:52 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538760533'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA62QQWsCMRCF/0rIaRciLKurVE/W3cOqVKFUsFIkG2c1EBNJ
+        JlIr/vfGQ9GKBQ+9DMN7b3gfszhSuaJdar1atkY7TNM6zyadapAcOpRR0LxS
+        EAI1Vw4YdcLKHYZ87bVAaXSE4DAOSc23EHTg1leHsxg0Y1dgabcZ7pCvz7Yy
+        a6mXzgsBztETu2ovh+15MUvKp2GymU/3zet2tP5eOYm8A8uIMBrhE8NSxeQY
+        ZqS9Uoz8cuPe6YL5A0kapHjpP4+L/ILbegh3Vrj3si/FZGreslR/PfKsf+HN
+        y9cb4OxP4I9vGxU/Bt8BAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:52 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_update_rule/should_update_the_disabled_rule_to_be_enabled.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_update_rule/should_update_the_disabled_rule_to_be_enabled.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules/rul_VEsZIAicOPoU52nz?fields=stage&include_fields=false
+    body:
+      encoding: UTF-8
+      string: '{"enabled":true}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '16'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1538760540'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA1WNMQvCMBCF/0q4qYW4CF3qVGmHgqAgOriUNj1LIL1IcgG1
+        9L97urk8HryP9y1gRyghJNddm3hrK2uOJ38ptvQGDUj94FAADgk1RBPsgwW/
+        JzJsPaksRQxaGU+MT5Yy5GqRzCg5p9Xfmu9WuaR+xp9weDFGVhtVt+dqf2hq
+        GX0YMUBZiIr76cs5P1nqYjIGY4T1A/r3+UOvAAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:58 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/create_test_disabled_rule.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/create_test_disabled_rule.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules
+    body:
+      encoding: UTF-8
+      string: '{"name":"rubytest - DISABLED","enabled":false,"script":"function (user,
+        context, cb) { cb(null, user, context);}","stage":"login_success"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '138'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:50 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538760531'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA1WNsQrCMBRFfyW8qYW4CF3qVGmHgqAgOriUJH0tgfgieQmo
+        pf9udHO5XLiHexawI9QQkhuuHd/6xprjyV+qLb1BApLSDjMwKccogU2wj5j5
+        KZGJ1pMoEmOQwniK+Iy56FIsOQtKzknxt5a7NX+SuuPPqF8ROYqNaPtzsz90
+        bR59GDFAXWVVVPOXc362NHAyBplh/QCFzEMxsAAAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:50 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/create_test_enabled_rule.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/create_test_enabled_rule.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules
+    body:
+      encoding: UTF-8
+      string: '{"name":"rubytest - ENABLED","enabled":true,"script":"function (user,
+        context, cb) { cb(null, user, context);}","stage":"login_success"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '136'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 17:28:49 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538760531'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA1WNwQrCMBBEfyXsqYUIBUWwnhRzaBHxJPRU2nStgZhIshGl
+        9N9dvXkZBuYxbwIzQAkh2baq1426FNWmLm7N+bkECei63iIDFBJKiDqYBzF+
+        TU6T8U5kKWKQQntH+CIufS4mzswla6X4W/PtzJeuu+NP2L8JI4mFUKfd/qgO
+        vPkwYIByxSbqxi9m/WhcG5PWGCPMH2y13sCuAAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 17:28:49 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Stats/_active_users/should_have_at_least_one_active_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Stats/_active_users/should_have_at_least_one_active_user.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/stats/active-users
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:04:01 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538769843'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAzMAACHf2/QBAAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:04:01 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Stats/_daily_stats/should_have_at_least_one_stats_entry_for_the_timeframe.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Stats/_daily_stats/should_have_at_least_one_stats_entry_for_the_timeframe.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/stats/daily?from=20170101&to=20180101
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:04:02 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538769844'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA43UTQrCMBAF4Ltk3cqbyX/P4UoRKbSUorTFVFyId7e6FeFB
+        FoEMH0PmJcen6dq1N41RSKxFa/g90HzXDsDBVOY6D+NUTIPKlHGY7su292q3
+        g7699N15aUt5zLfuU/KqfsXAidbRYqTEkEGLiesx0z2KcKJkWlRKjIkGLQUq
+        PC06SpQUaJGLo0v8NXKjFlg64ZI50oEmFRzpAz1u5RIp4BOkXCQzD3J/hcY/
+        L/v0Bl06MQnRBAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:04:02 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tenants/_get_tenant_settings/should_get_the_tenant_settings.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tenants/_get_tenant_settings/should_get_the_tenant_settings.yml
@@ -1,0 +1,95 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/tenants/settings?include_fields=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:12:41 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538770363'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA51XjW7bNhB+FVZd12SwJCdtsVZJigZu0BboT4Cm2Lp5M2jp
+        LLGhSI2k4mie3313lGXLdtoVC5BEOvK+u/vueDougrTgKodJxa2da5MFySIA
+        xacS8NGZGgZB4UoZJMHpvZcfRlefLy8YCZ6P1en6P/AM/zN2WoLjDBGNBXc2
+        Dmo3C5+Og95a4VwVwl+1uMHlX8NP5+FIlxV3Ag2OA5Zq5UCR6puLM8hyGKSF
+        0SWcHXUoTjgJz0feadbo2rDO89O4XdsYUxw1x8GNgHmljdvCn4vMFWcZ3IgU
+        Qv8yYEIJJ7gMbcolmoyGA1byW1HWZV9UWzD+nUg6UxphYzTqzVrXSGCuqciu
+        g1sXp9auXGdsqrNmQKQtKp5lQuXJ8KTkJhcqGS4jR3iLTNhK8ibxbyeVtuiS
+        VgmfWi1rBycFiLxwydFw+ODEu90+Tnl6nRtdqyyRQgE3YW54JjDWA5NP+cHx
+        kyeD7jd6dDjYEw4PD3sgYaqlNsl9eApTmC2jFKTcdi0k0ckNGCeQipBLkauk
+        FFkmAbe3NK/DPH5S3bIu1lDCzCW8droTGB+Sl7QhHT8dVrdLz2jsKfX8YqXF
+        q1I7JSrbTGfihqUSa4AY576MVnRvLZG765Xdtdbd3jJuuBeG7Jc3L19dXLEw
+        7C+QpshIzRdh2NUfVVEOLiQ0jjkwiHca4+5d1Iv3L+9A7m/dPHdPbXWlRlSO
+        WZOidTpJNonjNFMRUlcMkfUy/mLjXbeOoqOoFCr6Yr1DLcg25Mqsgjk7J6j2
+        eF2uEA4WnY/r0JIuIPY9NAz8zjhmhk6+gazDg5ILucFq8RYLL14uO8Wv/CDe
+        yw/s/YcrNnp9/v7VBbt6/ebj2lNrZhOnr0Gt4R8uFhvpcvnwa+DfxMVqvwa3
+        5TLittJvYP4nbsfepNJSpE3S4u5I7zbwbX8LKCFhi00JCkxM4mnGmufKRZVI
+        XW1gUhvJ/mEZzHgtMcKHu6XlD2Jeiwxi7IPRMBZlHk85JjuqVP7Q52tjpjIC
+        T3cz8n0Ezd0H/uTR8aNx0G1Zrjdn6MCWixhRF/ml5CkUWmbgUXzDpzLt1rds
+        9vRGWs2EKTk1zx2MtF1i/wvrHXdpcWFMG9SlBG6BgbJIIHG91mFcZV6Q9pQZ
+        X+2y+GGKvmbuozOgcuyCO5Ssj589d2/RriMPRq2IccfIF8ceZEzPvJGZllLP
+        sf2SjD5Jllbo48xTB8Ymuw5gbWTYBqmfj+gTTvjvNSu195orwlnv6AExss+M
+        nrMDiPJowMbjcfDA0l+mtGOc/IDscN+e0uqirFzTWlIh0MuGw3W72Fesyyms
+        PGwf2YGIIGLD8NkddqQntEfbeY+u7UDarXdAYAhmhNkm9bf0wlLKvQTnVQ94
+        +Pcdlm2ha5mtskSqH72gS+UdObAVpKLNwCpPpNUK+756rtm9F/d/ePDnjz/d
+        Ybquqo3Hn+hlx+Pz8LfDzXn0WsttEFunKVj7Dn957nE+9ycuVnDLpgAKM4UD
+        X7d9VkvZ7JW3Pwh5bfxJWJ+gc8WAnplOa4OpjthVAVhvHP3FEmROowGsrlLY
+        LQBKVVvkptwzpcChe9drI1d05MDceAYUlSRiGuBpAdmAYNCgsGilMhoHiJLN
+        hSs8/Appz4ITJejafaeFqm0TzjSM55j1PbhWtY+GHs2RXN7Rg54RtXSat9qM
+        J34Pj6YkMFc4fxLcBU43BqPr9zoi7nRqcHJdfW33I8RZ2neYdtS+/EqTnAO/
+        7tY2fbGzIiiD2m+Kdkqt8+S1sE6bZl+XiqsyOKDr2sqmrTOcvbMe0LJ9WB6e
+        rGbFbpo5jVcDIk6M7SUlWA4CTyXedHKgW87qWhMMAjyk84nU+QRH5+sgmXFp
+        8dqD30Nc7sassknpoqKaSJs89kgEOZM8t4SGwzENnxNR4kGzWvkq7W5Q7YVq
+        gp9PnjYTzOVMSNhZxMGXBpMJr8Rxt+Q7Z6fml4Wa6QmorNJCuR0Ea/Xa+VbT
+        j2ZYM5P+DtIhzw3eDjLZTOiWhIH6wQ/J6I0DvfC3R4E5TPFeAjGmCpyNiVH8
+        i7Vo/VCAD9gmsF5jrxLmsqmK8Gj4LHuc/vwofRzZm5xoxw6F17KJL0C0tXp/
+        0dpBmnt7tr1ZSTce0U784k717QQPkvXUB4/3pXbCb9AYkREkvwdPccfj4I/l
+        v3OaVo0GDwAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:12:41 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tenants/_get_tenant_settings_with_specific_fields/should_exclude_a_field_not_requested.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tenants/_get_tenant_settings_with_specific_fields/should_exclude_a_field_not_requested.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/tenants/settings?fields=support_email&include_fields=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:12:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1538770364'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWKi4tKMgvKolPzU3MzFGygvEdEktLMgz08ovSlXSUihPz
+        UpLyK+LLUouKM/PzgKosMEWL4xPLgEYkJuWkKllFg1WYKMXWAgC6q/eQYgAA
+        AA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:12:42 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tenants/_get_tenant_settings_with_specific_fields/should_include_the_field_requested.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tenants/_get_tenant_settings_with_specific_fields/should_include_the_field_requested.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/tenants/settings?fields=support_email&include_fields=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:12:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538770364'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWKi4tKMgvKolPzU3MzFGygvEdEktLMgz08ovSlXSUihPz
+        UpLyK+LLUouKM/PzgKosMEWL4xPLgEYkJuWkKllFg1WYKMXWAgC6q/eQYgAA
+        AA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:12:42 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tenants/_update_tenant_settings/should_revert_the_tenant_name.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tenants/_update_tenant_settings/should_revert_the_tenant_name.yml
@@ -1,0 +1,96 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/tenants/settings?fields=support_email&include_fields=true
+    body:
+      encoding: UTF-8
+      string: '{"friendly_name":"Auth0"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '25'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:12:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1538770365'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA51XDW/bNhD9K6y6rslgSU7aYq2SFA2coC3QjwBNsXUwZtDS
+        WWJDkRpJxdE8//fdUZYt22lXLEASieS9e3x3PB0XQVpwlcOk4tbOtcmCZBGA
+        4lMJ+OhMDYOgcKUMkuD0wcXH0fWXq0tGAy/H6nT9H3iG/xk7LcFxhojGgjsb
+        B7Wbhc/HQW+ucK4K4a9a3OL07+Hn83Cky4o7gQ7HAUu1cqDI9O3lGWQ5DNLC
+        6BLOjjoUJ5yElyNPmjW6Nqxjfhq3cxtniqPlOLgVMK+0cVv4c5G54iyDW5FC
+        6F8GTCjhBJehTblEl9FwwEp+J8q67A/VFox/J5HOlEbYGJ16t9Y1EphrKvLr
+        4M7FqbUr6oxNddYMSLRFxbNMqDwZnpTc5EIlw2XkCG+RCVtJ3iT+7aTSFilp
+        lfCp1bJ2cFKAyAuXHA2Hj0487fZxytOb3OhaZYkUCrgJc8MzgXs9MPmUHxw/
+        ezbofqMnh4O9weHhYQ8kTLXUJnkIz2EKs2WUgpTb1EIaOrkF4wRKEXIpcpWU
+        Issk4PJW5vU2j59Vd6zbayhh5hJeO90NGL8lP9Ju6fj5sLpbekVjL6nXFzMt
+        XqXaKUnZRjoTtyyVmAOkOPdptJJ7a4rormd251q6vWlc8CAM2W9vL15fXrMw
+        7E+QpcjIzCdh2OUfZVEOLiQ0jjEwiHca4+pd1MsPF/cg95dunrunNrtSIyrH
+        rEnRO50km8RxmqkIpSuGqHoZf7XxLq2j6CgqhYq+Wk+oBdmGXLlVMGfnBNUe
+        r6sVwsGi47jeWtJtiP2IDAO/Mo6ZoZNvIOvwoORCbrBavMXCDy+XneE3fhDv
+        4iP78PGajd6cf3h9ya7fvP20ZmrNbOL0Dag1/OPFYjO6XD7+Fvh3cTHbb8Bt
+        UUbcdvQ7mP+J26k3qbQUaZO0uDuj9zv4Pt8CSkjYYpOCAgOTeJkx57lyUSVS
+        VxuY1Eayf1gGM15L3OHj3dTyBzGvRQYx1sFoGIsyj6ccgx1VKn/s47VxUxmB
+        p7sZ+TqC7h4Cf/bk+Mk46JYs14szJLBFEXfU7fxK8hQKLTPwKL7gU5p281s+
+        e3YjrWbClJyK5w5G2k6x/4X1nru0uDSm3dSVBG6BgbIoIGm9tmFcZX4g7Rkz
+        vlpl8cMUfcvdJ2dA5VgFdyRZHz977t6hX0cMRu0Q444RF8ceZUzPvJOZllLP
+        sfzSGH2SLM3Qx5mnDoxNdglgbmRYBqmej+gTTvgfNCu1Z80V4axX9IAY+WdG
+        z9kBRHk0YOPxOHhk6S9T2jFOPCA73PentLosK9e0nlQI9LLRcF0u9g3rcgor
+        hu0jOxARRGwYvrjHj/SC9mQ778m1vZF26T0QuAUzwmiT+Tt6YSnFXoLzpgc8
+        /Psez7bQtcxWUSLTT36gC+U9MbAVpKKNwCpOZNUO9rl6rdmDVw9/evTnz7/c
+        47quqg3jz/Syw/g8/ONwcx691XIbxNZpCta+x1+ee5wv/Y6LFdyyKYDCSGHD
+        1y2f1VI2e+ntD0JeG38S1ifoXDGgZ6bT2mCoI3ZdAOYbR76YgsxpdIDZVQq7
+        BUChapPclHuuFDikd7N2ck1HDsytV0BRSiKmAZ4WkA0IBh0Ki14qo7GBKNlc
+        uMLDr5D2PDhRgq7dD3qo2jLhTMN4jlHfg2tN+2jIaI7i8k4eZEbS0mneKjNe
+        +D086pLAXGP/SXCX2N0Y3F2/1pFwp1ODnevqa7u/Q+ylfYVpW+2rbxTJOfCb
+        bm5TFzsvgiKo/aJoJ9U6Jm+Eddo0+7aUXJXBBl3XVjZtnmHvnfWAlu3D8vBk
+        1St23cxpvGoQsWNsLynBchB4KfGmkwPdclbXmmAQ4CGdT6TOJ9g63wTJjEuL
+        1x78HuJ012aVTUoXFdVE2uSxRyLImeS5JTRsjqn5nIgSD5rVymdpd4NqL1QT
+        /HzytJlgLGdCws4kNr7UmEx4JY67KV85OzM/LdRMT0BllRbK7SBYq9fkW0vf
+        mmHOTPoryIaYG7wdZLKZ0C0JN+obPxSj1w70tr/dCsxhivcSiDFU4GxMiuJf
+        zEXrmwJ8wDKB+Rp7kzCXTVWER8MX2dP01yfp08je5iQ7Vii8lk18AqKv1fur
+        1g/K3FuzzWY1umFEK/GLO9V3EzxI1ksfPA2W/wJGcEuv3w4AAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:12:42 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tenants/_update_tenant_settings/should_update_the_tenant_settings_with_a_new_tenant_name.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tenants/_update_tenant_settings/should_update_the_tenant_settings_with_a_new_tenant_name.yml
@@ -1,0 +1,96 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/tenants/settings?fields=support_email&include_fields=true
+    body:
+      encoding: UTF-8
+      string: '{"friendly_name":"Auth0-CHANGED"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '33'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:12:42 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1538770365'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA51XDW/bNhD9K6y6rslgSU7aYq2SFA2coC3QjwBNsXUwZtDS
+        WWJDkRpJxdE8//fdUZYt22lXLEASieS9e3x3PB0XQVpwlcOk4tbOtcmCZBGA
+        4lMJ+OhMDYOgcKUMkuD0wcXH0fWXq0tGAy/H6nT9H3iG/xk7LcFxhojGgjsb
+        B7Wbhc/HQW+ucK4K4a9a3OL07+Hn83Cky4o7gQ7HAUu1cqDI9O3lGWQ5DNLC
+        6BLOjjoUJ5yElyNPmjW6Nqxjfhq3cxtniqPlOLgVMK+0cVv4c5G54iyDW5FC
+        6F8GTCjhBJehTblEl9FwwEp+J8q67A/VFox/J5HOlEbYGJ16t9Y1EphrKvLr
+        4M7FqbUr6oxNddYMSLRFxbNMqDwZnpTc5EIlw2XkCG+RCVtJ3iT+7aTSFilp
+        lfCp1bJ2cFKAyAuXHA2Hj0487fZxytOb3OhaZYkUCrgJc8MzgXs9MPmUHxw/
+        ezbofqMnh4O9weHhYQ8kTLXUJnkIz2EKs2WUgpTb1EIaOrkF4wRKEXIpcpWU
+        Issk4PJW5vU2j59Vd6zbayhh5hJeO90NGL8lP9Ju6fj5sLpbekVjL6nXFzMt
+        XqXaKUnZRjoTtyyVmAOkOPdptJJ7a4rormd251q6vWlc8CAM2W9vL15fXrMw
+        7E+QpcjIzCdh2OUfZVEOLiQ0jjEwiHca4+pd1MsPF/cg95dunrunNrtSIyrH
+        rEnRO50km8RxmqkIpSuGqHoZf7XxLq2j6CgqhYq+Wk+oBdmGXLlVMGfnBNUe
+        r6sVwsGi47jeWtJtiP2IDAO/Mo6ZoZNvIOvwoORCbrBavMXCDy+XneE3fhDv
+        4iP78PGajd6cf3h9ya7fvP20ZmrNbOL0Dag1/OPFYjO6XD7+Fvh3cTHbb8Bt
+        UUbcdvQ7mP+J26k3qbQUaZO0uDuj9zv4Pt8CSkjYYpOCAgOTeJkx57lyUSVS
+        VxuY1Eayf1gGM15L3OHj3dTyBzGvRQYx1sFoGIsyj6ccgx1VKn/s47VxUxmB
+        p7sZ+TqC7h4Cf/bk+Mk46JYs14szJLBFEXfU7fxK8hQKLTPwKL7gU5p281s+
+        e3YjrWbClJyK5w5G2k6x/4X1nru0uDSm3dSVBG6BgbIoIGm9tmFcZX4g7Rkz
+        vlpl8cMUfcvdJ2dA5VgFdyRZHz977t6hX0cMRu0Q444RF8ceZUzPvJOZllLP
+        sfzSGH2SLM3Qx5mnDoxNdglgbmRYBqmej+gTTvgfNCu1Z80V4axX9IAY+WdG
+        z9kBRHk0YOPxOHhk6S9T2jFOPCA73PentLosK9e0nlQI9LLRcF0u9g3rcgor
+        hu0jOxARRGwYvrjHj/SC9mQ778m1vZF26T0QuAUzwmiT+Tt6YSnFXoLzpgc8
+        /Psez7bQtcxWUSLTT36gC+U9MbAVpKKNwCpOZNUO9rl6rdmDVw9/evTnz7/c
+        47quqg3jz/Syw/g8/ONwcx691XIbxNZpCta+x1+ee5wv/Y6LFdyyKYDCSGHD
+        1y2f1VI2e+ntD0JeG38S1ifoXDGgZ6bT2mCoI3ZdAOYbR76YgsxpdIDZVQq7
+        BUChapPclHuuFDikd7N2ck1HDsytV0BRSiKmAZ4WkA0IBh0Ki14qo7GBKNlc
+        uMLDr5D2PDhRgq7dD3qo2jLhTMN4jlHfg2tN+2jIaI7i8k4eZEbS0mneKjNe
+        +D086pLAXGP/SXCX2N0Y3F2/1pFwp1ODnevqa7u/Q+ylfYVpW+2rbxTJOfCb
+        bm5TFzsvgiKo/aJoJ9U6Jm+Eddo0+7aUXJXBBl3XVjZtnmHvnfWAlu3D8vBk
+        1St23cxpvGoQsWNsLynBchB4KfGmkwPdclbXmmAQ4CGdT6TOJ9g63wTJjEuL
+        1x78HuJ012aVTUoXFdVE2uSxRyLImeS5JTRsjqn5nIgSD5rVymdpd4NqL1QT
+        /HzytJlgLGdCws4kNr7UmEx4JY67KV85OzM/LdRMT0BllRbK7SBYq9fkW0vf
+        mmHOTPoryIaYG7wdZLKZ0C0JN+obv7BtIS5QlF5b0JNhuyWYwxTvJxBjyMDZ
+        mJTFv5iT1jcH+IDlAvM29iZhLpuqCI+GL7Kn6a9P0qeRvc1JfqxUeD2b+ERE
+        X6v3V60flLu3ZpvNanTDiFbil3eq7yZ4oKwPQfA0WP4Lh0ff8+cOAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:12:42 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tickets/_post_email_verification/should_create_an_email_verification_ticket.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tickets/_post_email_verification/should_create_an_email_verification_ticket.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/tickets/email-verification
+    body:
+      encoding: UTF-8
+      string: '{"user_id":"auth0|5bb7af36f4f6d955a959f2f2","result_url":"https://auth0.com/callback"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '86'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 18:36:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538764600'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWKslMzk4tUbJSyigpKSi20tdPLC3JMNAtTsnWLUktLinW
+        A/P1kvNz9XPy9ctSizLTKuNTcxMzc+whWm1dU/y9DYKrKjIKy5wNnSu88lIK
+        DPzLinJNXHJMqrLSnJSVagE+p+NBZwAAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 18:36:39 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tickets/_post_password_change/should_create_a_password_change_ticket.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tickets/_post_password_change/should_create_a_password_change_ticket.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/tickets/password-change
+    body:
+      encoding: UTF-8
+      string: '{"user_id":"auth0|5bb7af36f4f6d955a959f2f2","result_url":"https://auth0.com/callback","new_password":"secret"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '110'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 18:36:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538764601'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWKslMzk4tUbJSyigpKSi20tdPLC3JMNAtTsnWLUktLinW
+        A/P1kvNz9XPy9YtSi1NL7CF6bL1KitIi0nPDyg3LAkpMPXyMQhKDXRyzwwtD
+        gs0KSwI9lJVqAWhI2t5gAAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 18:36:40 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tickets/create_test_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tickets/create_test_user.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users
+    body:
+      encoding: UTF-8
+      string: '{"email":"rubytest-rubytest-username@auth0.com","password":"SrU8Hd01Mw","connection":"Username-Password-Authentication","name":"rubytest-username"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '147'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 18:36:38 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538764599'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA41Ry2rDMBD8F0Fyih+ybMc2hDaXngttLy0lrKVVIprIRpJT
+        Spp/r+Q8yCkUdBhJszOzuweCO1Bb0hAztD8OrYuuYLBoNOzwEQa3SWPe7ciM
+        hIdb9oXkv0al1R6NkgoFaSRsLc7I0AtwKFbgfF2W0iqiaZQWr7RqWNmwKmaM
+        vvvyXnE3mCC+ca63TZLYeG1gDw5MME9OMMlKxlOUNC+wolRk5bykfO4Breu8
+        quSDXeRVOjWLfj0Vi1FrwpaT7MkfLnR87cbfT5LWIzPEvV77GKGhlfLxyUj8
+        Ldp2DpKVMpelqIsC6qKWmczCLBT/ujMPJVA75RRa0nwcCO+0Ru5Upz3/7UyL
+        nsHa786IaOndAp/DSLkNcidCb7q99zGXuMHWvnRcwfa8gOPnjHCD/1jB8Q+5
+        2y0YDQIAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 18:36:38 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tickets/delete_test_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tickets/delete_test_user.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C5bb7af36f4f6d955a959f2f2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 18:36:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538764602'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 18:36:40 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_delete_user/should_delete_the_user_successfully.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_delete_user/should_delete_the_user_successfully.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C5bb7c4425e09334d77899bdc
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:06:28 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '5'
+      X-Ratelimit-Reset:
+      - '1538769992'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:06:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_patch_user/should_patch_email_verified_and_return_the_updated_data.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_patch_user/should_patch_email_verified_and_return_the_updated_data.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C5bb7c4425e09334d77899bdc
+    body:
+      encoding: UTF-8
+      string: '{"email_verified":true}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '23'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:06:28 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1538769991'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA31Ry27CMBD8F0v0RBLHediJhFouPVdqe6GqkGNvwCo4kR9U
+        FeXfa4eCOCH5MLZnZ2Z3jwj2XO1Qi4zvfhxYl1yBt2A038MT926LUzHs0RzF
+        h1v2hRS+JqX1AYzqFUjUOuNhjvwouQO55i6UEZyzJMcJrt4IbnHdEpYSSleh
+        elTCeRO1t86Nts0ym24MP3DHTfTOzjAjdSEw9HlZActzSWpa54IGkDdNyVj/
+        aBclww9mMW4e5GLSmhXLGXkOR0idXpsJ97OkDcj4dNSbECP2s1YhPZqIv1XX
+        UVGWpALcFEUpKWVN00kRR6HE151xKAnaKafAovbjiMSgNQinBh347/+05IVb
+        +z0YmSyDW+QLPlFug9yJMJrhEHzMJW60ta+DUDystOc7C6fPORIG7q2gTpsa
+        r9DpD4j2v9EMAgAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:06:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_patch_user/should_patch_user_metadata_and_return_the_updated_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_patch_user/should_patch_user_metadata_and_return_the_updated_user.yml
@@ -1,0 +1,69 @@
+---
+http_interactions:
+- request:
+    method: patch
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C5bb7c4425e09334d77899bdc
+    body:
+      encoding: UTF-8
+      string: '{"user_metadata":{"addresses":{"home_address":"742 Evergreen Terrace"}}}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '72'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:06:28 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1538769991'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA31Ry2rDMBD8lSBITrEtvx8Q2hzac6HpJaUYWVo7ovGDlZxS
+        XP97ZedBTgEdRqvRzOzuQKBm8kgygn3xq0Fp6wZ6BdiwGp5Zrw/U5m1N1mQq
+        3LOvJPM0K+UnQFlKECTT2MOa9J1gGkTOtPnmUTexXGrRcOfRjEaZl9ihG+zN
+        705y3eOkfdC6U5njKLtCdmKa4eTtnKHjRT6nULpBCInrCi+KI5fHBrhpGiRJ
+        +aQ2QUJXuOmqldjMWkt/u/RezeGisW/NmPtZUhmEvd01lYkx9ZNLk57MxL+w
+        KGIeBF4INPX9QMRxkqaF4NMoJP9+MA4poNFSS1Ak+xwIb5sGuJZtY/gfF5r1
+        xpT6aVFYW+M28TmbKfdBHkTosD0ZH7zGnWzVe8slMyst2VHB+LUmHOHRCiI7
+        jej+almDZmZjjGQDYUIgKDV1MJBDW0N+qRidOPAWL2bZFQI0ix0gMg5kHMd/
+        rlqT4FMCAAA=
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:06:28 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_user/_filters/should_exclude_fields_not_indicated.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_user/_filters/should_exclude_fields_not_indicated.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C5bb7c4425e09334d77899bdc?fields=email&include_fields=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:06:27 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1538769990'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWSs1NzMxRslIqKk2qLEktLtGFM0qLU4vyEnNTHRJLSzIM
+        9JLzc5VqAZaP4MwwAAAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:06:27 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_user/_filters/should_exclude_the_fields_indicated.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_user/_filters/should_exclude_the_fields_indicated.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C5bb7c4425e09334d77899bdc?fields=picture,email,user_id&include_fields=false
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:06:27 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1538769990'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA42Py27CMBBF/2XWMTIhD+Jd/6BSYUNVRRN7EKMGG9kOVRXl
+        3xkQa8T26tzXDB7PBAbiNPxnSllNieJDK4DOyGN/pchHJgfmiGOiAqaLw0yu
+        xyy+Uq+3aq2VrnelNroxZbPqGn0Qu2f7+yKdHfnMmSmB+Z7BBu/JZg5e+P0T
+        U5+Y0l+ITn1M+XTnLT4QWSFIz7IK6mFobVWVNelus6lc2267bnBWoEsMV+mJ
+        QqEE6Htt+gqWcXzeWX4KsJHeOLTcAGqQKmEsAQAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:06:27 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_user/_filters/should_include_the_fields_indicated.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_user/_filters/should_include_the_fields_indicated.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C5bb7c4425e09334d77899bdc?fields=picture,email,user_id&include_fields=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:06:27 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538769989'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAz2OywqDMBBF/yWgqzYxD00iSNtNf6PEJFWhWsmjUNr+e6OC
+        MIszcOfO+QA7quEBauBi+w7Wh+MO0Vs3qdGeVQx9AfVzBAcwDzpEZ9NBH8Ls
+        a4Q87Jx6qaDcEkEbIlJRXdg7ZqUVGBtS8QprngBLyYS4n3zDRJG7Zu5y06xd
+        Gb1k5JpGmwnuP9O+VfpELsJ56pLG4nYbTNJYg9+ybblmjJS2kJQyw7mQsjUa
+        /P5TVpM14gAAAA==
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:06:27 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_user/should_retrieve_the_created_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_user/should_retrieve_the_created_user.yml
@@ -1,0 +1,66 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C5bb7c4425e09334d77899bdc?include_fields=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:06:27 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1538769989'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA41Ry2rDMBD8F0Fy8kOS34bQ5tJzoe2lpQRZWjuisWwkOaWk
+        +fdKzoOcQkGHkTQ7M7t7QNAzuUM10lPzY8HY8AomA1qxHh7ZZLc44kOPAuQf
+        btkXkvualTZ70LKVIFDdsp2BAE2jYBbEhllXRzEpQ4JDnL1SXOO8pnlU5fjd
+        lY+S20l78a21o6nj2ESdZntmmfbm8QnGNE84hpakGZSECJoXOeGFA6Sq0rJs
+        H8wqLfFSr8ZuKVaz1iJZL+iTO1yo6NqNu58kjUN6ikbVuRi+oY108dFM/M2a
+        puBpSjPAVZKkoijKqmoE97OQ/OvOPKQAZaWVYFD9cUB8UAq4lYNy/LczLXxm
+        xnwPWoRr5+b5nM2U2yB3Iox62DsffYnrbc3LwCXbnRdw/AwQ1/CPFRz/AIkm
+        rdkNAgAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:06:27 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_users/_filters/is_expected_to_find_a_user_with_a_v2_search_engine_query.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_users/_filters/is_expected_to_find_a_user_with_a_v2_search_engine_query.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users?fields=user_id&per_page=1&q=updated_at:%7B2016-01-01%20TO%20*%7D&search_engine=v2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.5.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 17:11:26 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538673087'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4uuViotTi2Kz0xRslJKLC3JMKgxTUoyM7FMsjQzNUkzMDNPSjQyNbM0SLFUqo0FAJsCrnkuAAAA
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 17:11:26 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_users/_filters/is_expected_to_find_a_user_with_a_v3_search_engine_query.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_users/_filters/is_expected_to_find_a_user_with_a_v3_search_engine_query.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users?fields=user_id&per_page=1&q=updated_at:%5B2016-01-01%20TO%20*%5D&search_engine=v3
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.5.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 17:11:27 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538673088'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4uuViotTi2Kz0xRslJKLC3JMKgxTUoyM7FMsjQzNUkzMDNPSjQyNbM0SLFUqo0FAJsCrnkuAAAA
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 17:11:27 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_users/_filters/should_exclude_the_indicated_fields_when_paginated.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_users/_filters/should_exclude_the_indicated_fields_when_paginated.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users?fields=email&include_fields=false&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.5.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 17:11:25 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538673087'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA42QTUsDMRCG/0ugnrofyX4HivTiWVAvlrJMJ7NtsJtdkrQeav+72a2CBxEhhwnzzvPOvJsLox70sT2T1Z0mxWQHR0dLZqAnJtmBjCLrBsOW7OTItjpIGJz8If0ooAaFXHQF1oJnuBMVkmowSEeN/mRngPejk0ni4r2FM3iwMQ59ciuTqhNZU/IMsqIWFZSqLvK8LDDnVQe7pr53q7xO7+xq3N+p1cxaZOuFeAgPlYnnRSZg+N+QLlQHikezD2sYjW+/HKIVGa+9Jsfk5sJwMIbQ69CT7CUcOY1Ej+Dc+2BVtA4ekx5hlvzM4a8E7HAOPvY7rcnWPQ2o4fiV8XUbUKMCT6oFH3Qi5XWUiog3zzyXvJB5GZdp9RpG0dK/dDCObU8eAhWYvFyv208wzCg74gEAAA==
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 17:11:25 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_users/_filters/should_include_the_indicated_fields_when_paginated.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_users/_filters/should_include_the_indicated_fields_when_paginated.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users?fields=picture,email,user_id&include_fields=true&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.5.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 17:11:24 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538673085'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAAyWOywrCMBBF/yWgK0ltHm0qFHXjT4jIOJk+wMaQpCKo/25UmMW9cDh3jk9GE4xXtmFSSVkprdRAzlKIN7ejB0z+StxRYis2Rwrn0WYU5jSsXxoMWCxFp9GIUuJF1Ei2wYz6EdMcKKNDSj5uiiLyPsAdEgSOt6n4x6LuhGyqUoLURtRQWZP3K42qrDu4NGYbW2XWy9D6fmnbn2sh9wtxyIfW8d8jX2Huf2XMaSDuXc/epw8ONK2S3gAAAA==
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 17:11:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_users/_filters/should_not_include_other_fields_when_paginated.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_users/_filters/should_not_include_other_fields_when_paginated.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users?fields=email&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.5.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 17:11:24 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538673086'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA4uuVkrNTczMUbJSMjYxNjYzMTUxyUjNS0ktKs7Pc0itSMwtyEnVy0stUaqNBQDKCTEMLAAAAA==
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 17:11:24 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_users/_filters/should_return_the_correct_number_of_results_when_paginated.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_users/_filters/should_return_the_correct_number_of_results_when_paginated.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users?per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.5.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 17:11:23 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538673084'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA42QT0/DMAzFv0uk7bR2Tfq/0gS7cEYCLkxT5SXuFtGmVZINpLHvjtsB4oAQUg6O/HvP9tucGXagW1axOInjLEmT5IBGoXW9ucU36IYWQ4OeLa5gfUKrG42KVQ20DhfMQIck/1YReXRoa00Ig6M/RO8pFKAkF00qC8FjuRO5RFVKQgct/dFOBt4PrlouXbi3cAIPNpR9t7yWy7wRcZnxGOK0EDlkqqBNs1QmPG9gVxY3bpUU0dyuhv1crSavWbyeiTt6UplwWmQ0pP/V0lF1wHAwe1rDaPnyyyFaofHaa3Ss2pyZ7I1B6TX1KvZER46S4B6ce+2tCtY0Y+QlTMjPHP5KwPYnmmO/0hrHuodeamg/M75syWpQ4FHV4IkTES+CSAS8fORJxdMqycIsyp9JKi3+i4NhqDv0QK7AqvPlsv0AxAdj3QsCAAA=
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 17:11:23 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_users/should_have_at_least_one_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_users/should_have_at_least_one_user.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.5.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 04 Oct 2018 17:11:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538673084'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA82dWW/kSHKA/8pCwO7TDCfvQ8DA3gf72YDXL14sCpGXiqMSS2CVetwe7393sKRWF1lJkcnOOYBGQ2pFpCoiP2Ycmcn++y938Qnaw939HRecKyGF2McuxP507P41/g88PR9i08Xz3XevgrtPsW9TG8PdfYLDKX5318FTRPV3LZR8OcV+16LIHbyc9+T/JBgInrIkvWGUe8e0j8F6FH1u/fmlvwxwPj+f7n/44dQ89PAJztA3/vj0w+uXP+jEuFWUA5eGaVDB4CdV0guqEzhr/uX0ozDkL/2Pzw9/CT9exvoz/+uf2b/jHx+65vJBhgHx+9chT/jVPjbP3QN+jK71jxlD2hC7c3tu4+nu/u+/3Plj10V/bvFn93f/hUYOKt//B5xOPx/78P1f8XcM8h4uItd++MgD/fET/p7+i7eGX3v6z6Nv4fDm43/+A4d6DnCOYQdnlGOEmu8J+57av1FxT+W9UI0i+r9R1fdxlRw8P++e4hlwVLi7/+Wf//wuQ8JDPKbUx8/vIBz7h0UQvijNcyAnXogFHATFmJRUWGKlFtqzKGyk2nJlHTEibuPgIcPBlR21Mcg6oAYGtuHarMDgXW4VBulw7GPnY9F68EVpHgOjLNeeaq6lxLmMpAADGqNVilqVTCQsMh2SUVI5aTShzqttGKTDLQZXdtTGIOuAChhI1jDFljH4KrduNeihO6PP0BnPvi0MD1/Vmss481i4iVdoARYqJAKORw0OnNHO4hcRQDOuwcatWPjjLRYZe2rjkXVEDTxkQ5Vcgce73Co8Anw6djsP/Tn2RWhcK85jEcZrJvCS1YJzSl0KIiVrWQBMGBIQo7TXMYRkt2ER4BaLiS21kcg6oQYSpiHErkDiXW4VEvHgYn8uguFVZRYDRiYPhSzJIZ0nSVPAlCF4RxJQDQmHC6Cp0XQjBjETNN6tqAxA3vxvBkDdE9IYppYAuJZbBcDxfD7ujo9XsSKfQZ77l68IvCvNU8ClV9o6qg0lKYJlBRSAwaQhcKUSWBWUEphI+IQgGFBKio0UHM+3FFwbUhuErAdqgMAbRekKEDjmDutXgodDbP2+QyMeYo8/7JaSyRERX3Sa92Hm0bATx6gCNAjBIlMSJrGSCDoRz4DjeudiEF4TtxGNfHGRsag2I1lXVGCEkoaZNYuFbSxdX23iYMcDFNWaryrzMPjJcgklMATHWPAxcsMIRo0ghUxepUCGLCLwjblkn8klv1hRG4Cs+TUA4A0lYhkAyhotL4vJ5aNdEXAHIfTxdBos/eVuf3yKu7d/wXG0YH/6N5zyhz7G7k9/i30PWH8hNPMc3RJyjZdWjJB928PTZNX5yEx7z2gjXvl9m6gPx1pdoyhlGJar1Dg/dLJ4CiFI4jTlRoatiwwXb1zlnwSslq9RkIyNERxbdoviFK3seKW8rkPxI8S+zlEJCU/g2/fJQ0euAcEImgMhM9TqbNQm54FH7lmiFCMMJVQxnlK0OpKtHc1FDsYxwYsZDgbD1mCQGe53wuAyQ9PAcrGlR/t2/ng4tN1pMlkfh5drxTmXBjfOyaUSBRBEGgkAx1SKJyxMJEEeAqYb1DorHKRtEPTtbZCZ2FI31Mw44VtDDWP3gjSEL1WmI7mlXOOCxE8vh/a4c8e4fyoi4kpvHgg2eigcMUXRgSQs7qmkIVhPKeUBjEhY8rPAadzYwfrp5RaIsSm1ecj6oAYPDAvQpfpkJLeKh31sQ1uUel405hkYt/jxMS9gYPBc4jImJQ0RwSQGikXNqCBecS5r7nW9GlF79rPW15h9idXpUuUxkls1+yePpfrn3ScYdv4+HQtbVjfa81SYyVNhS5qYqIrRIipJbcDlVkjMGqi3VvtLFN5GxcnfUpEzqDYhWU/UIMQ0wi7thI7kVhGSekB7H9vmJ8C/y3bCXlWaL0PM0+EmT00qoCM5xxXREagDBRR8wq9S9FhnEMOi2Bg3Mi3uW3Nqs5H1QwU2JG24JctsfJVbxUYf2w52rodwfoxl+eW15jwXcfKshJJ8whgZEQgpXMSaPTJgHHNMZnDx8DZs3C/vM7FkakxtKrJeqEGFaJjiK6h4l1tFhYP+vD8ehs7G/7pj5+FxAY1Rx/NWexYPT8aOoSX76MJYSiNLAoQWycZEGGDW6TyBQCXb2IxwmWUja1FlRvKuqMGIxupiDSOqUXo9I/1xxf7YiItXjXkW9KQMK2l4KmWSlVYoG6TRTDHvvDMBgtM6oEs3LhWZzfN3K2rPf9b8b55/Pux26OW88yLH+aqDNZf59wdocSn1+2H+264odkx055GAcTRlJe0Jz43Ah4ojGNwJbo1RwmshvFUiJhE29sAzO6a35tRmI+uHGmyoRvKlZvirHDX2j9EMZ+hWHGj3+LJv/fpWKNP3kjeK8Ewr9KMhV3fDcPWOKgVKk6KgiYsBXZuYCYZ5Ev2v0RKN01a2o/mW6MjAxdZoftjfvDV6NWMlePQRP2ff7HHc/aQrsoCHaIiwOTw+GHJ1jZOUoMQ5yUKSWOUkH4MDyiNlYJP6VXZOYoTJPM7snIwMXIFHbtjfBY9hxky+c85chJeiqDQozLkywSQ8F23HGohaMh95IAkkw0XcUe+BEh4Fk2Hj2uAyhcybDXXjz4zx3xp/OL2c2DBLh35HcmtyE4Y/fSpqiA4K81M/wT26gqkPwxiRKlABgzhgFTZsmgIES4OIdONOPITbqX+zofbUZ42vMfWqEWbpJOdIbtXUx2GvCHY4N0MjsKylMdGdByJMfFJyGQQzUa81AKYGXnFBFeKBRETBQXoKG5tdMXM049ac2mxk/VCDDdswu2ZZeJdbxcZrb7gIiVeVWRLcpGgvOsxnnBJYsL7ulyhmnXRSecOpkV5SvnFpmG+K1wcgb34FAChriFm6BTCSWwXAM/TtqYVuF0PZwV5cbt9U51GY7BrakkPeRNDEvWTM0WSDY/hNECZa9DDVWEdsXBQyUWJsSm0esj6owYNojF7qYY3k1i0I5+PhHDuHFWpzgJceiqi4aDRXY8yzIccLZSppc0rHg0zJA3NOW4xwNigjKdjhoA2LG7vgh0ybM2dQbUKynqhBiMYMcWlvfSS3ipAQ3bGHadH3YZvzTWUehsn2oS05YmF8kIp754zSmmoikYTIAqEycFxA3MbbIJlK4qsZtRHI2l8BAUYaSVZkDShH1x+3Yf5zd963sDv2RTcBrtTmUYjjvh6U7Kn7ZIIl3oBEKJzGPF2GYHiiJEbt7EYU/OdMf3NkSm0csj6ogYNuGFvqbQ5yqjFyfYHxiMHzXNjvftOZ5cDTySNRsksqwNvgiebOOHCcRxBE8aAUjUqQsPFsxWOmoPhqRmUG8vZXYICThpAVRSazjVJ/kP62+Cl2XRt3w6bjzeWjj8yVQ62sXzf/Jw2+D8dcfYhHqZACJyRQAtxTZ4RjgngAAkjaRtA+bGFiijPuPyjq8y3MsYVLPcyZcX/zHubVnBURctx3u4dDhFMpILgmCpUFZH7I1S1uqYZbiUJFh8kJV1Y5BcA1BZCC/iqHwnEe3Xjp8GaOjysDV+CRG/Z3weNtxnKxSDxBfICuOZ7a7vQ4Pcv/cUgaq865F9PKsR9i0bkuj+kJk9qJYJjyKUSDpYyLYshgTdy4A/uUqVxurKkaoObc8M0BylzO/vOlzfmR3JokRZzO8We4Op2xqtX1qjOLgiLjRC2VHAumHBcAmgwLVFhIwlsvkrIUs1VQMW7tdWUurn41ozIDeftrMCAavZykXMutYuAR+kNZlooK87PPx/FSllxet9wGMbzmRFBhrAcZqKNSek+slQk2tjAeMwvBmw21pz5rfI2p141kSzdERnKrpj7En9tz2UHwV5X56VfjBTCVvdlE+oQ5AfrNE+cigkC48Zow4xUkqNm0eLOiNgBZ8ysAgAWKWO5ZXMutW//h6enzbkh5btO5hSgwaDZvmvM42MkDoQtwAMp8otTHZCXVWDgImaQDARGHS4ptjAWZ1WBqTG0qsl6oQQVv2OJh75HcKiqOoY3NEzw8tMeiwHClN0+En/iipJUljKMqUi8oJMoTk5JEEYIUnEnvxMZW1jGz/TE2pTYPWR/U4EE1RCxdDBnJreIBHrp4an4ezr6fS1qb13rzQEzOvKeSJQLDgpCK4ChOaBVVABG8pMIRAMa2HueFh8ypibEttYnIOqEGEaYxakXdgHKSrY8bjy/PezjshlNEh6tdjxWHu99UmtcRZqnAB2PskKK3WngZhA1Ea4heKqwpNJeEJ2c9o15upGLuGNXImspc5N1QgQshG0lXRA6Uo+sPe2M+0YW+7eLOH/un9uodaetSirHyPBx6VGElUnKaQhMbrNEcJFfRMK4pc54KCRSLTuu3VpjZrOLGntp4ZB1RAw/T8MW7AIOcbqxmf4B+uOaWH9rDoYUO1p/1FuxSLMubTucHw63OXq33DLNWmaIFxzjECEGZiBHfCr/1FVwfdzmZHL+iQBmX6XJeG7fY4cwP+Zt3OK9mqgSJR3zspm9bWuBBNoxneciNtbqtpZNw3gy3Va20OgrlQ8KRrSWgEJJfB4bxbplnMAPDxbIVJOTG+11IeJujmxA0GPNwPJ8PbXRNfzzFw+eyN7i+6TRfBpnzLafjhM3LkvwkDPvvDBy1hiVtJZfDBpkLRhijraE1L6Hd2FM3BM044ltDkJD3kjRKL4WgkdxihjLg4XqMyp93p/bp2LVlb8oZq86iweg4KMuSczs2Jm+jdEEnboadMe0MONAKkz8p1MYWmMts0t9YUxmMvBtqgMEbqZZaYSO5VWDgbPgWk5T+6XTuj91DERpT5Xk4xMQrJeuGoFw7y4KITHOK9Q3FKt5CNKAcC3HrqxszcGTsqY1H1hE18FANX6x4R3Kr8HiCrtvthzdadqX/Z8RFpxn+msdifHFG+ZKKxgdlAyWWx+HeKhVAFC7HVlhQgoutfdL8q3RGttRGIuuEGkjYhtGlE14juVVI+P3rOaey08DvWvMwTI6c+JLbzEQSxpO0AwDR4cNlITkRo9NeSe83Xhvx+8xpvytDapOQ9cA3k6DuCWvIYttjJLeOBDjv+8/d7oyVbNm9kZHmPBF+sliWnPtzTIJGxeFuIeAqkTCXCMMLGJl3gsLWd7xmGh5TY2pTkfVCDSpEY+TS7upI7oaKf/w/W6pKNWVoAAA=
+    http_version: 
+  recorded_at: Thu, 04 Oct 2018 17:11:22 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/create_test_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/create_test_user.yml
@@ -1,0 +1,68 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users
+    body:
+      encoding: UTF-8
+      string: '{"email":"rubytest-rubytest-username@auth0.com","password":"VeR6ItEuZ29m","connection":"Username-Password-Authentication","name":"rubytest-username"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby/2.3.1
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      Authorization:
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      Content-Length:
+      - '149'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Fri, 05 Oct 2018 20:06:26 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1538769988'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA41Ry2rDMBD8F0Fy8kOS34bQ5tJzoe2lpQRZWjuisWwkOaWk
+        +fdKzoOcQkGHkTQ7M7t7QNAzuUM10lPzY8HY8AomA1qxHh7ZZLc44kOPAuQf
+        btkXkvualTZ70LKVIFDdsp2BAE2jYBbEhllXRzEpQ4JDnL1SXOO8pnlU5fjd
+        lY+S20l78a21o6nj2ESdZntmmfbm8QnGNE84hpakGZSECJoXOeGFA6Sq0rJs
+        H8wqLfFSr8ZuKVaz1iJZL+iTO1yo6NqNu58kjUN6ikbVuRi+oY108dFM/M2a
+        puBpSjPAVZKkoijKqmoE97OQ/OvOPKQAZaWVYFD9cUB8UAq4lYNy/LczLXxm
+        xnwPWoRr5+b5nM2U2yB3Iox62DsffYnrbc3LwCXbnRdw/AwQ1/CPFRz/AIkm
+        rdkNAgAA
+    http_version: 
+  recorded_at: Fri, 05 Oct 2018 20:06:26 GMT
+recorded_with: VCR 4.0.0

--- a/spec/integration/lib/auth0/api/v2/api_blacklist_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_blacklist_spec.rb
@@ -3,12 +3,25 @@ describe Auth0::Api::V2::Blacklists do
   let(:client) { Auth0Client.new(v2_creds) }
   let(:token) { 'faketoken' }
 
-  describe '.add_token_to_blacklist' do
-    it { expect(client.add_token_to_blacklist(token)).to be_empty }
+  describe '.add_token_to_blacklist', vcr: true do
+    it 'should add a token to the blacklist' do
+      expect do
+        client.add_token_to_blacklist(
+          token,
+          v2_creds[:client_id]
+        )
+      end.to_not raise_error
+    end
   end
 
-  describe '.blacklisted_tokens' do
-    let(:response) { { 'aud' => ENV['GLOBAL_CLIENT_ID'], 'jti' => token } }
-    it { expect(client.blacklisted_tokens).to include response }
+  describe '.blacklisted_tokens', vcr: true do
+    it 'should get the added token from the blacklist' do
+      expect(client.blacklisted_tokens.first).to(
+        include(
+          'aud' => v2_creds[:client_id],
+          'jti' => token
+        )
+      )
+    end
   end
 end

--- a/spec/integration/lib/auth0/api/v2/api_device_credentials_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_device_credentials_spec.rb
@@ -1,85 +1,128 @@
 require 'spec_helper'
 require 'base64'
 describe Auth0::Api::V2::DeviceCredentials do
-  attr_reader :user, :client, :basic_client, :existing_device_credentials
+  attr_reader :test_user, :client, :basic_client, :test_credential
 
   before(:all) do
     @client = Auth0Client.new(v2_creds)
-    username = Faker::Internet.user_name
-    email = "#{entity_suffix}#{Faker::Internet.safe_email(username)}"
+    test_user_name = "#{entity_suffix}-username"
+    email = "#{entity_suffix}-#{test_user_name}@auth0.com"
     password = Faker::Internet.password
-    sleep 1
-    @user = client.create_user(username,  'email' => email,
-                                          'password' => password,
-                                          'email_verified' => true,
-                                          'connection' => Auth0::Api::AuthenticationEndpoints::UP_AUTH,
-                                          'app_metadata' => {})
 
-    basic_creds = { connection_id: Auth0::Api::AuthenticationEndpoints::UP_AUTH,
-                    user: email,
-                    password: password,
-                    authorization: 'Basic' }
+    VCR.use_cassette('Auth0_Api_V2_DeviceCredentials/create_test_user') do
+      @test_user = client.create_user(
+        test_user_name,
+        'email' => email,
+        'password' => password,
+        'email_verified' => true,
+        'connection' => Auth0::Api::AuthenticationEndpoints::UP_AUTH
+      )
+    end
+
+
+    basic_creds = {
+      connection_id: Auth0::Api::AuthenticationEndpoints::UP_AUTH,
+      user: email,
+      password: password,
+      authorization: 'Basic'
+    }
 
     @basic_client = Auth0Client.new(v2_creds.merge(basic_creds))
-    sleep 1
-    @existing_device_credentials = basic_client.create_device_credential(
-      "#{user['name']}_phone_1",
-      'dmFsdWU=',
-      '68753A44-4D6F-1226-9C60-0050E4C00067',
-      ENV['CLIENT_ID']
-    )
+
+    VCR.use_cassette('Auth0_Api_V2_DeviceCredentials/create_test_credential') do
+      @test_credential = basic_client.create_device_credential(
+        "#{test_user['name']}_phone_1",
+        'dmFsdWU=',
+        '68753A44-4D6F-1226-9C60-0050E4C00067',
+        v2_creds[:client_id]
+      )
+    end
+
   end
 
   after(:all) do
-    sleep 1
-    client.delete_user(user['user_id'])
+    VCR.use_cassette('Auth0_Api_V2_DeviceCredentials/delete_test_user') do
+      client.delete_user(test_user['user_id'])
+    end
+
+    VCR.use_cassette('Auth0_Api_V2_DeviceCredentials/delete_test_credential') do
+      client.delete_device_credential(test_credential['id'])
+    end
   end
 
-  describe '.device_credentials' do
-    let(:device_credentials) do
-      sleep 1
-      basic_client.device_credentials(ENV['CLIENT_ID'])
+  describe '.create_device_credential', vcr: true do
+    it 'should create the test credentials' do
+      expect(test_credential).to(
+        include('id' => test_credential['id'])
+      )
     end
-    it do
-      sleep 1
+
+    it 'should raise an error if the device_name is empty' do
+      expect do
+        basic_client.create_device_credential(
+          '', 'value', 'device_id', 'client_id'
+        )
+      end.to raise_error Auth0::InvalidParameter
+    end
+
+    it 'should raise an error if the value is empty' do
+      expect do
+        basic_client.create_device_credential(
+          'device_name', '', 'device_id', 'client_id'
+        )
+      end.to raise_error Auth0::InvalidParameter
+    end
+
+    it 'should raise an error if the device_id is empty' do
+      expect do
+        basic_client.create_device_credential(
+          'device_name', 'value', '', 'client_id'
+        )
+      end.to raise_error Auth0::InvalidParameter
+    end
+
+    it 'should raise an error if the client_id is empty' do
+      expect do
+        basic_client.create_device_credential(
+          'device_name', 'value', 'device_id', ''
+        )
+      end.to raise_error Auth0::InvalidParameter
+    end
+  end
+
+  describe '.device_credentials', vcr: true do
+    let(:device_credentials) do
+      basic_client.device_credentials(v2_creds[:client_id])
+    end
+
+    it 'should have at least 1 entry' do
       expect(device_credentials.size).to be > 0
     end
-    it do
-      sleep 1
-      expect(device_credentials.find { |cred| cred['id'] == existing_device_credentials['id'] }).to_not be_empty
+
+    it 'should include the test credential' do
+      expect(
+        device_credentials.find do |cred|
+          cred['id'] == test_credential['id']
+        end).to_not be_empty
     end
+
     context '#filter_by_type' do
-      let(:filtered_device_credentials) { basic_client.device_credentials(ENV['CLIENT_ID'], type: 'refresh_token') }
-      it do
-        sleep 1
-        expect(filtered_device_credentials.find do |cred|
-                 cred['id'] == existing_device_credentials['id']
-               end).to eq nil
+      it 'should exclude the test credential' do
+        expect(
+          basic_client.device_credentials(
+            v2_creds[:client_id],
+            type: 'refresh_token'
+          )
+        ).to be_empty
       end
     end
   end
 
-  describe '.create_device_credential' do
-    let!(:new_credentials) do
-      sleep 1
-      basic_client.create_device_credential(
-        "#{user['name']}_phone_2",
-        'dmFsdWU=',
-        '68753A44-4D6F-1226-9C60-0050E4C00067',
-        ENV['CLIENT_ID']
-      )
-    end
-    it do
-      sleep 1
-      expect(basic_client.device_credentials(ENV['CLIENT_ID'])
-        .find { |cred| cred['id'] == new_credentials['id'] }).to_not be_empty
-    end
-  end
-
-  describe '.delete_device_credential' do
-    it do
-      sleep 1
-      expect { basic_client.delete_device_credential(existing_device_credentials['id']) }.to_not raise_error
+  describe '.delete_device_credential', vcr: true do
+    it 'should delete the test credential without an error' do
+      expect do
+        basic_client.delete_device_credential(test_credential['id'])
+      end.to_not raise_error
     end
   end
 end

--- a/spec/integration/lib/auth0/api/v2/api_email_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_email_spec.rb
@@ -1,121 +1,116 @@
 require 'spec_helper'
 describe Auth0::Api::V2::Emails do
+  attr_reader :client
+
   before(:all) do
-    client = Auth0Client.new(v2_creds)
+    @client = Auth0Client.new(v2_creds)
+
     begin
-      sleep 1
-      client.delete_provider
-    rescue
+      VCR.use_cassette(
+        'Auth0_Api_V2_Emails/delete_existing_provider'
+      ) do
+        client.delete_provider
+      end
+    rescue Auth0::NotFound
       puts 'no email provider to delete'
     end
   end
 
-  let(:client) { Auth0Client.new(v2_creds) }
   let(:name) { 'mandrill' }
   let(:enabled) { true }
-  let(:credentials) { { 'api_key' => 'api_key' } }
-  let(:settings) { { 'first_setting' => 'first_setting_set', 'second_setting' => 'second_setting_set' } }
+  let(:credentials) { {api_key: 'api_key'} }
+
+  let(:settings) do
+    {
+      first_setting: 'first_setting_set',
+      second_setting: 'second_setting_set'
+    }
+  end
+
   let(:body) do
-    { 'name' => name,
-      'enabled' => enabled,
-      'credentials' => credentials,
-      'settings' => settings }
+    {
+      name: name,
+      enabled: enabled,
+      credentials: credentials,
+      settings: settings
+    }
   end
 
-  describe '.configure_provider' do
-    let!(:email_provider) do
-      sleep 1
+  describe '.configure_provider', vcr: true do
+    it 'should configure a new email provider' do
       begin
-        client.configure_provider(body)
-      rescue
-        puts 'email provider is already configured'
-      end
-    end
-    it do
-      if email_provider
-        sleep 1
-        expect(email_provider).to include(
-          'name' => name, 'enabled' => enabled, 'credentials' => credentials, 'settings' => settings
-        )
+        expect(
+          client.configure_provider(body).deep_symbolize_keys
+        ).to include(body)
+      rescue Auth0::Unsupported
+        puts 'Email provider is already configured'
       end
     end
   end
 
-  describe '.get_provider' do
-    let(:provider) do
-      sleep 1
+  describe '.get_provider', vcr: true do
+    it 'should get the existing email provider' do
       begin
-        client.get_provider
-      rescue
-        'no email provider'
-      end
-    end
-
-    it do
-      if provider
-        sleep 1
-        expect(provider.size).to be > 0
+        expect(client.get_provider.size).to be > 0
+      rescue Auth0::NotFound
+        'No email provider configured'
       end
     end
 
     context '#filters' do
-      it do
+      it 'should get the existing email provider with specific fields' do
         begin
-          sleep 1
           expect(
-              client.get_provider(fields: [:name, :enabled, :credentials].join(','), include_fields: true)
-          ).to(
-              include('name', 'enabled', 'credentials')
-          )
-        rescue
-          'no email provider'
+              client.get_provider(
+                fields: [:name, :enabled, :credentials].join(','),
+                include_fields: true
+              )
+          ).to include('name', 'enabled', 'credentials')
+        rescue Auth0::NotFound
+          'No email provider configured'
         end
       end
-      it do
+
+      it 'should get the existing email provider without specific fields' do
         begin
-          sleep 1
           expect(
-              client.get_provider(fields: [:enabled].join(','), include_fields: false).first
-          ).to_not(include('enabled'))
-        rescue
-          'no email provider'
+              client.get_provider(
+                fields: [:enabled].join(','),
+                include_fields: false
+              ).first
+          ).to_not include('enabled')
+        rescue Auth0::NotFound
+          'No email provider configured'
         end
       end
     end
   end
 
-  describe '.update_provider' do
-    let(:update_name) { 'sendgrid' }
-    let(:update_settings) do
-      { 'first_up_setting' => 'first_up_setting_set', 'second_up_setting' => 'second_up_setting_set' }
-    end
+  describe '.update_provider', vcr: true do
     let(:update_body) do
-      { 'name' => update_name,
-        'settings' => update_settings }
+      {
+        name: 'sendgrid',
+        settings: {
+          first_up_setting: 'first_up_setting_set',
+          second_up_setting: 'second_up_setting_set'
+        }.merge(settings),
+        credentials: credentials
+      }
     end
-    it do
-      begin
-        sleep 1
-        expect(
-          client.update_provider(update_body)
-        ).to(
-          include(
-            'name' => update_name, 'enabled' => enabled, 'credentials' => credentials, 'settings' => update_settings
-          )
-        )
-      rescue
-        puts 'email provider is not configured'
-      end
+
+    it 'should update the existing email provider' do
+      expect(
+        client.update_provider(update_body).deep_symbolize_keys
+      ).to include(update_body)
     end
   end
 
-  describe '.delete_provider' do
-    it do
-      sleep 1
+  describe '.delete_provider', vcr: true do
+    it 'should delete the existing email provider without an error' do
       expect { client.delete_provider }.to_not raise_error
     end
-    it do
-      sleep 1
+
+    it 'should throw an error trying to get the email provider' do
       expect { client.get_provider }.to raise_error(Auth0::NotFound)
     end
   end

--- a/spec/integration/lib/auth0/api/v2/api_logs_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_logs_spec.rb
@@ -1,83 +1,91 @@
 require 'spec_helper'
 
 describe Auth0::Api::V2::Logs do
-  attr_reader :client, :user
+  attr_reader :client, :test_user
 
   before(:all) do
     @client = Auth0Client.new(v2_creds)
-    username = Faker::Internet.user_name
-    email = "#{entity_suffix}#{Faker::Internet.safe_email(username)}"
-    password = Faker::Internet.password
-    sleep 1
-    @user = client.create_user(username,  'email' => email,
-                                          'password' => password,
-                                          'email_verified' => false,
-                                          'connection' => Auth0::Api::AuthenticationEndpoints::UP_AUTH,
-                                          'app_metadata' => {})
+    test_user_name = "#{entity_suffix}-username"
+
+    VCR.use_cassette('Auth0_Api_V2_Logs/create_test_user') do
+      @test_user = client.create_user(
+        test_user_name,
+        'email' => "#{entity_suffix}-#{test_user_name}@auth0.com",
+        'password' => Faker::Internet.password,
+        'connection' => Auth0::Api::AuthenticationEndpoints::UP_AUTH
+      )
+    end
+
   end
 
   after(:all) do
-    sleep 1
-    client.delete_user(user['user_id'])
+    VCR.use_cassette('Auth0_Api_V2_Logs/delete_test_user') do
+      client.delete_user(test_user['user_id'])
+    end
   end
 
-  describe '.logs' do
+  describe '.logs', vcr: true do
     let(:logs) do
-      sleep 1
       client.logs
     end
 
     context '#filters' do
-      it do
-        sleep 1
+      it 'should have one log entry' do
         expect(client.logs(per_page: 1).size).to be 1
       end
-      it do
-        sleep 1
+
+      it 'should include the specified fields' do
         expect(
-          client.logs(per_page: 1, fields: [:date, :description, :type].join(','), include_fields: true).first
+          client.logs(
+            per_page: 1,
+            fields: [:date, :description, :type].join(','),
+            include_fields: true
+          ).first
         ).to(include('date', 'description', 'type'))
       end
-      it do
-        sleep 1
-        expect(client.logs(per_page: 1, fields: [:date].join(',')).first).to_not include('type', 'description')
-      end
-      it do
-        sleep 1
+
+      it 'should exclude fields not specified' do
         expect(
-          client.logs(per_page: 1, fields: [:date].join(','), include_fields: false).first
+          client.logs(
+            per_page: 1,
+            fields: [:date].join(',')
+          ).first
+        ).to_not include('type', 'description')
+      end
+
+      it 'should exclude the specified fields' do
+        expect(
+          client.logs(
+            per_page: 1,
+            fields: [:date].join(','),
+            include_fields: false
+          ).first
         ).to include('type', 'description')
       end
     end
 
     context '#from' do
-      it do
-        sleep 1
+      it 'should take one log entry' do
         expect(client.logs(from: logs.last['_id'], take: 1).size).to be 1
       end
     end
   end
 
-  describe '.log' do
+  describe '.log', vcr: true do
     let(:first_log) do
-      sleep 1
       client.logs.first
     end
+
     let(:log) do
-      sleep 1
       client.log(first_log['_id'])
     end
-    it do
-      sleep 1
+
+    it 'should not be empty' do
       expect(log).to_not be_empty
     end
-    it do
-      sleep 1
+
+    it 'should match the created log entry' do
       expect(log['_id']).to eq(first_log['_id'])
-    end
-    it do
-      sleep 1
-      expect(log['date']).to eq(first_log['date'])
     end
   end
 end

--- a/spec/integration/lib/auth0/api/v2/api_rules_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_rules_spec.rb
@@ -1,116 +1,177 @@
 require 'spec_helper'
 describe Auth0::Api::V2::Rules do
-  attr_reader :client, :enabled_rule, :disabled_rule
+  attr_reader :client, :test_script, :enabled_rule, :disabled_rule
 
   before(:all) do
     @client = Auth0Client.new(v2_creds)
-    suffix = "#{entity_suffix}#{Faker::Lorem.word}"
-    script = 'function (user, context, callback) { callback(null, user, context);}'
-    stage = 'login_success'
-    sleep 1
-    @enabled_rule = client.create_rule("Enabled Rule #{suffix}", script, nil, true, stage)
-    sleep 1
-    @disabled_rule = client.create_rule("Disabled Rule #{suffix}", script, nil, false, stage)
-  end
+    @test_script = 'function (user, context, cb) { cb(null, user, context);}'
 
-  after(:all) do
-    rules = client.rules
-    rules.each do |rule|
-      client.delete_rule(rule['id'])
+    VCR.use_cassette('Auth0_Api_V2_Rules/create_test_enabled_rule') do
+      @enabled_rule = client.create_rule(
+        "#{entity_suffix} - ENABLED",
+        test_script
+      )
+    end
+
+    VCR.use_cassette('Auth0_Api_V2_Rules/create_test_disabled_rule') do
+      @disabled_rule = client.create_rule(
+        "#{entity_suffix} - DISABLED",
+        test_script,
+        nil,
+        false
+      )
     end
   end
 
-  describe '.rules' do
+  after(:all) do
+    VCR.use_cassette('Auth0_Api_V2_Logs/delete_test_enabled_rule') do
+      client.delete_rule(disabled_rule['id'])
+    end
+    VCR.use_cassette('Auth0_Api_V2_Logs/delete_test_disabled_rule') do
+      client.delete_rule(disabled_rule['id'])
+    end
+  end
+
+  describe '.create_rule', vcr: true do
+    it 'should create the test enabled rule with the correct attributes' do
+      expect(enabled_rule).to(
+        include(
+          'name' => "#{entity_suffix} - ENABLED",
+          'stage' => 'login_success',
+          'script' => test_script,
+          'enabled' => true
+        )
+      )
+    end
+
+    it 'should create the test disabled rule with the correct attributes' do
+      expect(disabled_rule).to(
+        include(
+          'name' => "#{entity_suffix} - DISABLED",
+          'stage' => 'login_success',
+          'script' => test_script,
+          'enabled' => false
+        )
+      )
+    end
+
+    it 'should raise an error if the name is empty' do
+      expect do
+        client.create_rule('', 'SCRIPT')
+      end.to raise_error(Auth0::InvalidParameter)
+    end
+
+    it 'should raise an error if the name is empty' do
+      expect do
+        client.create_rule('NAME', '')
+      end.to raise_error(Auth0::InvalidParameter)
+    end
+  end
+
+  describe '.rules', vcr: true do
     let(:rules) do
       client.rules
     end
 
-    it do
+    it 'should return at least 1 rule' do
       expect(rules.size).to be > 0
     end
 
     context '#filters' do
-      it do
-        sleep 0.5
+      it 'should return at least 1 enabled rule' do
         expect(client.rules(enabled: true).size).to be >= 1
       end
 
-      it do
-        sleep 0.5
+      it 'should return at least 1 disabled rule' do
         expect(client.rules(enabled: false).size).to be >= 1
       end
 
-      it do
-        sleep 0.5
-        expect(client.rules(enabled: true, fields: [:script, :order].join(',')).first).to(include('script', 'order'))
+      it 'should include the specified fields' do
+        expect(
+          client.rules(
+            fields: [:script, :order].join(',')
+          ).first
+        ).to(include('script', 'order'))
       end
 
-      it do
-        sleep 0.5
-        expect(client.rules(enabled: true, fields: [:script].join(',')).first).to_not(include('order', 'name'))
+      it 'should exclude fields not specified' do
+        expect(
+          client.rules(
+            fields: [:script].join(',')
+          ).first
+        ).to_not(include('order', 'name'))
       end
 
-      it do
-        sleep 0.5
+      it 'should return paginated results' do
         rule_1 = client.rules(fields: :name, page: 0, per_page: 2)
-        sleep 0.5
         rule_2 = client.rules(fields: :name, page: 1, per_page: 1)
         expect(rule_1.last).to eq(rule_2.first)
       end
     end
   end
 
-  describe '.rule' do
-    it do
+  describe '.rule', vcr: true do
+    it 'should get a specific rule' do
       expect(client.rule(enabled_rule['id'])).to(
-        include('stage' => enabled_rule['stage'], 'order' => enabled_rule['order'], 'script' => enabled_rule['script'])
+        include(
+          'name' => enabled_rule['name'],
+          'script' => enabled_rule['script']
+        )
       )
     end
 
     context '#filters' do
       let(:rule_include) do
-        client.rule(enabled_rule['id'], fields: [:stage, :order, :script].join(','))
-      end
-      let(:rule_not_include) do
-        client.rule(enabled_rule['id'], fields: :stage, include_fields: false)
+        client.rule(
+          enabled_rule['id'],
+          fields: [:stage, :order, :script].join(',')
+        )
       end
 
-      it do
+      let(:rule_not_include) do
+        client.rule(
+          enabled_rule['id'],
+          fields: :stage,
+          include_fields: false
+        )
+      end
+
+      it 'should include the specified fields' do
         expect(rule_include).to(include('stage', 'order', 'script'))
       end
 
-      it do
+      it 'should exclude the specified fields' do
         expect(rule_not_include).to(include('order', 'script'))
+      end
+
+      it 'should exclude the fields not specified' do
         expect(rule_not_include).to_not(include('stage'))
       end
     end
   end
 
-  describe '.create_rule' do
-    let(:name) { "#{Faker::Lorem.word}#{entity_suffix}" }
-    let(:stage) { 'login_success' }
-    let(:script) { 'function(test)' }
-    let(:enabled) { false }
-    let!(:rule) do
-      client.create_rule(name, script, nil, enabled, stage)
-    end
-    it do
-      expect(rule).to include('name' => name, 'stage' => stage, 'script' => script)
+  describe '.update_rule', vcr: true do
+    it 'should update the disabled rule to be enabled' do
+      expect(
+        client.update_rule(
+          disabled_rule['id'],
+          enabled: true
+        )
+      ).to(include('enabled' => true))
     end
   end
 
-  describe '.delete_rule' do
-    it do
-      expect { client.delete_rule(enabled_rule['id']) }.to_not raise_error
-    end
-    it do
+  describe '.delete_rule', vcr: true do
+    it 'should raise an error if the rule ID is not passed' do
       expect { client.delete_rule '' }.to raise_error(Auth0::InvalidParameter)
     end
-  end
 
-  describe '.update_rule' do
-    it do
-      expect(client.update_rule(disabled_rule['id'], enabled: true)).to(include('enabled' => true))
+    it 'should delete the test enabled rule without an error' do
+      expect { client.delete_rule(enabled_rule['id']) }.to_not raise_error
+    end
+
+    it 'should delete the test disabled rule without an error' do
+      expect { client.delete_rule(disabled_rule['id']) }.to_not raise_error
     end
   end
 end

--- a/spec/integration/lib/auth0/api/v2/api_stats_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_stats_spec.rb
@@ -2,24 +2,21 @@ require 'spec_helper'
 describe Auth0::Api::V2::Stats do
   let(:client) { Auth0Client.new(v2_creds) }
 
-  describe '.active_users' do
-    it do
-      sleep 1
+  describe '.active_users', vcr: true do
+    it 'should have at least one active user' do
       expect(Integer(client.active_users)).to be >= 0
     end
   end
 
   # rubocop:disable Date
-  describe '.daily_stats' do
-    let(:from) { Date.today.prev_day.strftime('%Y%m%d') }
-    let(:to) { Date.today.strftime('%Y%m%d') }
-    let(:daily_stats) do
-      sleep 1
-      client.daily_stats(from, to)
-    end
-    it do
-      sleep 1
-      expect(daily_stats.size).to be > 0
+  describe '.daily_stats', vcr: true do
+    it 'should have at least one stats entry for the timeframe' do
+      expect(
+        client.daily_stats(
+          Date.new(2017, 1, 1).strftime('%Y%m%d'),
+          Date.new(2018, 1, 1).strftime('%Y%m%d')
+        ).size
+      ).to be > 0
     end
   end
 end

--- a/spec/integration/lib/auth0/api/v2/api_users_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_users_spec.rb
@@ -1,53 +1,76 @@
 require 'spec_helper'
 describe Auth0::Api::V2::Users do
   let(:client) { Auth0Client.new(v2_creds) }
-  let(:username) { Faker::Internet.user_name }
-  let(:email) { "#{entity_suffix}#{Faker::Internet.safe_email(username)}" }
-  let(:password) { Faker::Internet.password }
-  let(:user) do
-    sleep 1
-    client.create_user(username,  'email' => email,
-                                  'password' => password,
-                                  'email_verified' => false,
-                                  'connection' => Auth0::Api::AuthenticationEndpoints::UP_AUTH,
-                                  'app_metadata' => {})
+  let(:test_user_name) { "#{entity_suffix}-username" }
+  let(:test_user_email) { "#{entity_suffix}-#{test_user_name}@auth0.com" }
+  let(:test_user) do
+    VCR.use_cassette(
+      'Auth0_Api_V2_Users/create_test_user'
+    ) do
+      client.create_user(
+        test_user_name,
+        'email' => test_user_email,
+        'password' => Faker::Internet.password,
+        'connection' => Auth0::Api::AuthenticationEndpoints::UP_AUTH
+      )
+    end
   end
 
-  describe '.users' do
+  describe '.create_user', vcr: true do
+    it 'should return the created user' do
+      expect(test_user).to include('user_id', 'email', 'email_verified', 'name')
+      expect(test_user).to include(
+        'email' => test_user_email,
+        'name' => test_user_name,
+        'email_verified' => false
+      )
+    end
+  end
+
+  describe '.users', vcr: true do
     let(:users) do
-      sleep 1
       client.users
     end
 
-    it do
-      sleep 1
+    it 'should have at least one user' do
       expect(users.size).to be > 0
     end
 
     context '#filters' do
-      it do
-        sleep 1
+      it 'should return the correct number of results when paginated' do
         expect(client.users(per_page: 1).size).to be 1
       end
-      it do
-        sleep 1
+
+      it 'should include the indicated fields when paginated' do
         expect(
-          client.users(per_page: 1, fields: [:picture, :email, :user_id].join(','), include_fields: true).first
+          client.users(
+            per_page: 1,
+            fields: [:picture, :email, :user_id].join(','),
+            include_fields: true
+          ).first
         ).to(include('email', 'user_id', 'picture'))
       end
-      it do
-        sleep 1
-        expect(client.users(per_page: 1, fields: [:email].join(',')).first).to_not include('user_id', 'picture')
-      end
-      it do
-        sleep 1
+
+      it 'should not include other fields when paginated' do
         expect(
-          client.users(per_page: 1, fields: [:email].join(','), include_fields: false).first
+          client.users(
+            per_page: 1,
+            fields: [:email].join(',')
+          ).first
+        ).to_not include('user_id', 'picture')
+      end
+
+      it 'should exclude the indicated fields when paginated' do
+        expect(
+          client.users(
+            per_page: 1,
+            fields: [:email].join(','),
+            include_fields: false
+          ).first
         ).to include('user_id', 'picture')
       end
 
       it 'is expected to find a user with a v2 search engine query' do
-        sleep 1
         expect(
           client.users(
             per_page: 1,
@@ -59,7 +82,6 @@ describe Auth0::Api::V2::Users do
       end
 
       it 'is expected to find a user with a v3 search engine query' do
-        sleep 1
         expect(
           client.users(
             per_page: 1,
@@ -72,108 +94,89 @@ describe Auth0::Api::V2::Users do
     end
   end
 
-  describe '.user' do
-    let(:subject) do
-      sleep 1
-      client.user(user['user_id'])
-    end
-
-    it do
-      sleep 1
-      should include('email' => email, 'name' => username)
-    end
-    it do
-      sleep 1
+  describe '.user', vcr: true do
+    it 'should retrieve the created user' do
       expect(
-        client.user(user['user_id'], fields: [:picture, :email, :user_id].join(','), include_fields: true)
-      ).to(include('email', 'user_id', 'picture'))
-    end
-    it do
-      sleep 1
-      expect(
-        client.user(user['user_id'], fields: [:picture, :email, :user_id].join(','), include_fields: false)
-      ).not_to(include('email', 'user_id', 'picture'))
+        client.user(test_user['user_id'])
+      ).to include(
+        'email' => test_user_email,
+        'name' => test_user_name
+      )
     end
 
     context '#filters' do
-      it do
-        sleep 1
-        expect(client.user(user['user_id'], fields: [:picture, :email, :user_id].join(','))).to(
-          include('email', 'user_id', 'picture')
-        )
+      it 'should include the fields indicated' do
+        expect(
+          client.user(
+            test_user['user_id'],
+            fields: [:picture, :email, :user_id].join(','),
+            include_fields: true
+          )
+        ).to include('email', 'user_id', 'picture')
       end
-      it do
-        sleep 1
-        expect(client.user(user['user_id'], fields: [:email].join(','))).to_not include('user_id', 'picture')
+
+      it 'should exclude the fields indicated' do
+        expect(
+          client.user(
+            test_user['user_id'],
+            fields: [:picture, :email, :user_id].join(','),
+            include_fields: false
+          )
+        ).not_to include('picture', 'email', 'user_id')
+      end
+
+      it 'should exclude fields not indicated' do
+        expect(
+          client.user(
+            test_user['user_id'],
+            fields: [:email].join(','))
+        ).to_not include('user_id', 'picture')
       end
     end
   end
 
-  describe '.create_user' do
-    let(:subject) { user }
-
-    it do
-      sleep 1
-      should include('user_id', 'identities')
-    end
-    it do
-      sleep 1
-      expect(client.patch_user(user['user_id'], 'email_verified' => true)).to include('email_verified' => true)
-    end
-  end
-
-  describe '.delete_user' do
-    it do
-      sleep 1
-      expect { client.delete_user user['user_id'] }.to_not raise_error
-    end
-    it do
-      sleep 1
-      expect { client.delete_user '' }.to raise_error(Auth0::MissingUserId)
-    end
-  end
-
-  describe '.patch_user' do
-    it do
-      sleep 1
-      expect(client.patch_user(user['user_id'], 'email_verified' => true)).to(include('email_verified' => true))
-    end
-    let(:body_path) do
+  describe '.patch_user', vcr: true do
+    let(:patch_user_body) do
       {
         'user_metadata' => {
           'addresses' => { 'home_address' => '742 Evergreen Terrace' }
         }
       }
     end
-    it do
-      sleep 1
+
+    it 'should raise an error when the user_id is missing' do
+      expect { client.patch_user('', {}) }.to raise_error Auth0::MissingUserId
+    end
+
+    it 'should raise an error when the body is missing' do
+      expect do
+        client.patch_user(test_user['user_id'], {})
+      end.to raise_error Auth0::InvalidParameter
+    end
+
+    it 'should patch email_verified and return the updated data' do
       expect(
-        client.patch_user(user['user_id'], body_path)
-      ).to(include('user_metadata' => { 'addresses' => { 'home_address' => '742 Evergreen Terrace' } }))
+        client.patch_user(
+          test_user['user_id'],
+          'email_verified' => true
+        )
+      ).to include('email_verified' => true)
+    end
+
+    it 'should patch user_metadata and return the updated user' do
+      expect(
+        client.patch_user(test_user['user_id'], patch_user_body)
+      ).to include(patch_user_body)
     end
   end
 
-  describe '.link_user_account and .unlink_users_account' do
-    let(:email_link) { "#{entity_suffix}#{Faker::Internet.safe_email(Faker::Internet.user_name)}" }
-    let!(:link_user) do
-      sleep 1
-      client.create_user(username,  'email' => email_link,
-                                    'password' => Faker::Internet.password,
-                                    'email_verified' => false,
-                                    'connection' => Auth0::Api::AuthenticationEndpoints::UP_AUTH,
-                                    'app_metadata' => {})
-    end
-    let(:email_primary) { "#{entity_suffix}#{Faker::Internet.safe_email(Faker::Internet.user_name)}" }
-    let!(:primary_user) do
-      sleep 1
-      client.create_user(username,  'email' => email_primary,
-                                    'password' => Faker::Internet.password,
-                                    'email_verified' => false,
-                                    'connection' => Auth0::Api::AuthenticationEndpoints::UP_AUTH,
-                                    'app_metadata' => {})
+  describe '.delete_user', vcr: true do
+    it 'should raise an error when the user_id is missing' do
+      expect { client.delete_user '' }.to raise_error Auth0::MissingUserId
     end
 
-    let(:body_link) { { 'provider' => 'auth0', 'user_id' => link_user['user_id'] } }
+    it 'should delete the user successfully' do
+      expect { client.delete_user test_user['user_id'] }.to_not raise_error
+    end
   end
-
 end

--- a/spec/integration/lib/auth0/auth0_client_spec.rb
+++ b/spec/integration/lib/auth0/auth0_client_spec.rb
@@ -44,12 +44,6 @@ describe Auth0::Client do
     api_version: 2, token: 'token'
   }, Auth0::InvalidApiNamespace
 
-  let(:valid_v1_credentials) do
-    { client_id: ENV['CLIENT_ID'],
-      client_secret: ENV['CLIENT_SECRET'],
-      domain: ENV['DOMAIN'],
-      api_version: 1 }
-  end
   let(:token) { ENV['MASTER_JWT'] }
   let(:v2_credentials) { { domain: ENV['DOMAIN'] } }
 
@@ -57,12 +51,10 @@ describe Auth0::Client do
     it { expect { Auth0Client.new(credentials) }.to_not raise_error }
   end
 
-  it_should_behave_like 'invalid credentials' do
-    let(:credentials) { valid_v1_credentials }
-  end
   it_should_behave_like 'valid credentials' do
     let(:credentials) { v2_credentials.merge(token: token) }
   end
+
   it_should_behave_like 'valid credentials' do
     let(:credentials) { v2_credentials.merge(access_token: ENV['MASTER_JWT']) }
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,13 @@ Dotenv.load
 require 'webmock/rspec'
 WebMock.allow_net_connect!
 
+require 'vcr'
+VCR.configure do |config|
+  config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
+  config.configure_rspec_metadata!
+  config.hook_into :webmock
+end
+
 mode = ENV['MODE'] || 'unit'
 
 $LOAD_PATH.unshift File.expand_path('..', __FILE__)
@@ -19,9 +26,10 @@ Dir['./spec/support/**/*.rb'].each { |f| require f }
 Dir['./spec/support/*.rb'].each { |f| require f }
 
 def entity_suffix
-  (ENV['TRAVIS_JOB_ID'] || ENV['TEST_ENTITY_SUFFIX'] || 'rubytest').delete('_')
+  'rubytest'
 end
 
 puts "Entity suffix is #{entity_suffix}"
+puts "Running in mode #{mode}"
 
 require_relative "spec_helper_#{mode}.rb"

--- a/spec/spec_helper_full.rb
+++ b/spec/spec_helper_full.rb
@@ -13,26 +13,6 @@ RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
   config.include Credentials
-  config.after(:suite) do
-    puts "Cleaning up for #{entity_suffix}"
-    v2_client = Auth0Client.new(
-      token: ENV['MASTER_JWT'], api_version: 2, domain: ENV['DOMAIN']
-    )
-    v2_client
-      .clients
-      .select { |client| client['name'] != 'DefaultApp' && !client['global'] && client['name'].include?(entity_suffix) }
-      .each { |client|
-        sleep 1
-        v2_client.delete_client(client['client_id'])
-      }
-    v2_client
-      .users(q: "email:#{entity_suffix}*", fields: 'user_id', page: 0, per_page: 50)
-      .each { |user|
-        sleep 1
-        v2_client.delete_user(user['user_id'])
-      }
-    puts "Finished cleaning up for #{entity_suffix}"
-  end
 end
 
 def wait(time, increment = 5, elapsed_time = 0, &block)

--- a/spec/support/credentials.rb
+++ b/spec/support/credentials.rb
@@ -2,22 +2,29 @@ module Credentials
   module_function
 
   def v1_creds
-    { client_id: ENV['CLIENT_ID'],
+    {
+      client_id: ENV['CLIENT_ID'],
       client_secret: ENV['CLIENT_SECRET'],
       domain: ENV['DOMAIN'],
-      api_version: 1 }
+      api_version: 1
+    }
   end
 
   def v1_global_creds
-    { client_id: ENV['GLOBAL_CLIENT_ID'],
+    {
+      client_id: ENV['GLOBAL_CLIENT_ID'],
       client_secret: ENV['GLOBAL_CLIENT_SECRET'],
       domain: ENV['DOMAIN'],
-      api_version: 1 }
+      api_version: 1
+    }
   end
 
   def v2_creds
-    { client_id: ENV['CLIENT_ID'],
+    {
+      client_id: ENV['CLIENT_ID'],
+      client_secret: ENV['CLIENT_SECRET'],
       token: ENV['MASTER_JWT'],
-      domain: ENV['DOMAIN'] }
+      domain: ENV['DOMAIN']
+    }
   end
 end


### PR DESCRIPTION
Add [VCR HTTP recording](https://github.com/vcr/vcr) to integration test suite. Specifically:

- Add VCR gem and config
- Add ~7K lines of recorded HTTP requests/responses as YML files
- Refactor all integration tests to add VCR, add expect text, and fix several tests
- Disallow outbound HTTP calls
- Remove cleanup routine for `after(:suite)`
- Fix a handful of bugs in the SDK found while testing