### PR TITLE
Formal deprecation of 4 auth endpoint methods; rubocop

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -41,12 +41,13 @@ module Auth0
         client_secret: @client_secret
       )
         raise Auth0::InvalidParameter, 'Must provide an authorization code' if code.to_s.empty?
+
         request_params = {
-          grant_type:    'authorization_code',
-          client_id:     client_id,
+          grant_type: 'authorization_code',
+          client_id: client_id,
           client_secret: client_secret,
-          code:          code,
-          redirect_uri:  redirect_uri
+          code: code,
+          redirect_uri: redirect_uri
         }
         AccessToken.from_response post('/oauth/token', request_params)
       end
@@ -66,6 +67,7 @@ module Auth0
         client_secret: @client_secret
       )
         raise Auth0::InvalidParameter, 'Must provide a refresh token' if refresh_token.to_s.empty?
+
         request_params = {
           grant_type: 'refresh_token',
           client_id: client_id,
@@ -75,45 +77,7 @@ module Auth0
         AccessToken.from_response post('/oauth/token', request_params)
       end
 
-      # Retrieve an access token.
-      # TODO: Deprecate, use the api_token method in this module instead.
-      # @see https://auth0.com/docs/api/authentication#client-credentials
-      # @param access_token [string] Social provider's access_token
-      # @param connection [string] Currently, this endpoint only works for Facebook, Google, Twitter and Weibo
-      # @return [json] Returns the access token
-      def obtain_access_token(access_token = nil, connection = 'facebook', scope = 'openid')
-        if access_token
-          request_params = { client_id: @client_id, access_token: access_token, connection: connection, scope: scope }
-          post('/oauth/access_token', request_params)['access_token']
-        else
-          request_params = { client_id: @client_id, client_secret: @client_secret, grant_type: 'client_credentials' }
-          post('/oauth/token', request_params)['access_token']
-        end
-      end
-
-      # Get access and ID tokens using an Authorization Code.
-      # TODO: Deprecate, use the exchange_auth_code_for_tokens method in this module instead.
-      # @see https://auth0.com/docs/api/authentication#authorization-code
-      # @param code [string] The access code obtained through passive authentication
-      # @param redirect_uri [string] Url to redirect after authorization
-      # @param connection [string] Currently, this endpoint only works for Facebook, Google, Twitter and Weibo
-      # @param scope [string] Defaults to openid. Can be 'openid name email', 'openid offline_access'
-      # @return [json] Returns the access_token and id_token
-      def obtain_user_tokens(code, redirect_uri, connection = 'facebook', scope = 'openid')
-        raise Auth0::InvalidParameter, 'Must supply a valid code' if code.to_s.empty?
-        raise Auth0::InvalidParameter, 'Must supply a valid redirect_uri' if redirect_uri.to_s.empty?
-        request_params = {
-          client_id:     @client_id,
-          client_secret: @client_secret,
-          connection:    connection,
-          grant_type:    'authorization_code',
-          code:          code,
-          scope:         scope,
-          redirect_uri:  redirect_uri
-        }
-        post('/oauth/token', request_params)
-      end
-
+      # rubocop:disable Metrics/ParameterLists
       # Get access and ID tokens using Resource Owner Password.
       # Requires that your tenant has a Default Audience or Default Directory.
       # @see https://auth0.com/docs/api/authentication#resource-owner-password
@@ -136,49 +100,23 @@ module Auth0
         audience: nil,
         scope: 'openid'
       )
-        raise Auth0::InvalidParameter,
-              'Must supply a valid login_name' if login_name.empty?
-        raise Auth0::InvalidParameter,
-              'Must supply a valid password' if password.empty?
+
+        raise Auth0::InvalidParameter, 'Must supply a valid login_name' if login_name.empty?
+        raise Auth0::InvalidParameter, 'Must supply a valid password' if password.empty?
+
         request_params = {
-          username:      login_name,
-          password:      password,
-          client_id:     client_id,
+          username: login_name,
+          password: password,
+          client_id: client_id,
           client_secret: client_secret,
-          realm:         realm,
-          scope:         scope,
-          audience:      audience,
-          grant_type:    realm ? 'http://auth0.com/oauth/grant-type/password-realm' : 'password'
+          realm: realm,
+          scope: scope,
+          audience: audience,
+          grant_type: realm ? 'http://auth0.com/oauth/grant-type/password-realm' : 'password'
         }
         AccessToken.from_response post('/oauth/token', request_params)
       end
