### PR TITLE
More password change params

### DIFF
--- a/lib/auth0/api/v2/tickets.rb
+++ b/lib/auth0/api/v2/tickets.rb
@@ -53,15 +53,17 @@ module Auth0
             mark_email_as_verified: nil,
             includeEmailInRedirect: nil,
             new_password: nil)
+
+          booleans = [true, false]
           path = "#{tickets_path}/password-change"
           request_params = {
             result_url: result_url,
             user_id: user_id,
             connection_id: connection_id,
             email: email,
-            ttl_sec: ttl_sec,
-            mark_email_as_verified: mark_email_as_verified,
-            includeEmailInRedirect: includeEmailInRedirect,
+            ttl_sec: ttl_sec.is_a?(Integer) ? ttl_sec : nil,
+            mark_email_as_verified: booleans.include?(mark_email_as_verified) ? mark_email_as_verified : nil,
+            includeEmailInRedirect: booleans.include?(includeEmailInRedirect) ? includeEmailInRedirect : nil,
             new_password: new_password
           }
           post(path, request_params)

--- a/lib/auth0/api/v2/tickets.rb
+++ b/lib/auth0/api/v2/tickets.rb
@@ -29,22 +29,40 @@ module Auth0
 
         # Create a password change ticket
         # @see https://auth0.com/docs/api/v2#!/Tickets/post_password_change
-        # @param new_password [string] The password to be set for the user once the ticket is used.
-        # @param user_id [string] The user_id of for which the ticket is to be created.
         # @param result_url [string] The user will be redirected to this endpoint once the ticket is used.
+        # @param user_id [string] The user_id of for which the ticket is to be created.
         # @param connection_id [string] The connection that provides the identity for which the password is to be
         # changed. If sending this parameter, the email is also required and the user_id is invalid.
         # @param email [string] The user's email.
+        # @param ttl_sec [integer] The ticket's lifetime in seconds starting from the moment of creation. After
+        # expiration, the ticket cannot be used to change the user's password. If not specified or if you send 0,
+        # the Auth0 default lifetime of 5 days will be applied.
+        # @param mark_email_as_verified [boolean] true if email_verified attribute must be set to true once password is
+        # changed, false if email_verified attribute should not be updated
+        # @param includeEmailInRedirect [boolean] Whether or not we include the email as part of the returnUrl
+        # in the reset_email
+        # @param new_password [string] The password to be set for the user once the ticket is used.
         #
         # @return [json] Returns the created ticket url.
-        def post_password_change(new_password: nil, user_id: nil, result_url: nil, connection_id: nil, email: nil)
+        def post_password_change(
+            result_url: nil,
+            user_id: nil,
+            connection_id: nil,
+            email: nil,
+            ttl_sec: nil,
+            mark_email_as_verified: nil,
+            includeEmailInRedirect: nil,
+            new_password: nil)
           path = "#{tickets_path}/password-change"
           request_params = {
-            user_id: user_id,
             result_url: result_url,
-            new_password: new_password,
+            user_id: user_id,
             connection_id: connection_id,
-            email: email
+            email: email,
+            ttl_sec: ttl_sec,
+            mark_email_as_verified: mark_email_as_verified,
+            includeEmailInRedirect: includeEmailInRedirect,
+            new_password: new_password
           }
           post(path, request_params)
         end

--- a/spec/lib/auth0/api/v2/tickets_spec.rb
+++ b/spec/lib/auth0/api/v2/tickets_spec.rb
@@ -31,10 +31,16 @@ describe Auth0::Api::V2::Tickets do
   context '.post_password_change' do
     it { expect(@instance).to respond_to(:post_password_change) }
     it 'expect client to send post to /api/v2/tickets/password-change with body' do
-      expect(@instance).to receive(:post).with('/api/v2/tickets/password-change', user_id: nil, result_url: nil,
-                                                                                  new_password: nil,
-                                                                                  connection_id: nil, email: nil)
-      expect { @instance.post_password_change }.not_to raise_error
+      expect(@instance).to receive(:post).with('/api/v2/tickets/password-change',
+                                               result_url: nil,
+                                               user_id: nil,
+                                               connection_id: nil,
+                                               email: nil,
+                                               ttl_sec: nil,
+                                               mark_email_as_verified: nil,
+                                               includeEmailInRedirect: nil,
+                                               new_password: nil)
+      expect {@instance.post_password_change}.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
### Changes

Updates the `post_password_change` method to contain a few new parameters based on the [auth0 docs]:

- `mark_email_as_verified` - if true, this marks the user's email as verified after they change their password
- `includeEmailInRedirect` - if true, this includes the user's email address as part of the returnUrl
- `ttl_sec` - The TTL of the ticket

Additionally, I reordered the params to match the auth0 documentation. This might be a breaking change, I'm not a proficient-enough rubyist to know.

### References

[Auth0 "Create a password change ticket" documentation][auth0 docs]

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed


[auth0 docs]: https://auth0.com/docs/api/management/v2#!/Tickets/post_password_change
