### PR TITLE
Add missing redcarpet dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 group :development do
   gem 'terminal-notifier-guard', require: false unless ENV['TRAVIS']
   gem 'coveralls', require: false
+  gem 'redcarpet', require: false
   gem 'rubocop', require: false
   gem 'yard', require: false
 end


### PR DESCRIPTION
While investigating #135, I noticed that the build requires the
redcarpet gem, otherwise we get the error:

    [error]: Missing 'redcarpet' gem for Markdown formatting. Install it
    with `gem install redcarpet`