### PR TITLE
Add patch resource server

### DIFF
--- a/lib/auth0/api/v2/resource_servers.rb
+++ b/lib/auth0/api/v2/resource_servers.rb
@@ -62,6 +62,17 @@ module Auth0
           delete(path)
         end
 
+        # Updates a resource server.
+        # @see https://auth0.com/docs/api/management/v2#!/Resource_Servers/patch_resource_servers_by_id
+        # @param id [string] The id or audience of the resource server to update.
+        # @param options [hash] The Hash options used to define the resource servers's properties.
+        def patch_resource_server(id, options)
+          raise Auth0::InvalidParameter, 'Must specify a resource server id' if id.to_s.empty?
+          raise Auth0::InvalidParameter, 'Must specify a valid body' if options.to_s.empty?
+          path = "#{resource_servers_path}/#{id}"
+          patch(path, options)
+        end
+        
         private
 
         # Resource Servers API path

--- a/lib/auth0/api/v2/resource_servers.rb
+++ b/lib/auth0/api/v2/resource_servers.rb
@@ -65,12 +65,12 @@ module Auth0
         # Updates a resource server.
         # @see https://auth0.com/docs/api/management/v2#!/Resource_Servers/patch_resource_servers_by_id
         # @param id [string] The id or audience of the resource server to update.
-        # @param options [hash] The Hash options used to define the resource servers's properties.
-        def patch_resource_server(id, options)
-          raise Auth0::InvalidParameter, 'Must specify a resource server id' if id.to_s.empty?
-          raise Auth0::InvalidParameter, 'Must specify a valid body' if options.to_s.empty?
+        # @param body [hash] The Hash options used to define the resource servers's properties.
+        def patch_resource_server(id, body)
+          raise Auth0::InvalidParameter, 'Must specify a resource server id or audience' if id.to_s.empty?
+          raise Auth0::InvalidParameter, 'Must specify a valid body' if body.to_s.empty?
           path = "#{resource_servers_path}/#{id}"
-          patch(path, options)
+          patch(path, body)
         end
         
         private

--- a/spec/integration/lib/auth0/api/v2/api_resource_servers_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_resource_servers_spec.rb
@@ -98,22 +98,10 @@ describe Auth0::Api::V2::ResourceServers do
     end
   end
 
-    describe '.patch_client', vcr: true do
-    it 'should raise an error with a missing client_id' do
-      expect do
-        client.patch_resource_server('', token_lifetime: 654321)
-      end.to raise_error Auth0::InvalidParameter
-    end
-
-    it 'should raise an error with an empty body' do
-      expect do
-        client.patch_resource_server('__test_resource_server_id__', {})
-      end.to raise_error Auth0::InvalidParameter
-    end
-
+  describe '.patch_resource_server', vcr: true do
     it 'should update the resource server with the correct attributes' do
       expect(
-        client.patch_client(
+        client.patch_resource_server(
           test_server['id'],
           token_lifetime: 654321,
         )

--- a/spec/integration/lib/auth0/api/v2/api_resource_servers_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_resource_servers_spec.rb
@@ -98,6 +98,33 @@ describe Auth0::Api::V2::ResourceServers do
     end
   end
 
+    describe '.patch_client', vcr: true do
+    it 'should raise an error with a missing client_id' do
+      expect do
+        client.patch_resource_server('', token_lifetime: 654321)
+      end.to raise_error Auth0::InvalidParameter
+    end
+
+    it 'should raise an error with an empty body' do
+      expect do
+        client.patch_resource_server('__test_resource_server_id__', {})
+      end.to raise_error Auth0::InvalidParameter
+    end
+
+    it 'should update the resource server with the correct attributes' do
+      expect(
+        client.patch_client(
+          test_server['id'],
+          token_lifetime: 654321,
+        )
+      ).to(
+        include(
+          'token_lifetime' => 654321,
+        )
+      )
+    end
+  end
+
   describe '.delete_resource_server', vcr: true do
     it 'should raise an error if the id is empty' do
       expect do
@@ -111,4 +138,6 @@ describe Auth0::Api::V2::ResourceServers do
       end.to_not raise_error
     end
   end
+
+  
 end

--- a/spec/lib/auth0/api/v2/resource_servers_spec.rb
+++ b/spec/lib/auth0/api/v2/resource_servers_spec.rb
@@ -80,7 +80,7 @@ describe Auth0::Api::V2::ResourceServers do
       expect(@instance).to receive(:patch).with('/api/v2/resource-servers/1', fields: 'fields')
       expect { @instance.patch_resource_server('1', fields: 'fields') }.not_to raise_error
     end
-    it { expect { @instance.patch_resource_server('', nil) }.to raise_error 'Must specify a resource server id' }
-    it { expect { @instance.patch_resource_server('some', nil) }.to raise_error 'Must specify a valid body' }
+    it { expect { @instance.patch_resource_server('', nil) }.to raise_error Auth0::InvalidParameter }
+    it { expect { @instance.patch_resource_server('some', nil) }.to raise_error Auth0::InvalidParameter }
   end
 end

--- a/spec/lib/auth0/api/v2/resource_servers_spec.rb
+++ b/spec/lib/auth0/api/v2/resource_servers_spec.rb
@@ -73,4 +73,14 @@ describe Auth0::Api::V2::ResourceServers do
       expect { @instance.delete_resource_server(nil) }.to raise_error 'Must supply a valid resource server id'
     end
   end
+
+  context '.patch_resource_server' do
+    it { expect(@instance).to respond_to(:patch_resource_server) }
+    it 'is expected to send patch to /api/v2/resource_servers/1' do
+      expect(@instance).to receive(:patch).with('/api/v2/resource-servers/1', fields: 'fields')
+      expect { @instance.patch_resource_server('1', fields: 'fields') }.not_to raise_error
+    end
+    it { expect { @instance.patch_resource_server('', nil) }.to raise_error 'Must specify a resource server id' }
+    it { expect { @instance.patch_resource_server('some', nil) }.to raise_error 'Must specify a valid body' }
+  end
 end


### PR DESCRIPTION
### Changes

Adds a `patch_resource_server` method that takes a resource server id and a hash of options. Includes spec tests that pass and tentative integration tests awaiting VCR cassettes.

### References

Discussion in #156.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby - Tested on 2.4.4

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
