### PR TITLE
Add refresh token method and unit tests

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -29,22 +29,48 @@ module Auth0
       # Get access and ID tokens using an Authorization Code.
       # @see https://auth0.com/docs/api/authentication#authorization-code
       # @param code [string] The authentication code obtained from /authorize
-      # @param redirect_uri [string] Url to redirect after authorization
-      # @return [json] Returns the access_token and id_token
+      # @param redirect_uri [string] URL to redirect to after authorization.
+      #   Required only if it was set at the GET /authorize endpoint
+      # @param client_id [string] Client ID for the Application
+      # @param client_secret [string] Client Secret for the Application.
+      # @return [AccessToken] Returns the access_token and id_token
       def exchange_auth_code_for_tokens(
         code,
-        redirect_uri,
+        redirect_uri: nil,
         client_id: @client_id,
         client_secret: @client_secret
       )
         raise Auth0::InvalidParameter, 'Must provide an authorization code' if code.to_s.empty?
-        raise Auth0::InvalidParameter, 'Must provide a redirect URI' if redirect_uri.to_s.empty?
         request_params = {
           grant_type:    'authorization_code',
           client_id:     client_id,
           client_secret: client_secret,
           code:          code,
           redirect_uri:  redirect_uri
+        }
+        AccessToken.from_response post('/oauth/token', request_params)
+      end
+
+      # Get access and ID tokens using a refresh token.
+      # @see https://auth0.com/docs/api/authentication#refresh-token
+      # @param refresh_token [string] Refresh token to use. Request this with
+      #   the offline_access scope when logging in.
+      # @param client_id [string] Client ID for the Application
+      # @param client_secret [string] Client Secret for the Application.
+      #   Required when the Application's Token Endpoint Authentication Method
+      #   is Post or Basic.
+      # @return [AccessToken] Returns tokens allowed in the refresh_token
+      def exchange_refresh_token(
+        refresh_token,
+        client_id: @client_id,
+        client_secret: @client_secret
+      )
+        raise Auth0::InvalidParameter, 'Must provide a refresh token' if refresh_token.to_s.empty?
+        request_params = {
+          grant_type:    'refresh_token',
+          client_id:     client_id,
+          client_secret: client_secret,
+          refresh_token:  refresh_token
         }
         AccessToken.from_response post('/oauth/token', request_params)
       end
@@ -66,7 +92,7 @@ module Auth0
       end
 
       # Get access and ID tokens using an Authorization Code.
-      # TODO: Deprecate, use the auth_code_exchange method in this module instead.
+      # TODO: Deprecate, use the exchange_auth_code_for_tokens method in this module instead.
       # @see https://auth0.com/docs/api/authentication#authorization-code
       # @param code [string] The access code obtained through passive authentication
       # @param redirect_uri [string] Url to redirect after authorization

--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -67,10 +67,10 @@ module Auth0
       )
         raise Auth0::InvalidParameter, 'Must provide a refresh token' if refresh_token.to_s.empty?
         request_params = {
-          grant_type:    'refresh_token',
-          client_id:     client_id,
+          grant_type: 'refresh_token',
+          client_id: client_id,
           client_secret: client_secret,
-          refresh_token:  refresh_token
+          refresh_token: refresh_token
         }
         AccessToken.from_response post('/oauth/token', request_params)
       end

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -91,17 +91,17 @@ describe Auth0::Api::AuthenticationEndpoints do
   end
 
 
-  context '.auth_code_exchange' do
+  context '.exchange_auth_code_for_tokens' do
     it { is_expected.to respond_to(:exchange_auth_code_for_tokens) }
 