-
-      # Get access and ID tokens using Resource Owner Password.
-      # TODO: Deprecate, use the login_with_resource_owner method in this module instead.
-      # @see https://auth0.com/docs/api/authentication#resource-owner-password
-      # @param username [string] Username or email
-      # @param password [string] Password
-      # @param id_token [string] Token's id
-      # @param connection_name [string] Connection name; use a database or
-      #    passwordless connection, Active Directory/LDAP, Windows Azure or ADF
-      # @param options [hash] Additional options - :scope, :grant_type, :device
-      # @return [json] Returns the access_token and id_token
-      def login(username, password, id_token = nil, connection_name = UP_AUTH, options = {})
-        raise Auth0::InvalidParameter, 'Must supply a valid username' if username.to_s.empty?
-        raise Auth0::InvalidParameter, 'Must supply a valid password' if password.to_s.empty?
-        request_params = {
-          client_id:     @client_id,
-          client_secret: @client_secret,
-          username:      username,
-          password:      password,
-          scope:         options.fetch(:scope, 'openid'),
-          connection:    connection_name,
-          grant_type:    options.fetch(:grant_type, 'password'),
-          id_token:      id_token,
-          device:        options.fetch(:device, nil)
-        }
-        post('/oauth/token', request_params)
-      end
+      # rubocop:enable Metrics/ParameterLists
 
       # Sign up with a database connection using a username and password.
       # @see https://auth0.com/docs/api/authentication#signup
@@ -189,11 +127,12 @@ module Auth0
       def signup(email, password, connection_name = UP_AUTH)
         raise Auth0::InvalidParameter, 'Must supply a valid email' if email.to_s.empty?
         raise Auth0::InvalidParameter, 'Must supply a valid password' if password.to_s.empty?
+
         request_params = {
-          email:      email,
-          password:   password,
+          email: email,
+          password: password,
           connection: connection_name,
-          client_id:  @client_id
+          client_id: @client_id
         }
         post('/dbconnections/signup', request_params)
       end
@@ -207,11 +146,12 @@ module Auth0
       # @param connection_name [string] Database connection name
       def change_password(email, password, connection_name = UP_AUTH)
         raise Auth0::InvalidParameter, 'Must supply a valid email' if email.to_s.empty?
+
         request_params = {
-          email:      email,
-          password:   password,
+          email: email,
+          password: password,
           connection: connection_name,
-          client_id:  @client_id
+          client_id: @client_id
         }
         post('/dbconnections/change_password', request_params)
       end
@@ -224,12 +164,13 @@ module Auth0
       # @param auth_params [hash] Append or override the magic link parameters
       def start_passwordless_email_flow(email, send = 'link', auth_params = {})
         raise Auth0::InvalidParameter, 'Must supply a valid email' if email.to_s.empty?
+
         request_params = {
-          email:       email,
-          send:        send,
-          authParams:  auth_params,
-          connection:  'email',
-          client_id:   @client_id
+          email: email,
+          send: send,
+          authParams: auth_params,
+          connection: 'email',
+          client_id: @client_id
         }
         post('/passwordless/start', request_params)
       end
@@ -240,10 +181,11 @@ module Auth0
       # @param phone_number [string] User's phone number.
       def start_passwordless_sms_flow(phone_number)
         raise Auth0::InvalidParameter, 'Must supply a valid phone number' if phone_number.to_s.empty?
+
         request_params = {
           phone_number: phone_number,
-          connection:   'sms',
-          client_id:    @client_id
+          connection: 'sms',
+          client_id: @client_id
         }
         post('/passwordless/start', request_params)
       end
@@ -266,15 +208,7 @@ module Auth0
       # @see https://auth0.com/docs/api/authentication#get-user-info
       # @return [json] User information based on the Auth0 access token
       def userinfo(access_token)
-        get('/userinfo', {}, {'Authorization' => "Bearer #{access_token}"})
-      end
-
-      # Return the user information based on the Auth0 access token.
-      # TODO: Deprecate, use the userinfo method in this module instead.
-      # @see https://auth0.com/docs/api/authentication#get-user-info
-      # @return [json] User information based on the Auth0 access token
-      def user_info
-        get('/userinfo')
+        get('/userinfo', {}, 'Authorization' => "Bearer #{access_token}")
       end
 
       # Return an authorization URL.
@@ -284,6 +218,7 @@ module Auth0
       # @return [url] Authorization URL.
       def authorization_url(redirect_uri, options = {})
         raise Auth0::InvalidParameter, 'Must supply a valid redirect_uri' if redirect_uri.to_s.empty?
