### PR TITLE
Get all resource servers

### DIFF
--- a/lib/auth0/api/v2/resource_servers.rb
+++ b/lib/auth0/api/v2/resource_servers.rb
@@ -5,6 +5,20 @@ module Auth0
       module ResourceServers
         attr_reader :resource_servers_path
 
+        # Retrieves a list of all resource servers.
+        # @see https://auth0.com/docs/api/management/v2#!/Resource_servers/get_resource_servers
+        # @param page [int] Page number to get, 0-based.
+        # @param per_page [int] Results per page if also passing a page number.
+        # @return [json] Returns the resource servers.
+        def resource_servers(page: nil, per_page: nil)
+          request_params = {
+            page: !page.nil? ? page.to_i : nil,
+            per_page: !page.nil? && !per_page.nil? ? per_page.to_i : nil
+          }
+          get(resource_servers_path, request_params)
+        end
+        alias get_resource_servers resource_servers
+
         # Retrieves a resource server by its ID.
         # @see https://auth0.com/docs/api/management/v2#!/Resource_Servers/get_resource_servers_by_id
         # @param resource_server_id [string] The id of the resource server to retrieve.

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/_delete_resource_server/should_delete_the_test_server_without_an_error.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/_delete_resource_server/should_delete_the_test_server_without_an_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers/5bb7c2988dfaba46c47a9918
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers/5c464b0acb6332081b45f804
     body:
       encoding: US-ASCII
       string: ''
@@ -12,13 +12,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.3.1
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      - Bearer API_TOKEN
       Host:
       - auth0-sdk-tests.auth0.com
   response:
@@ -27,7 +27,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 05 Oct 2018 19:59:22 GMT
+      - Mon, 21 Jan 2019 22:43:23 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
@@ -35,9 +35,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '9'
+      - '5'
       X-Ratelimit-Reset:
-      - '1538769564'
+      - '1548110607'
       Vary:
       - origin,accept-encoding
       Cache-Control:
@@ -50,5 +50,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 05 Oct 2018 19:59:22 GMT
+  recorded_at: Mon, 21 Jan 2019 22:43:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/_resource_server/should_get_the_test_server.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/_resource_server/should_get_the_test_server.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers/5bb7c2988dfaba46c47a9918
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers/5c464b0acb6332081b45f804
     body:
       encoding: US-ASCII
       string: ''
@@ -12,13 +12,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.3.1
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      - Bearer API_TOKEN
       Host:
       - auth0-sdk-tests.auth0.com
   response:
@@ -27,7 +27,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 05 Oct 2018 19:59:22 GMT
+      - Mon, 21 Jan 2019 22:43:23 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -37,9 +37,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '9'
+      - '6'
       X-Ratelimit-Reset:
-      - '1538769563'
+      - '1548110606'
       Vary:
       - origin,accept-encoding
       Cache-Control:
@@ -53,12 +53,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA12Py07DMBBF/8VrIA+S5rGrEELdoIpWAlaW7YyTIa4d2UOr
-        gvh3pmwqsZyZc0fnfgscRC9qrRtTdm07WKVVtTJVo7quaMWN8OoATOwh0Q7i
-        EeJt/NRn4pGPOIAntAiRkYloSX2WuWCUm0KiuwuVqQWzY5ExnXD06EeZwEQg
-        Tnxsh2LI9696bJbnDrfmbaB3etxsntZz/TUdHpBTyrlwksFahx6kMgZSEr1V
-        LgG/nHGRJvjEHtKGKFmQfZR2IC3GRHJRkc7SOGTimqMwg5cOLRBe+hXlfVWv
-        /u//Pp5Ai74p8/xaQLmR7V92Zb0SP7/OQVooQwEAAA==
+        H4sIAAAAAAAAA12Py04DMQxF/yVrYDLPltlVCKFuUEUrAasoyTgzpmkySkyrgvh3XDaVWNo+1zr3W+AgetHapmuM1NZ0dV3JZWma1i1lI25E0AdgYgeZtpCOkG7TpzkTj3zEAQKhQ0iMTERz7ovCR6v9FDPdXahCz1gcy4LpjGPAMKoMNgFx4mMzlIPcvZpxMT/f48a+DfROj+v102rffk2HB+SU9j6eVHTOYwClrYWcRe+0z8Av9zgrG0NmD+ViUizIPtp4UA5TJjXrRGdlPTJxzVHcQ1AeHRBe+pVV3bTd//3fxxMY0S8qKa8FtB/Z/mVbtZ34+QU3bsrIQwEAAA==
     http_version: 
-  recorded_at: Fri, 05 Oct 2018 19:59:22 GMT
+  recorded_at: Mon, 21 Jan 2019 22:43:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/_resource_servers/should_get_the_test_server.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/_resource_servers/should_get_the_test_server.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Jan 2019 22:43:23 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1548110605'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA72YbW/jKBDHvwry67Z5Tpu866WrqrrrqdpmdXdaVQhjnLAhxjI4VW/V774YQ+PYHjt7Wl1fpZ6Zn5k/Ax74+j3gUbAMZmQ8Jzezm1G4mFyTWTSaTUfD4XQRXAQJ2TPjcZvr7RA9koRs2J4lGt0+PRgrj8xvHnOWGZ+t1qlaDgak8L1U0e5SM6XVlf3/isr9gKR8cBgPTCARQr5iGceCJwwTSplSwTImQrGLQO14iqlMlIHjWGb4wDLzEhIKhmOeKY1Tkuk3TAU3Hsc4LXcswYLHTPNi1KPr+XQ4rD+3xFcWBsvrcWFVfJPwZIOJ2JgkPj+PZ3MzQEVlygz66/cgYopmPNVcJoUDIxFa2Tej+4wU778IDkTkhUyZMS7LYeFNaXy/qBNWxkszkEGtuZdyxwTroETW3Ev5kkZdY8mtuZdiNfmiWNbQIrcPwffWY9z7oCiXcz3K5QpFOb3rUU5nKOqYE7pNU/TINDFjI60JYpKmeO89urOFaNXU+3hVHSBeVZQ+XlUhiFeV6yd4aM3pjrUVeEHC2lkB/VduhbeusN56Biu5dz2BK6l3PYMruSdH9Dt7g3aSXWHqW7u1+NOVCxBO95Aa4XQHAQine1mNcLqTAYRSA5kkjBZPmhpUTLAGrfFeg06C16CV4DXoJHgNWgleg06C1eAzUzLPKEPPLDu0bKWZs2Pl7KAaHSQnyRksp0sHy4lzBssp1MFyMp3BslrdsQM3HMO1DYj5/NfViqwHphUPUK9OmlPsLJ7TrJPnVDuL53Tr5DnlzuKVdZYL1iwu+xCuqFqMLyMgytdOLcoXDBDlq6QW5UsDiDrmVKzAmG/acyv6SWvszrGFUc21g1LNuYVSzb2DYrP5tCdcoKdMHkx/ndXTYYUVp94K5gNSXEK9HJcRyHEp9XLcvIIcN8G9nN8EoTvBlUbroqGvqht601KXJkDZZ02a3YSyD4GINUtM02t2LK3NIaERq63ZbFfODM4GzHHT0U+y4/lDNgchJOz/vOVMRM2c3WNwtppxbprgSFcvzUhXKHCk1yjjm03r90p7CzRLzchyenribIfaforrO3i1h7pUu09K9znJIk4SFBOqpWm5y/0gz4j1qg/EeWPnDetX5zZ1PIN1OkKWZFKIfVsT/sGq+oBy9RC9bucxXY0enZA7RyBztv94VbN2W/B9J5DyTPRw94R0fdP5OP9hHqUY3HjcYFOi1KvMIkS3jO7MEkffZNiyvryf+Uo4R2wcQWFVOxiRJEJECMSNKL6rahH87LdZMWiutNyjSJqtOqmVbbNxt87YOcOVcS7U9+J92JUDMJSw1xq9pTHvw9nE7bcJabZPhQlqpFp+uo5muGJBzslHsIvk1jpMOvm8d5FsZo+50LzcDVBxyVc0j9Rqj1IpOOXNbPcxwR82cIA/B3aD7kHbEZuV29K/ys6esh7je0ogylVmPcr3cECUS7we5fvHMurlIuAKqzdlZiYw36ecFaDyFjYs/uZjNmGT0WK8oAtyPR9F9HgLu2am+VmVFd1xARtmudnTrqjIw0FZ3+XN6+jX37wWCTQvXm9+yb2rF7C4RV7a58Z+KvktKoyoNL6/HKWk0/k0HBIazieT8fBmFE5n8c1weipleQy9zPLwrcBAcgpJidhKpa8Kr4qUPgPFTD1pE/HtKRpFw/Vf4eY6/XPBn+jfkf5Hf3p4uL/dzf7d7lf8f7v6Hk+ms/l/mYL3lx+kYCIRFhgAAA==
+    http_version: 
+  recorded_at: Mon, 21 Jan 2019 22:43:23 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/_resource_servers/should_return_at_least_1_result.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/_resource_servers/should_return_at_least_1_result.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Jan 2019 22:43:22 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1548110604'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA72YbW/jKBDHvwry67Z5Tpu866WrqrrrqdpmdXdaVQhjnLAhxjI4VW/V774YQ+PYHjt7Wl1fpZ6Zn5k/Ax74+j3gUbAMZmQ8Jzezm1G4mFyTWTSaTUfD4XQRXAQJ2TPjcZvr7RA9koRs2J4lGt0+PRgrj8xvHnOWGZ+t1qlaDgak8L1U0e5SM6XVlf3/isr9gKR8cBgPTCARQr5iGceCJwwTSplSwTImQrGLQO14iqlMlIHjWGb4wDLzEhIKhmOeKY1Tkuk3TAU3Hsc4LXcswYLHTPNi1KPr+XQ4rD+3xFcWBsvrcWFVfJPwZIOJ2JgkPj+PZ3MzQEVlygz66/cgYopmPNVcJoUDIxFa2Tej+4wU778IDkTkhUyZMS7LYeFNaXy/qBNWxkszkEGtuZdyxwTroETW3Ev5kkZdY8mtuZdiNfmiWNbQIrcPwffWY9z7oCiXcz3K5QpFOb3rUU5nKOqYE7pNU/TINDFjI60JYpKmeO89urOFaNXU+3hVHSBeVZQ+XlUhiFeV6yd4aM3pjrUVeEHC2lkB/VduhbeusN56Biu5dz2BK6l3PYMruSdH9Dt7g3aSXWHqW7u1+NOVCxBO95Aa4XQHAQine1mNcLqTAYRSA5kkjBZPmhpUTLAGrfFeg06C16CV4DXoJHgNWgleg06C1eAzUzLPKEPPLDu0bKWZs2Pl7KAaHSQnyRksp0sHy4lzBssp1MFyMp3BslrdsQM3HMO1DYj5/NfViqwHphUPUK9OmlPsLJ7TrJPnVDuL53Tr5DnlzuKVdZYL1iwu+xCuqFqMLyMgytdOLcoXDBDlq6QW5UsDiDrmVKzAmG/acyv6SWvszrGFUc21g1LNuYVSzb2DYrP5tCdcoKdMHkx/ndXTYYUVp94K5gNSXEK9HJcRyHEp9XLcvIIcN8G9nN8EoTvBlUbroqGvqht601KXJkDZZ02a3YSyD4GINUtM02t2LK3NIaERq63ZbFfODM4GzHHT0U+y4/lDNgchJOz/vOVMRM2c3WNwtppxbprgSFcvzUhXKHCk1yjjm03r90p7CzRLzchyenribIfaforrO3i1h7pUu09K9znJIk4SFBOqpWm5y/0gz4j1qg/EeWPnDetX5zZ1PIN1OkKWZFKIfVsT/sGq+oBy9RC9bucxXY0enZA7RyBztv94VbN2W/B9J5DyTPRw94R0fdP5OP9hHqUY3HjcYFOi1KvMIkS3jO7MEkffZNiyvryf+Uo4R2wcQWFVOxiRJEJECMSNKL6rahH87LdZMWiutNyjSJqtOqmVbbNxt87YOcOVcS7U9+J92JUDMJSw1xq9pTHvw9nE7bcJabZPhQlqpFp+uo5muGJBzslHsIvk1jpMOvm8d5FsZo+50LzcDVBxyVc0j9Rqj1IpOOXNbPcxwR82cIA/B3aD7kHbEZuV29K/ys6esh7je0ogylVmPcr3cECUS7we5fvHMurlIuAKqzdlZiYw36ecFaDyFjYs/uZjNmGT0WK8oAtyPR9F9HgLu2am+VmVFd1xARtmudnTrqjIw0FZ3+XN6+jX37wWCTQvXm9+yb2rF7C4RV7a58Z+KvktKoyoNL6/HKWk0/k0HBIazieT8fBmFE5n8c1weipleQy9zPLwrcBAcgpJidhKpa8Kr4qUPgPFTD1pE/HtKRpFw/Vf4eY6/XPBn+jfkf5Hf3p4uL/dzf7d7lf8f7v6Hk+ms/l/mYL3lx+kYCIRFhgAAA==
+    http_version: 
+  recorded_at: Mon, 21 Jan 2019 22:43:22 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/_resource_servers/should_return_the_first_page_of_one_result.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/_resource_servers/should_return_the_first_page_of_one_result.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers?page=0&per_page=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Jan 2019 22:43:23 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Link:
+      - <http://auth0-sdk-tests.auth0.com/api/v2/resource-servers?page=0&per_page=1>;
+        rel="first", <http://auth0-sdk-tests.auth0.com/api/v2/resource-servers?page=1&per_page=1>;
+        rel="next", <http://auth0-sdk-tests.auth0.com/api/v2/resource-servers?page=2&per_page=1>;
+        rel="last"
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1548110605'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA5WY0W7cKhCGXwX5Ou1ucrJJu3dpUlVVT6SoSa+qCrE23nCWNZbBG0VV3/1gPGS9mDHuXeKZ+WB+Bhj25+9MFNk6W7GLK/Zh9eF88/Gfa7YqzleX58vl5cfsLKvYnluPm9Y8L8k9q9iW73llyM3DV2sVhf1blII31ufZmFqvFwvW+b7Txe6d4dro9+7/97naL1gtFoeLhQ1kUqoXqspSiopTludc62xdMqn5WaZ3oqa5qrSF01I19MAbOwjbSE5L0WhDa9aYV5pLYT2OcUbteEWlKLkR3azPr68ul8vwuyO+8E22vr7orFpsK1FtKZNbm8T3x4vVlZ2gzlXNLfrn76zgOm9EbYSqOgfOCnLrRiZfGtaNf5YdmGw7mRprXPfTotve+OcsJNxaL8NRRu7MScodl3yCUjhzkvKjLqbm0jpzkuI0+aF5M9KidR/RccMYGA+LgpzDKMgViwK9wyjQGYs65kRu6prcc8Ps3Fg0Qcrqmu69x3S2GG2Yeoo31AHjDUVJ8YYKYbyhXH/BI08i3/FYgXckasCK6H8LOzy6w5L1jFZycj+hOym5n9GdnMiRfOOv2Emy60ypvRvEn+5chHB6hgSE0xMEIZyeZQHh9CRDCL0Gqqp43n0ZazAw4RpE470GkwSvQZTgNZgkeA2iBK/BJMFp8J1r1TY5J4+8OUSO0gbsVIMdVWOCBJLMYIEuEywQZwYLFJpggUwzWE6rO34QlmO5rgGx13+oVuE8aD7wQPWapIFis3ig2SQPVJvFA90meaDcLF5fZ63k4+JyH/GKCmJ8GSFRvnaCKF8wSJSvkiDKlwYSdcyp24Gl2MZz6/pJZ5zOMcIY5jpBGeYcoQxzn6C4bD7vmZDkoVEH2183YTq8s9LaW9F8UAoklORARigHUkpyYF1RDixwkvNJsnwnhTbkqWvoh+puvGltehOi7KNh425Cu49IxBOvbNNrTyxj7CNhFGuc2R5XYEZXA+fAcqRJbj7/qvEkpML9H58Fl8U4Z/iMrtY4DpYJj4R6GUdCoeCRXqNGbLfR+8p4C7ZK48h+eRJxrkONv+JSD694KKQ6/VL60rKmEKwiJcuNsi13fx60DXNe4UTAm4I3rl/IHes4g3U6Q141Ssp9rAl/Yw19ULkSRK/bPCbU6NGJwDuC2Lf921Dj2o3gUy+Q/k309e6BmPDQeXv/UVHUFD14YLI10/pFNQXJn3m+s1uc/Kc2kf3l/ewtAY7UOqLC6jiYsKogTEoirCi+q4oIPns0J0beaqP2pFD2qK6Csh037s6ZgjNeGXOhvhdPYW8BwEnFXwJ6pDFP4Vzi7m4ihu9raYNGqfZX19GMVyzKObkEp0iw13HSyfU+RXKZ3bfSiP40IN2PfF3zmDvtSa2kyMU4233J6JsNneDfgWHSCbSbsd25kf5VTfaUYYzvKZEoqMwwyvdwSBQkHkb5/rGP+nWWCU31q7Yrk9n7qeV/fv0PkV3J/IcVAAA=
+    http_version: 
+  recorded_at: Mon, 21 Jan 2019 22:43:23 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/create_test_server.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/create_test_server.yml
@@ -12,13 +12,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.3.1
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      - Bearer API_TOKEN
       Content-Length:
       - '176'
       Host:
@@ -29,7 +29,7 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 05 Oct 2018 19:59:20 GMT
+      - Mon, 21 Jan 2019 22:43:22 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
@@ -41,7 +41,7 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '9'
       X-Ratelimit-Reset:
-      - '1538769562'
+      - '1548110604'
       Vary:
       - origin,accept-encoding
       Cache-Control:
@@ -55,12 +55,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA12Py07DMBBF/8VrIA+S5rGrEELdoIpWAlaW7YyTIa4d2UOr
-        gvh3pmwqsZyZc0fnfgscRC9qrRtTdm07WKVVtTJVo7quaMWN8OoATOwh0Q7i
-        EeJt/NRn4pGPOIAntAiRkYloSX2WuWCUm0KiuwuVqQWzY5ExnXD06EeZwEQg
-        Tnxsh2LI9696bJbnDrfmbaB3etxsntZz/TUdHpBTyrlwksFahx6kMgZSEr1V
-        LgG/nHGRJvjEHtKGKFmQfZR2IC3GRHJRkc7SOGTimqMwg5cOLRBe+hXlfVWv
-        /u//Pp5Ai74p8/xaQLmR7V92Zb0SP7/OQVooQwEAAA==
+        H4sIAAAAAAAAA12Py04DMQxF/yVrYDLPltlVCKFuUEUrAasoyTgzpmkySkyrgvh3XDaVWNo+1zr3W+AgetHapmuM1NZ0dV3JZWma1i1lI25E0AdgYgeZtpCOkG7TpzkTj3zEAQKhQ0iMTERz7ovCR6v9FDPdXahCz1gcy4LpjGPAMKoMNgFx4mMzlIPcvZpxMT/f48a+DfROj+v102rffk2HB+SU9j6eVHTOYwClrYWcRe+0z8Av9zgrG0NmD+ViUizIPtp4UA5TJjXrRGdlPTJxzVHcQ1AeHRBe+pVV3bTd//3fxxMY0S8qKa8FtB/Z/mVbtZ34+QU3bsrIQwEAAA==
     http_version: 