-    it 'is expected to make post request to /oauth/token' do
+    it 'is expected to make post request to /oauth/token with default params' do
       allow(@instance).to receive(:post).with(
         '/oauth/token',
         client_id: @instance.client_id,
         client_secret: @instance.client_secret,
         grant_type: 'authorization_code',
         code: '__test_auth_code__',
-        redirect_uri: '__test_redirect_uri__'
+        redirect_uri: nil
       ).and_return('access_token' => 'AccessToken')
 
       is_expected.to receive(:post).with(
@@ -110,27 +110,110 @@ describe Auth0::Api::AuthenticationEndpoints do
         client_secret: @instance.client_secret,
         grant_type: 'authorization_code',
         code: '__test_auth_code__',
+        redirect_uri: nil
+      )
+
+      expect(
+        @instance.exchange_auth_code_for_tokens(
+          '__test_auth_code__'
+        )['access_token']
+      ).to eq 'AccessToken'
+    end
+
+    it 'is expected to make post request to /oauth/token with custom params' do
+      allow(@instance).to receive(:post).with(
+        '/oauth/token',
+        grant_type: 'authorization_code',
+        client_id: '_test_custom_client_id__',
+        client_secret: '_test_custom_client_secret__',
+        code: '__test_auth_code__',
+        redirect_uri: '__test_redirect_uri__'
+      ).and_return('access_token' => 'AccessToken')
+
+      is_expected.to receive(:post).with(
+        '/oauth/token',
+        grant_type: 'authorization_code',
+        client_id: '_test_custom_client_id__',
+        client_secret: '_test_custom_client_secret__',
+        code: '__test_auth_code__',
         redirect_uri: '__test_redirect_uri__'
       )
 
       expect(
         @instance.exchange_auth_code_for_tokens(
           '__test_auth_code__',
-          '__test_redirect_uri__'
+          redirect_uri: '__test_redirect_uri__',
+          client_id: '_test_custom_client_id__',
+          client_secret: '_test_custom_client_secret__'
         )['access_token']
       ).to eq 'AccessToken'
     end
 
     it 'is expected to raise an error when the code is empty' do
       expect do
-        @instance.exchange_auth_code_for_tokens('', '')
+        @instance.exchange_auth_code_for_tokens(nil)
       end.to raise_error 'Must provide an authorization code'
     end
+  end
 
-    it 'is expected to raise an error when the URI is empty' do
+  context '.exchange_refresh_token' do
+    it { is_expected.to respond_to(:exchange_refresh_token) }
+
+    it 'is expected to make post request to /oauth/token with default params' do
+      allow(@instance).to receive(:post).with(
+        '/oauth/token',
+        grant_type: 'refresh_token',
+        client_id: @instance.client_id,
+        client_secret: @instance.client_secret,
+        refresh_token: '__test_refresh_token__'
+      ).and_return('access_token' => 'AccessToken')
+
+      is_expected.to receive(:post).with(
+        '/oauth/token',
+        grant_type: 'refresh_token',
+        client_id: @instance.client_id,
+        client_secret: @instance.client_secret,
+        refresh_token: '__test_refresh_token__'
+      )
+
+      expect(
+        @instance.exchange_refresh_token(
+          '__test_refresh_token__'
+        )['access_token']
+      ).to eq 'AccessToken'
+    end
+
+
+    it 'is expected to make post request to /oauth/token with custom params' do
+      allow(@instance).to receive(:post).with(
+        '/oauth/token',
+        grant_type: 'refresh_token',
+        client_id: '_test_custom_client_id__',
+        client_secret: '_test_custom_client_secret__',
+        refresh_token: '__test_refresh_token__'
+      ).and_return('access_token' => 'AccessToken')
+
+      is_expected.to receive(:post).with(
+        '/oauth/token',
+        grant_type: 'refresh_token',
+        client_id: '_test_custom_client_id__',
+        client_secret: '_test_custom_client_secret__',
+        refresh_token: '__test_refresh_token__'
+      )
+
+      expect(
+        @instance.exchange_refresh_token(
+          '__test_refresh_token__',
+          client_id: '_test_custom_client_id__',
+          client_secret: '_test_custom_client_secret__'
+        )['access_token']
+      ).to eq 'AccessToken'
+    end
+
+    it 'is expected to raise an error when the refresh_token is empty' do
       expect do
-        @instance.exchange_auth_code_for_tokens('code', '')
-      end.to raise_error 'Must provide a redirect URI'
+        @instance.exchange_refresh_token(nil)
+      end.to raise_error 'Must provide a refresh token'
     end
   end
 


### PR DESCRIPTION
### Changes

- Add `Auth0::Api::AuthenticationEndpoints.exchange_refresh_token` method.
- Remove requirement for `:redirect_uri` param in the `exchange_auth_code_for_tokens`method

### References

Closes #111 

### Testing

Also add a test for `exchange_auth_code_for_tokens` with custom params. 

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage (currently no integration tests for tokens)
* [x] This change has been tested on the latest version of Ruby (ruby-2.5.1)

### Checklist

* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed
