### PR TITLE
Add ttl_sec argument to post_email_verification request.

### DIFF
--- a/lib/auth0/api/v2/tickets.rb
+++ b/lib/auth0/api/v2/tickets.rb
@@ -22,7 +22,7 @@ module Auth0
           request_params = {
             user_id: user_id,
             result_url: result_url,
-            ttl_sec: ttl_sec
+            ttl_sec: ttl_sec.is_a?(Integer) ? ttl_sec : nil
           }
           post(path, request_params)
         end

--- a/lib/auth0/api/v2/tickets.rb
+++ b/lib/auth0/api/v2/tickets.rb
@@ -9,16 +9,20 @@ module Auth0
         # @see https://auth0.com/docs/api/v2#!/Tickets/post_email_verification
         # @param user_id [string] The user_id of for which the ticket is to be created.
         # @param result_url [string] The user will be redirected to this endpoint once the ticket is used.
+        # @param ttl_sec [integer] The ticket's lifetime in seconds starting from the moment of creation.
+        # After expiration, the ticket cannot be used to verify the user's email. If not specified or if
+        # you send 0, the Auth0 default lifetime of five days will be applied
         #
         # @return [json] Returns the created ticket url.
-        def post_email_verification(user_id, result_url: nil)
+        def post_email_verification(user_id, result_url: nil, ttl_sec: nil)
           if user_id.to_s.empty?
             raise Auth0::InvalidParameter, 'Must supply a valid user id to post an email verification'
           end
           path = "#{tickets_path}/email-verification"
           request_params = {
             user_id: user_id,
-            result_url: result_url
+            result_url: result_url,
+            ttl_sec: ttl_sec
           }
           post(path, request_params)
         end

--- a/spec/lib/auth0/api/v2/tickets_spec.rb
+++ b/spec/lib/auth0/api/v2/tickets_spec.rb
@@ -7,7 +7,8 @@ describe Auth0::Api::V2::Tickets do
   context '.post_email_verification' do
     it { expect(@instance).to respond_to(:post_email_verification) }
     it 'expect client to send post to /api/v2/tickets/email-verification with body' do
-      expect(@instance).to receive(:post).with('/api/v2/tickets/email-verification', user_id: 'user_id', result_url: nil)
+      expect(@instance).to receive(:post).with('/api/v2/tickets/email-verification', user_id: 'user_id',
+                                                                                     result_url: nil, ttl_sec: nil)
       expect { @instance.post_email_verification('user_id') }.not_to raise_error
     end
     it 'expect client to rasie error when calling with empty body' do

--- a/spec/lib/auth0/api/v2/tickets_spec.rb
+++ b/spec/lib/auth0/api/v2/tickets_spec.rb
@@ -11,12 +11,23 @@ describe Auth0::Api::V2::Tickets do
                                                                                      result_url: nil, ttl_sec: nil)
       expect { @instance.post_email_verification('user_id') }.not_to raise_error
     end
+    it 'expect client to accept integer ttl_sec' do
+      expect(@instance).to receive(:post).with('/api/v2/tickets/email-verification', user_id: 'user_id',
+                                                                                     result_url: nil, ttl_sec: 300)
+      expect { @instance.post_email_verification('user_id', ttl_sec: 300) }.not_to raise_error
+    end
+    it 'expect client to return nil when calling with a non-integer ttl_sec' do
+      expect(@instance).to receive(:post).with('/api/v2/tickets/email-verification', user_id: 'user_id',
+                                                                                     result_url: nil, ttl_sec: nil)
+      expect { @instance.post_email_verification('user_id', ttl_sec: "noninteger") }.not_to raise_error
+    end
     it 'expect client to rasie error when calling with empty body' do
       expect { @instance.post_email_verification(nil) }.to raise_error(
         'Must supply a valid user id to post an email verification'
       )
     end
   end
+
   context '.post_password_change' do
     it { expect(@instance).to respond_to(:post_password_change) }
     it 'expect client to send post to /api/v2/tickets/password-change with body' do


### PR DESCRIPTION
### Changes

Add ttl_sec argument to post_email_verification request. 

### References

The post_email_verification endpoint supports a ttl_sec parameter which this gem does not currently support. See: https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification

### Testing

The tickets spec was adjusted to include the relevant change here. Admittedly this is blind as I couldn't for the life of me figure our how to run the specs. If anyone can point me to some documentation or guide me through this then that would be great - otherwise I assume this is a relatively non-impactful change and shouldn't break anything. 

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