-  recorded_at: Fri, 05 Oct 2018 19:59:20 GMT
+  recorded_at: Mon, 21 Jan 2019 22:43:22 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/delete_test_server.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_ResourceServers/delete_test_server.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers/5bb7c2988dfaba46c47a9918
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers/5c464b0acb6332081b45f804
     body:
       encoding: US-ASCII
       string: ''
@@ -12,13 +12,13 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.3.1
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGc.eyJpc3MiOiJodHRwczovL2F1dGgwLXNkay10ZXN0cy5hdXRoMC5jb20vIiwic3ViIjoiQjRvUEhsMDA3VmExR0JkWlhpU0hhRUNVcVZXa2Q5WGtAY2xpZW50cyIsIm.PxfZjVd4wTb_bFbSTENdTmbj13CDQaPK352w3UNL3i3DnWcVJa6qSiA0hCr_tSU_uC34mHkK52O8tFVeZjxCYSeM9yOZUcKVya5N0I7G90X
+      - Bearer API_TOKEN
       Host:
       - auth0-sdk-tests.auth0.com
   response:
@@ -27,7 +27,7 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 05 Oct 2018 19:59:23 GMT
+      - Mon, 21 Jan 2019 22:43:23 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
@@ -35,9 +35,9 @@ http_interactions:
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '9'
+      - '5'
       X-Ratelimit-Reset:
-      - '1538769565'
+      - '1548110607'
       Vary:
       - origin,accept-encoding
       Cache-Control:
@@ -50,5 +50,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 05 Oct 2018 19:59:23 GMT
+  recorded_at: Mon, 21 Jan 2019 22:43:23 GMT
 recorded_with: VCR 4.0.0

--- a/spec/integration/lib/auth0/api/v2/api_resource_servers_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_resource_servers_spec.rb
@@ -41,7 +41,6 @@ describe Auth0::Api::V2::ResourceServers do
         per_page: 1
       )
       expect(results.first).to equal(results.last)
-      expect(results.first).to eq(test_server)
     end
   end
 

--- a/spec/integration/lib/auth0/api/v2/api_resource_servers_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_resource_servers_spec.rb
@@ -22,6 +22,29 @@ describe Auth0::Api::V2::ResourceServers do
     end
   end
 
+  describe '.resource_servers', vcr: true do
+    let(:resource_servers) do
+      client.resource_servers
+    end
+
+    it 'should return at least 1 result' do
+      expect(resource_servers.size).to be > 0
+    end
+
+    it 'should get the test server' do
+      expect(resource_servers).to include(test_server)
+    end
+
+    it 'should return the first page of one result' do
+      results = client.resource_servers(
+        page: 0,
+        per_page: 1
+      )
+      expect(results.first).to equal(results.last)
+      expect(results.first).to eq(test_server)
+    end
+  end
+
   describe '.create_resource_server', vcr: true do
     it 'should raise an error if the identifier is empty' do
       expect do