+
         request_params = {
           client_id: @client_id,
           response_type: options.fetch(:response_type, 'code'),
@@ -343,7 +278,7 @@ module Auth0
           wreply: options[:wreply]
         }
 
-        url_client_id = @client_id if !request_params[:wtrealm]
+        url_client_id = @client_id unless request_params[:wtrealm]
         URI::HTTPS.build(
           host: @domain,
           path: "/wsfed/#{url_client_id}",
@@ -355,6 +290,82 @@ module Auth0
       # DEPRECATED
       #
 
+      # Retrieve an access token.
+      # @deprecated 4.6.0 - Use the api_token method instead.
+      # @see https://auth0.com/docs/api/authentication#client-credentials
+      # @param access_token [string] Social provider's access_token
+      # @param connection [string] Currently, this endpoint only works for Facebook, Google, Twitter and Weibo
+      # @return [json] Returns the access token
+      def obtain_access_token(access_token = nil, connection = 'facebook', scope = 'openid')
+        if access_token
+          request_params = { client_id: @client_id, access_token: access_token, connection: connection, scope: scope }
+          post('/oauth/access_token', request_params)['access_token']
+        else
+          request_params = { client_id: @client_id, client_secret: @client_secret, grant_type: 'client_credentials' }
+          post('/oauth/token', request_params)['access_token']
+        end
+      end
+
+      # Get access and ID tokens using an Authorization Code.
+      # @deprecated 4.6.0 - Use the exchange_auth_code_for_tokens method instead.
+      # @see https://auth0.com/docs/api/authentication#authorization-code
+      # @param code [string] The access code obtained through passive authentication
+      # @param redirect_uri [string] Url to redirect after authorization
+      # @param connection [string] Currently, this endpoint only works for Facebook, Google, Twitter and Weibo
+      # @param scope [string] Defaults to openid. Can be 'openid name email', 'openid offline_access'
+      # @return [json] Returns the access_token and id_token
+      def obtain_user_tokens(code, redirect_uri, connection = 'facebook', scope = 'openid')
+        raise Auth0::InvalidParameter, 'Must supply a valid code' if code.to_s.empty?
+        raise Auth0::InvalidParameter, 'Must supply a valid redirect_uri' if redirect_uri.to_s.empty?
+
+        request_params = {
+          client_id: @client_id,
+          client_secret: @client_secret,
+          connection: connection,
+          grant_type: 'authorization_code',
+          code: code,
+          scope: scope,
+          redirect_uri: redirect_uri
+        }
+        post('/oauth/token', request_params)
+      end
+
+      # Get access and ID tokens using Resource Owner Password.
+      # @deprecated 4.6.0 - Use the login_with_resource_owner method instead.
+      # @see https://auth0.com/docs/api/authentication#resource-owner-password
+      # @param username [string] Username or email
+      # @param password [string] Password
+      # @param id_token [string] Token's id
+      # @param connection_name [string] Connection name; use a database or
+      #    passwordless connection, Active Directory/LDAP, Windows Azure or ADF
+      # @param options [hash] Additional options - :scope, :grant_type, :device
+      # @return [json] Returns the access_token and id_token
+      def login(username, password, id_token = nil, connection_name = UP_AUTH, options = {})
+        raise Auth0::InvalidParameter, 'Must supply a valid username' if username.to_s.empty?
+        raise Auth0::InvalidParameter, 'Must supply a valid password' if password.to_s.empty?
+
+        request_params = {
+          client_id: @client_id,
+          client_secret: @client_secret,
+          username: username,
+          password: password,
+          scope: options.fetch(:scope, 'openid'),
+          connection: connection_name,
+          grant_type: options.fetch(:grant_type, 'password'),
+          id_token: id_token,
+          device: options.fetch(:device, nil)
+        }
+        post('/oauth/token', request_params)
+      end
+
+      # Return the user information based on the Auth0 access token.
+      # @deprecated 4.6.0 - Use the userinfo method instead.
+      # @see https://auth0.com/docs/api/authentication#get-user-info
+      # @return [json] User information based on the Auth0 access token
+      def user_info
+        get('/userinfo')
+      end
+
       # Login using phone number + verification code.
       # @deprecated 4.5.0 - Legacy authentication pipeline; use a Password Grant
       #   instead - https://auth0.com/docs/api-auth/tutorials/password-grant
@@ -365,11 +376,12 @@ module Auth0
       def phone_login(phone_number, code, scope = 'openid')
         raise Auth0::InvalidParameter, 'Must supply a valid phone number' if phone_number.to_s.empty?
         raise Auth0::InvalidParameter, 'Must supply a valid code' if code.to_s.empty?
+
         request_params = {
-          client_id:  @client_id,
-          username:   phone_number,
-          password:   code,
-          scope:      scope,
+          client_id: @client_id,
+          username: phone_number,
+          password: code,
+          scope: scope,
           connection: 'sms',
           grant_type: 'password'
         }
@@ -383,6 +395,7 @@ module Auth0
       # @return User information associated with the user id (sub property) of the token.
       def token_info(id_token)
         raise Auth0::InvalidParameter, 'Must supply a valid id_token' if id_token.to_s.empty?
+
         request_params = { id_token: id_token }
         post('/tokeninfo', request_params)
       end
@@ -400,13 +413,14 @@ module Auth0
       # @return [json] Returns the refreshed delegation token
       def refresh_delegation(refresh_token, target, scope = 'openid', api_type = 'app', extra_parameters = {})
         raise Auth0::InvalidParameter, 'Must supply a valid token to refresh' if refresh_token.to_s.empty?
+
         request_params = {
-          client_id:      @client_id,
-          grant_type:     JWT_BEARER,
-          refresh_token:  refresh_token,
-          target:         target,
-          api_type:       api_type,
-          scope:          scope
+          client_id: @client_id,
+          grant_type: JWT_BEARER,
+          refresh_token: refresh_token,
+          target: target,
+          api_type: api_type,
+          scope: scope
         }.merge(extra_parameters)
         post('/delegation', request_params)
       end
@@ -424,13 +438,14 @@ module Auth0
       # @return [json] Returns the refreshed delegation token
       def delegation(id_token, target, scope = 'openid', api_type = 'app', extra_parameters = {})
         raise Auth0::InvalidParameter, 'Must supply a valid id_token' if id_token.to_s.empty?
+
         request_params = {
-          client_id:  @client_id,
+          client_id: @client_id,
           grant_type: JWT_BEARER,
-          id_token:   id_token,
-          target:     target,
-          api_type:   api_type,
-          scope:      scope
+          id_token: id_token,
+          target: target,
+          api_type: api_type,
+          scope: scope
         }.merge(extra_parameters)
         post('/delegation', request_params)
       end
@@ -449,16 +464,17 @@ module Auth0
         raise Auth0::InvalidParameter, 'Must supply a valid app_client_id' if app_client_id.to_s.empty?
         raise Auth0::InvalidParameter, 'Must supply a valid impersonator_id' if impersonator_id.to_s.empty?
         raise Auth0::MissingParameter, 'Must supply client_secret' if @client_secret.nil?
+
         authorization_header obtain_access_token
         request_params = {
-          protocol:         options.fetch(:protocol, 'oauth2'),
-          impersonator_id:  impersonator_id,
-          client_id:        app_client_id,
+          protocol: options.fetch(:protocol, 'oauth2'),
+          impersonator_id: impersonator_id,
+          client_id: app_client_id,
           additionalParameters: {
-            response_type:  options.fetch(:response_type, 'code'),
-            state:          options.fetch(:state, ''),
-            scope:          options.fetch(:scope, 'openid'),
-            callback_url:   options.fetch(:callback_url, '')
+            response_type: options.fetch(:response_type, 'code'),
+            state: options.fetch(:state, ''),
+            scope: options.fetch(:scope, 'openid'),
+            callback_url: options.fetch(:callback_url, '')
           }
         }
         result = post("/users/#{user_id}/impersonate", request_params)
@@ -476,8 +492,9 @@ module Auth0
       def unlink_user(access_token, user_id)
         raise Auth0::InvalidParameter, 'Must supply a valid access_token' if access_token.to_s.empty?
         raise Auth0::InvalidParameter, 'Must supply a valid user_id' if user_id.to_s.empty?
+
         request_params = {
-          access_token:  access_token,
+          access_token: access_token,
           user_id: user_id
         }
         post('/unlink', request_params)


### PR DESCRIPTION
### Changes

- Add deprecation notices on the following methods:
  - `Auth0::Api::AuthenticationEndpoints.obtain_access_token`
  - `Auth0::Api::AuthenticationEndpoints.obtain_user_tokens`
  - `Auth0::Api::AuthenticationEndpoints.login`
  - `Auth0::Api::AuthenticationEndpoints.user_info`
- Ran `rubocop` in `Auth0::Api::AuthenticationEndpoints` and fixed issues