--- a/spec/lib/auth0/api/v2/resource_servers_spec.rb
+++ b/spec/lib/auth0/api/v2/resource_servers_spec.rb
@@ -7,6 +7,19 @@ describe Auth0::Api::V2::ResourceServers do
     @instance = dummy_instance
   end
 
+  context '.resource_servers' do
+    it { expect(@instance).to respond_to(:resource_servers) }
+    it { expect(@instance).to respond_to(:get_resource_servers) }
+    it 'is expected to call get /api/v2/resource-servers' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/resource-servers',
+        page: nil,
+        per_page: nil,
+      )
+      expect { @instance.resource_servers }.not_to raise_error
+    end
+  end
+
   context '.resource_server' do
     it { expect(@instance).to respond_to(:resource_server) }
     it 'is expected to call get /api/v2/resource-servers/test' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ require 'vcr'
 VCR.configure do |config|
   # Uncomment the line below to record new VCR cassettes.
   # When this is commented out, VCR will reject all outbound HTTP calls.
-  config.allow_http_connections_when_no_cassette = true
+  # config.allow_http_connections_when_no_cassette = true
   config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   config.configure_rspec_metadata!
   config.hook_into :webmock

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ require 'vcr'
 VCR.configure do |config|
   # Uncomment the line below to record new VCR cassettes.
   # When this is commented out, VCR will reject all outbound HTTP calls.
-  # config.allow_http_connections_when_no_cassette = true
+  config.allow_http_connections_when_no_cassette = true
   config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   config.configure_rspec_metadata!
   config.hook_into :webmock


### PR DESCRIPTION
### Changes

Adds `Auth0::Api::V2::ResourceServers#resource_servers` method (and alias `get_resource_servers`) to fetch all Resource Servers in the tenant.

### References

Discussion in #154 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby
(my testing was done on 2.4.4, not 2.6.0)

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors - specs pass, I can't run integration tests locally
* [ ] Rubocop passes on all added/modified files - they don't pass on `master` when I run them, either
* [ ] All active GitHub checks have passed
