### PR TITLE
Add Client ID to send_verification_email

### DIFF
--- a/lib/auth0/api/v2/jobs.rb
+++ b/lib/auth0/api/v2/jobs.rb
@@ -3,29 +3,29 @@ module Auth0
     module V2
       # Methods to use the jobs endpoints
       module Jobs
-        attr_reader :jobs_path
-
         # Retrieves a job. Useful to check its status.
         # @see https://auth0.com/docs/api/v2#!/Jobs/get_jobs_by_job_id
-        # @param job_id [string] The id of the job.
+        # @param job_id [string] The ID of the job.
         #
         # @return [json] Returns the job status and properties.
         def get_job(job_id)
           raise Auth0::InvalidParameter, 'Must specify a job id' if job_id.to_s.empty?
+
           path = "#{jobs_path}/#{job_id}"
           get(path)
         end
 
         # Imports users to a connection from a file using a long running job.
-        # Important: The documentation for the file format is at https://docs.auth0.com/bulk-import.
+        # Documentation for the file format: https://docs.auth0.com/bulk-import
         # @see https://auth0.com/docs/api/v2#!/Jobs/post_users_imports
         # @param users_file [file] A file containing the users to import.
-        # @param connection_id [string] The connection id of the connection to which users will be inserted.
+        # @param connection_id [string] Database connection ID to import to.
         #
         # @return [json] Returns the job status and properties.
         def import_users(users_file, connection_id)
           raise Auth0::InvalidParameter, 'Must specify a valid file' if users_file.to_s.empty?
           raise Auth0::InvalidParameter, 'Must specify a connection_id' if connection_id.to_s.empty?
+
           request_params = {
             users: users_file,
             connection_id: connection_id
@@ -37,10 +37,11 @@ module Auth0
         # Export all users to a file using a long running job.
         # @see https://auth0.com/docs/api/v2#!/Jobs/post_users_exports
         # @param options [hash] The options used to configure the output file.
-        #   * :connection_id [string] The connection id of the connection from which users will be exported.
-        #   * :format [string] The format of the file. Valid values are: "json" and "csv".
-        #   * :limit [integer] Limit the number of users to export.
-        #   * :fields [array] A list of fields to be included in the CSV. If omitted, a set of predefined fields will be exported.
+        #   :connection_id [string] Database connection ID to export from.
+        #   :format [string] The format of the file. Valid values are: "json" and "csv".
+        #   :limit [integer] Limit the number of users to export.
+        #   :fields [array] A list of fields to be included in the CSV.
+        #     If omitted, a set of predefined fields will be exported.
         #
         # @return [json] Returns the job status and properties.
         def export_users(options = {})
@@ -55,15 +56,17 @@ module Auth0
         end
 
         # Send an email to the specified user that asks them to click a link to verify their email address.
-        # @see https://auth0.com/docs/api/v2#!/Jobs/post_verification_email
+        # @see https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email
         # @param user_id [string] The user_id of the user to whom the email will be sent.
+        # @param client_id [string] Client ID to send an Application-specific email.
         #
         # @return [json] Returns the job status and properties.
-        def send_verification_email(user_id)
+        def send_verification_email(user_id, client_id = nil)
           raise Auth0::InvalidParameter, 'Must specify a user id' if user_id.to_s.empty?
-          request_params = {
-            user_id: user_id
-          }
+
+          request_params = { user_id: user_id }
+          request_params[:client_id] = client_id unless client_id.nil?
+
           path = "#{jobs_path}/verification-email"
           post(path, request_params)
         end
@@ -76,11 +79,12 @@ module Auth0
         end
 
         # Map array of field names for export to array of objects
-        # @param fields [array] Field names to be included in the export
-        
-        # @return [array] Returns the fields mapped as array of objects for the export_users endpoint
+        # @param fields [array] Field names to be included in the export
+
+        # @return [array] Returns the fields mapped as array of objects for the export_users endpoint
         def fields_for_export(fields)
-          return nil if fields.nil? || fields.empty?
+          return nil if fields.to_s.empty?
+
           fields.map { |field| { name: field } }
         end
       end

--- a/lib/auth0/mixins/httpproxy.rb
+++ b/lib/auth0/mixins/httpproxy.rb
@@ -21,6 +21,7 @@ module Auth0
                    elsif method == :delete
                      call(:delete, url(safe_path), timeout, add_headers({params: body}))
                    elsif method == :post_file
+                     body.merge!(multipart: true)
                      call(:post, url(safe_path), timeout, headers, body)
                    else
                      call(method, url(safe_path), timeout, headers, body.to_json)
@@ -54,7 +55,13 @@ module Auth0
       end
 
       def call(method, url, timeout, headers, body = nil)
-        RestClient::Request.execute(method: method, url: url, timeout: timeout, headers: headers, payload: body)
+        RestClient::Request.execute(
+          method: method,
+          url: url,
+          timeout: timeout,
+          headers: headers,
+          payload: body
+        )
       rescue RestClient::Exception => e
         case e
         when RestClient::RequestTimeout

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/_export_users_and_get_job/should_create_an_export_users_job_successfully.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/_export_users_and_get_job/should_create_an_export_users_job_successfully.yml
@@ -1,0 +1,61 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/jobs/users-exports
+    body:
+      encoding: UTF-8
+      string: '{"connection_id":"con_Xx4Kruoab04wvlYX"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Content-Length:
+      - '40'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:13:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '8'
+      X-Ratelimit-Reset:
+      - '1551283997'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA1WOPQ+CMBCG/0tnMRQRlM3FxcVETZClKe2pJdKS9vgwxv/uyeZ4z/vc3ftm+OqAFawP4IOAqXMe2YIFlNgH4h1YbeydkHLWgkLjrDCaEppFOaUH3ztZx+k4PK8laTfnW4m/PAx/W4Qu9MTKFqKjDGF0Xke7Hh9g0Sg5K+R7kAhazCeSmG+jOImS/Myzgq8Kvl4m+bYib67QuFqcNi5k1bjXcaNM5hX7fAHRdXvC1AAAAA==
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:13:15 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/_export_users_and_get_job/should_get_the_export_users_job.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/_export_users_and_get_job/should_get_the_export_users_job.yml
@@ -1,0 +1,117 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/jobs/users-exports
+    body:
+      encoding: UTF-8
+      string: '{"connection_id":"con_Xx4Kruoab04wvlYX"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Content-Length:
+      - '40'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:13:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1551283998'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA1WOyw6CMBBF/6VrMbyN7NgZ2ZggCbhpCoxalJa0w8MY/92Rncs598zMfTN8DcASNlowlsMyaINswywKHC3xAVQr1Y1Qo5WCBqVWXLaU0MzLJczMqEXthvP0rErSrtr0An+5nf62CBX0RIkenJOwdtamddIR76BQNmJVyDcgEFq+nvBdb++4vuPvzl6ceEHiRdsoiC7krRU6XfOuyB9xejhWjcmmacnZ5wu9hN4Y1AAAAA==
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:13:15 GMT
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/jobs/job_jUSk6AHJYcrKvvxS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:13:15 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '7'
+      X-Ratelimit-Reset:
+      - '1551283998'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA1WOyw6CMBBF/6VrMbyN7NgZ2ZggCbhpCoxalJa0w8MY/92Rncs598zMfTN8DcASNlowlsMyaINswywKHC3xAVQr1Y1Qo5WCBqVWXLaU0MzLJczMqEXthvP0rErSrtr0An+5nf62CBX0RIkenJOwdtamddIR76BQNmJVyDcgEFq+nvBdb++4vuPvzl6ceEHiRdsoiC7krRU6XfOuyB9xejhWjcmmacnZ5wu9hN4Y1AAAAA==
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:13:15 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/_import_users_and_get_job/should_create_an_import_users_job_successfully.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/_import_users_and_get_job/should_create_an_import_users_job_successfully.yml
@@ -1,0 +1,60 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/jobs/users-imports
+    body:
+      encoding: ASCII-8BIT
+      string: "------RubyFormBoundary7fUORMCp03LhWn7G\r\nContent-Disposition: form-data;
+        name=\"users\"; filename=\"api-jobs-spec-import-users.json\"\r\nContent-Type:
+        application/json\r\n\r\n[{\"email\":\"rubytestzulema_haag@example.com\",\"email_verified\":false,\"app_metadata\":{\"roles\":[\"admin\"]},\"user_metadata\":{\"theme\":\"light\"}}]\r\n------RubyFormBoundary7fUORMCp03LhWn7G\r\nContent-Disposition:
+        form-data; name=\"connection_id\"\r\n\r\ncon_Xx4Kruoab04wvlYX\r\n------RubyFormBoundary7fUORMCp03LhWn7G--\r\n"
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - multipart/form-data; boundary=----RubyFormBoundary7fUORMCp03LhWn7G
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Content-Length:
+      - '463'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:14:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1551284058'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA1XNMQvCMBAF4P+S2UgSQ4vdCk6K4FChdQlpGzRik5BcrCL+d49ujvfex7sPgXcwpCI5mZiUnYKPQFYkgYacMA/GjdZdMRq8c2YA652yIzZ4q/YlDzF73TM5Px9d+8fQnHHV6cnQk05p9nGkdYabcWAHvRD00Wgwo9KAXjC+pUxQUTa8qLiseLmWBbugW37efa+aQoqOzfu6ro/hutmR7w/HprJfxQAAAA==
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:14:17 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/_import_users_and_get_job/should_get_the_import_users_job.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/_import_users_and_get_job/should_get_the_import_users_job.yml
@@ -1,0 +1,116 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/jobs/users-imports
+    body:
+      encoding: ASCII-8BIT
+      string: "------RubyFormBoundaryoUaJwiumU1KEMPgF\r\nContent-Disposition: form-data;
+        name=\"users\"; filename=\"api-jobs-spec-import-users.json\"\r\nContent-Type:
+        application/json\r\n\r\n[{\"email\":\"rubytestonie_adams@example.net\",\"email_verified\":false,\"app_metadata\":{\"roles\":[\"admin\"]},\"user_metadata\":{\"theme\":\"light\"}}]\r\n------RubyFormBoundaryoUaJwiumU1KEMPgF\r\nContent-Disposition:
+        form-data; name=\"connection_id\"\r\n\r\ncon_Xx4Kruoab04wvlYX\r\n------RubyFormBoundaryoUaJwiumU1KEMPgF--\r\n"
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - multipart/form-data; boundary=----RubyFormBoundaryoUaJwiumU1KEMPgF
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Content-Length:
+      - '462'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 202
+      message: Accepted
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:14:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1551284059'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA1XNMQvCMBAF4P+S2UoTitVugltBHRRqlxCbQyP2UpKLrYj/3aOb47338e4j6D2AqESKEKJ2/eADiYWIZChFzgdA6/DGUecRoSPnUTvLDd+6mYo6JG+ueTG+npfmj7E58yqaHrKjiXH0wWbbRHdAcp2ZCfsAhsBqQ+xVLjdZrjJVnuSqkkUl10tZqpbd/PPhr/oAvsZ+khJap/ZyJ74/CKFe28UAAAA=
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:14:18 GMT
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/jobs/job_OeoKnmx11eZi2N1D
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:14:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1551284059'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA1XNMQvCMBAF4P+S2UoTitVugltBHRRqlxCbQyP2UpKLrYj/3aOb47338e4j6D2AqESKEKJ2/eADiYWIZChFzgdA6/DGUecRoSPnUTvLDd+6mYo6JG+ueTG+npfmj7E58yqaHrKjiXH0wWbbRHdAcp2ZCfsAhsBqQ+xVLjdZrjJVnuSqkkUl10tZqpbd/PPhr/oAvsZ+khJap/ZyJ74/CKFe28UAAAA=
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:14:18 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/_send_verification_email_and_get_job/should_create_a_new_verification_email_job.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/_send_verification_email_and_get_job/should_create_a_new_verification_email_job.yml
@@ -1,0 +1,119 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users
+    body:
+      encoding: UTF-8
+      string: '{"email":"rubytestantonio_ankunding@example.net","password":"PeOp448vDfFvAz","connection":"Username-Password-Authentication","name":"antonio_ankunding"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Content-Length:
+      - '152'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:13:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1551283998'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA42R30vDMBDH/5fA9rS26c9shaF78VlQXxQpt+SyhbVJSdKpzP3vpp2CIIqQhwv3vc/dfe9EsAPVkprYYfvm0XnQ3mhlGtCHQQuld9f4Cl3fYqzRkwXR0GGQ/5CF1IRqjmiVVChILaF1uCBDL8CjaMCHuoymq4hmUcbu06pO8zqtYsqqx1A+OLSNEiN88Hv6XnJWbVnKKWPLFWOcCZkWpRRB2ivuBzvOsfe+d3WSuHhn4QgebMxNl1zCpJC4YiALmS/LQgYalFjRMi+Q0m1ayiu3LpZ0btf9bi7WE2uWb2bZTXhc6HgaZASG/wXpxkjH/bSwVvzw6cev9gWZEqi98godqZ9OhButkXtldKh7CEuPiOgWnHsxVkSb0HPUc5gk3335yxFrjqGP/XJvbOvuDFfQfh7i/Lwg3OI/TnH+AHRi/U0WAgAA
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:13:16 GMT
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/jobs/verification-email
+    body:
+      encoding: UTF-8
+      string: '{"user_id":"auth0|5c76b71c0778977c7df145fd"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Content-Length:
+      - '44'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:13:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1551283999'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWKqksSFWyUipLLcpMy0xOLMnMz4tPzU3MzFHSUSouSSwpLQbKFqTmpWTmpQOFkotSE0tSU+ITS4DCRgaGlroGRrpG5iGGZlaGxlaGZnpG5qZRQHWZKUD5rPykeMtcE2Mjt2LTxLCSEp+gJE+lWgBgU3tAdAAAAA==
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:13:16 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/_send_verification_email_and_get_job/should_get_the_completed_verification_email.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/_send_verification_email_and_get_job/should_get_the_completed_verification_email.yml
@@ -1,0 +1,175 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users
+    body:
+      encoding: UTF-8
+      string: '{"email":"rubytesthermann_dane@example.org","password":"5qMq3o8uZaQ","connection":"Username-Password-Authentication","name":"dane.hermann"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Content-Length:
+      - '139'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:13:16 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '5'
+      X-Ratelimit-Reset:
+      - '1551284000'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA41R30vDMBD+XwLb05qm7ZpuhaF78VlQXxQpt+S6Bdu0JOlU5v53r3WCDyJCHi6X78fluxPDFkzDSuaG3XtAHw7oWrC20mDxGt+g7RvknduzBbPQIiHHF36BUXcSqI7oTG1Qs7KGxuOCDb2GgLqCQJRUJOtIpFFa3CeyTLIykbwQ4pHog0dXGeIxGMJBfOSqkLsiUSqHlQIp1xkUhVRA0N6oMLhxhEMIvS/j2PO9gyMEcFx1bfxVxrWQya7WNYLENMOlzhPMAWtSzYWQ6ZXfLFdi7jb9fq43k9Ys287SGzpKWz4NMgrS/UvSU6WB93aKwaiXSxS/hUYIo9EGEwx6Vj6dmOqsRRVMZ4nyQP8d2dEteP/aOR1tyW7EK5ggPyP5KwzXHcnHfQc32vq7ThloLjs4Py+YcviPLZw/ARL3w0AHAgAA
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:13:16 GMT
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/jobs/verification-email
+    body:
+      encoding: UTF-8
+      string: '{"user_id":"auth0|5c76b71cc5a8ca6693a776ca"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Content-Length:
+      - '44'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:13:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '6'
+      X-Ratelimit-Reset:
+      - '1551284000'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWKqksSFWyUipLLcpMy0xOLMnMz4tPzU3MzFHSUSouSSwpLQbKFqTmpWTmpQOFkotSE0tSU+ITS4DCRgaGlroGRrpG5iGGZlaGxlaG5nqGBiZRQHWZKUD5rPykeO9sk4jkNJPyZMcSxzBfX1elWgCfpdR6dAAAAA==
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:13:17 GMT
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/jobs/job_Kk4Xcf4wcAtAVMME
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:13:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '5'
+      X-Ratelimit-Reset:
+      - '1551284000'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWKqksSFWyUipLLcpMy0xOLMnMz4tPzU3MzFHSUSouSSwpLQbKJufnFuSklqSmAAWTi1ITgaz4xBKghJGBoaWugZGukXmIoZmVobGVobmeoYFJFFBdZgpQPis/Kd472yQiOc2kPNmxxDHM19dVqRYAWI5p13YAAAA=
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:13:17 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/_send_verification_email_and_get_job/should_reject_an_invalid_client_id.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/_send_verification_email_and_get_job/should_reject_an_invalid_client_id.yml
@@ -1,0 +1,109 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users
+    body:
+      encoding: UTF-8
+      string: '{"email":"rubytestjan_johnston@example.org","password":"0a3fCuM8Jz","connection":"Username-Password-Authentication","name":"jan_johnston"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Content-Length:
+      - '138'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:13:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '5'
+      X-Ratelimit-Reset:
+      - '1551284001'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA41RW0vDMBT+L4Htqfe0SVsYuhefBfVFkXKaZFtmm5QkncrcfzftJuxBRMjDycl3OfnOEYkeZIdqZMb20wnr9qCavd4p67S6FR/QD52ItNmiACnohUdeI3x3FmgOwsiNFBzVG+isCNA4cHCCN+A8JUvSKkyyMKOPKalTXKc0ojl+9vTRCtNIz0Mwul3yVTBKWppyVkDJgJAKA6WEtR46SOZGM42wc26wdRzbaGvgAA5MxHQfn8sY05xiTBjwvCIClxjKIitJ1m7yiha8urGrvEyWZjVsl3w1ay3wepHd+cO4iuZBJkF/P0taX+0hGtQcg2Rvlyh+C80jJBfKSSeFRfXLETGtlGBO+rcaPfn/TuzwHqx914aHa2834RnMkOtI/grD6IP3MT/BTbb2QTMJ3WUHp9cAMSP+sYXTN7TTcG4HAgAA
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:13:17 GMT
+- request:
+    method: post
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/jobs/verification-email
+    body:
+      encoding: UTF-8
+      string: '{"user_id":"auth0|5c76b71dc5a8ca6693a776cb","client_id":"#<Random:0x00007f7fdf31b490>"}'
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Content-Length:
+      - '87'
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:13:17 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA02P0UoEMQxFfyXEh1EYpeLCYhEf9AOUxfel3aRrpdOMbWZ1EP/d7uw+GAgJ3HtC7g9WdTrVZyFGuzKmRy5FClp8cgQb/py4KvY4cK1u3zz46uYkTTu4FMlplAwLYqF78R+8U6BIuVMYXa3/XUHKsQensEuRs15HsnDxsHGZZLDm27Rah3WgcHfrV/fmsYOGjUVGLjqfoW0kuHx7Z2hTAmjbTkIPMUAWPQKHSEyLtk/iXWp3GL5iSuAZpsp0dYPnpKfkGPPy6dYLzfj7ByjnqOkXAQAA
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:13:17 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/delete_imported_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/delete_imported_user.yml
@@ -1,0 +1,110 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users?q=email:rubytest*
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:13:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '4'
+      X-Ratelimit-Reset:
+      - '1551284002'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA7WWXW/TMBSG/0skuNoyfzuuNAE3XCMBN0xTdWIft9lWp3LSAYL9d5yuW7eRVDQLUi9s+cRu3ueJ7YtfGa6guslmWdyUP1tsWlitIdbv8Udq3GAesM1OsgArTDX3Y6m/fWh+i7HyFbps5uGmwZNss3bQoptDm4oZoeaUsFOmv1A1I3ImSc6k/JYe3zQY55XrZty0S/JbWq1KKZFoXRitrXaeCml9Kl1Xtt3EbvFl266b2dlZky8i3EILMbf16uy+eebLwnmUjGgKJaU8dYhykhVYoETN3jXnoiBv4/l68dadb+d6wz+8YR/Tz7qQb/9IN2Hq30/ZdK1Vvg6LLoDKXu9CeB5UGqschrZqK2yy2cWvzNYhoG2rOqTir+lNu+dOP0HTfK+jO/2QFurqLWxLnoZxKIZY36Z14kNk3bLN59pWcLNL/+7yJLMR/yH/u5O/qdtlrJp+6NuhUcwpmVGVSy0GmStVEKE9gCZeWeq8oUcw5+iVkWXBuAYGxvpCllLYgjDvjSrEOOZ2Ocz8IYtpkQ+k8FrkT+LvQ34NAZsl9EPfDY7GrnNGyQHs5rnjaI/AbphCQEOkU14T5NyxBNuysrSeK03HYb+GYez7NKYG35vDFOB3APrAx3oF4RF7ymGPfTv0CuhGmIPQn1vOjoCOBmVptNM07fTCcy5MAQK8dyUthRz5rcd6GPpDFtMj70lhGuTb+PuQQ2jrUNVzCNeb4KqwGDjfX5aNU4F3+w7RalAFTe1z7707QgXh0WjwSYJCCp9mA4mKSC6QkJJKP/KoDweO+p5cptViIJFXa7FH0afFEmNyPMxd2t8ejajjYm9EN5Lvyl4hgybDh0F6dSuhsJA+DQ5aKwvH3PuIoqVPtz1QyDgKJylKQJ9mlYSokfc+d+AweBra//CgL4xpPNhS6PPgCsL8ql6GJmne78HTitEe6FwLfsAD9+LVy2PuglpozlNcThiFvOBQpMu/YqUXRktnxnlwdcCDF5FM7UFvGFN4sKNwd/kHrc27Y/0NAAA=
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:13:18 GMT
+- request:
+    method: delete
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C5c76b55e0778977c7df145cf
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:13:18 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '3'
+      X-Ratelimit-Reset:
+      - '1551284002'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:13:18 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/search_for_connection_id.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Jobs/search_for_connection_id.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - rest-client/2.0.2 (darwin17.7.0 x86_64) ruby/2.5.1p57
+      Content-Type:
+      - application/json
+      Auth0-Client:
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjYuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      Authorization:
+      - Bearer API_TOKEN
+      Host:
+      - auth0-sdk-tests.auth0.com
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Wed, 27 Feb 2019 16:13:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit:
+      - '10'
+      X-Ratelimit-Remaining:
+      - '9'
+      X-Ratelimit-Reset:
+      - '1551283992'
+      Vary:
+      - origin,accept-encoding
+      Cache-Control:
+      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=15724800
+      X-Robots-Tag:
+      - noindex, nofollow, nosnippet, noarchive
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA+1W33OqOhD+X3imM4Ao2jdrtVVba1Wq9kwnE5IAqUCABPxx5vzvJ6i1wrFzOnPv0537osO3Xza7m823+fFToVi5VhCLwGMQ1h43T5N6Jhb6fJorqsJiQVnEleufSujC4g8iQXOiXIs0I6qSEpGlESBRyoIAcCIEjTx+sP5SlRhyvmYpHrOAoq3cxmMMS7eYcugEBHDqRVmsXLsw4HtvSUZTwkHGSRrBkJwsTpoJAlyWIgLilAmCirg+ouAihYJ4W5CTlO9x49cnKreFmfA1ue/BpzIjXMgvygFmIaQRkNlHHy5PscAglJn8OLDfVIVERcwYoICSSOxNBormWeY1drC30N81j+jjVuu9bUdaz1xMs77y9ks9K/BiYw7TjEFHM9d5sFz88wL/u3Wxj2W/Gh/P7aotCTJZiuDe77dr9ldPl+upz7gYPC02y/hp3t3UjF7yPl9sg1FT7+gT21rJAP5aclWpddbPTWO7dnEyH1F9rEO33YDv+L63vPPNPi8oSbtvB827R3y30HPkpK+vK6OPjd2D3YNzqyUpTS0myx1pv8JGMBGb7pSNtW7PXtirWdJdtV4kpcNtU689NIVr02HiwaebDu222RJq4nnS0WqS0qX1vP7YtBr17rIxH012YtveWpbQiSHq7XwmKXePo8VU6wg3bJiD+OV5PhzsLKMz8u17etd+diTlBQ+0uqfl+vZGs3FCb4c3D23X3owS/cZA96akoNtBgrz7zrgZs+R1e+sudV8b2r1+I9+NZy23OOVY604y6+6+x0banM4f2k6v747ep7vlsMe1raQkO+e2xgfbbLbsGItav50YOVrWrGCMcGumFR27m4xvEHQzuzd6hGbCB8vndxcPX22t9RpY06TS8+lDPs0npvni8/SJ6bflnj+cPdiz9aZpNFqaWTNM3Wrq+6QOZk6QvAeSUm8ZLWS5DcMliBiWUce4ZUDXrGPkOhZuyCVx5kitKS6DS4NPASGyZ4OPe1HIC3BoKnwMtyVwTRxOBSlhPguJYOuoBAbs2Mil1SxdAZ9ywdKyW4KzA/2iFTosEyA87QoxByGMoEdCmf0phQKWNwyfgAMHxPKHn8D9F+A+W4NA7lXBj0uQgFUD4Rx6Ulu+wkHss4iAKAsdkn5J4pnDUUo/DviDVZwJ96uRHtGcYsLONQQDmGF58FLTIiL2RaWRHBW+4GUaymQxQ+CmkoyLbCv2y6uKKEDRDg7bnIWT8jwGJD+v+OF09hrHrxzGVvyyyaUikiW4bAwzTtFlU0TWXywq1+TQQ/lBJc+xQ+YV0JO6y/eeciq2ZVtAV6RCP7QEBl7KsrhiE9ArTHEAUXWZbAfBqhjj1QhTEuwbn/u06vzcBDAR8kT+ZFCvuDWxfD/I0VExcwFFVsH2hePVKxIxQd3j6Kl0g5yGBIZl7NgclbJeqI8j3UfwNG4Ri4sxutcatSQy6rm6qCVZUUt6ov4hJOplBVFL0qGeh1Oe8a48u6J3P8f8GfLNcX5acXFslwV/3IIzrdH18plmkT6alwW/pMMnkS7V78eR9Gl/K2ckH5FeQK5Y8XoxPtOqwt/Mrbzs/3fJf/hd8vYbF9Qi/e4MAAA=
+    http_version: 
+  recorded_at: Wed, 27 Feb 2019 16:13:11 GMT
+recorded_with: VCR 4.0.0

--- a/spec/integration/lib/auth0/api/v2/api_jobs_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_jobs_spec.rb
@@ -1,94 +1,112 @@
 require 'spec_helper'
 describe Auth0::Api::V2::Jobs do
-  skip "Jobs examples are skipped to avoid Job's creation" do
-    let(:client) { Auth0Client.new(v2_creds) }
-    let(:username) { Faker::Internet.user_name }
-    let(:email) { "#{entity_suffix}#{Faker::Internet.safe_email(username)}" }
+  UP_AUTH = Auth0::Api::AuthenticationEndpoints::UP_AUTH
 
-    describe '.import_users and .get_job' do
-      let(:file_content) do
-        [{
-          'email' => email,
-          'email_verified' => false,
-          'app_metadata' => {
-            'roles' => ['admin'],
-            'plan' => 'premium'
-          },
-          'user_metadata' => {
-            'theme' => 'light'
-          }
-        }]
-      end
-      let(:users_file) do
-        File.new('temp.json', 'w+') { |f| f.write(file_content) }
-      end
-      let(:connection_id) do
-        client.connections
-              .find do |connection|
-          connection['name'].include?(Auth0::Api::AuthenticationEndpoints::UP_AUTH)
-        end['id']
-      end
-      let(:imported_users) { client.import_users(users_file, connection_id) }
-      it do
-        expect(imported_users).to include(
-          'connection' => Auth0::Api::AuthenticationEndpoints::UP_AUTH,
-          'status' => 'pending',
-          'type' => 'users_import'
-        )
-      end
-      let(:import_job_id) { imported_users['id'] }
-      it do
-        expect(client.get_job(import_job_id)).to include(
-          'connection' => Auth0::Api::AuthenticationEndpoints::UP_AUTH, 'type' => 'users_import', 'id' => import_job_id
-        )
-      end
+  let(:client) { Auth0Client.new(v2_creds) }
+  let(:username) { Faker::Internet.user_name }
+  let(:email) { "#{entity_suffix}#{Faker::Internet.safe_email(username)}" }
+  let(:connection_id) do
+    VCR.use_cassette('Auth0_Api_V2_Jobs/search_for_connection_id') do
+      client.connections.find do |connection|
+        connection['name'].include?(UP_AUTH)
+      end['id']
+    end
+  end
+
+  describe '.import_users and .get_job', vcr: true do
+    let(:file_name) { 'spec/fixtures/api-jobs-spec-import-users.json' }
+    let(:file_content) do
+      [{
+        email: email,
+        email_verified: false,
+        app_metadata: { roles: ['admin'] },
+        user_metadata: { theme: 'light' }
+      }].to_json
+    end
+    let(:import_file) do
+      File.open(file_name, 'w+') { |f| f.write(file_content) }
+      File.new(file_name, 'rb')
+    end
+    let(:imported_users) { client.import_users(import_file, connection_id) }
+    let(:import_job_id) { imported_users['id'] }
+
+    it 'should create an import users job successfully' do
+      expect(imported_users).to include(
+        'connection' => UP_AUTH,
+        'type' => 'users_import'
+      )
     end
 
-    describe '.export_users and .get_job' do
-      let(:connection_id) do
-        client.connections
-              .find do |connection|
-          connection['name'].include?(Auth0::Api::AuthenticationEndpoints::UP_AUTH)
-        end['id']
-      end
-      let(:exported_users) { client.export_users(connection_id: connection_id) }
-      it do
-        expect(exported_users).to include(
-          'connection' => Auth0::Api::AuthenticationEndpoints::UP_AUTH,
-          'status' => 'pending',
-          'type' => 'users_export'
-        )
-      end
-      let(:export_job_id) { exported_users['id'] }
-      it do
-        expect(client.get_job(export_job_id)).to include(
-          'connection' => Auth0::Api::AuthenticationEndpoints::UP_AUTH, 'type' => 'users_export', 'id' => export_job_id
-        )
-      end
+    it 'should get the import users job' do
+      expect(client.get_job(import_job_id)).to include(
+        'connection' => UP_AUTH,
+        'type' => 'users_import',
+        'id' => import_job_id
+      )
     end
 
-    describe '.send_verification_email and .get_job' do
-      let(:user) do
-        client.create_user(username,  'email' => email,
-                                      'password' => Faker::Internet.password,
-                                      'email_verified' => false,
-                                      'connection' => Auth0::Api::AuthenticationEndpoints::UP_AUTH,
-                                      'app_metadata' => {})
-      end
-      let(:email_verification_job) { client.send_verification_email(user['user_id']) }
-      it { expect(email_verification_job).to include('status' => 'pending', 'type' => 'verification_email') }
-      let(:email_job_id) { email_verification_job['id'] }
-      it do
-        expect(client.get_job(email_job_id)).to include(
-          'status' => 'completed', 'type' => 'verification_email', 'id' => email_job_id
-        )
-      end
+    after do
+      File.delete(file_name)
+    end
+  end
+
+  describe '.export_users and .get_job', vcr: true do
+    let(:exported_users) { client.export_users(connection_id: connection_id) }
+    let(:export_job_id) { exported_users['id'] }
+
+    it 'should create an export users job successfully' do
+      expect(exported_users).to include(
+        'connection' => UP_AUTH,
+        'type' => 'users_export'
+      )
     end
 
-    after(:all) do
+    it 'should get the export users job' do
+      expect(client.get_job(export_job_id)).to include(
+        'connection' => UP_AUTH,
+        'type' => 'users_export',
+        'id' => export_job_id
+      )
+    end
+  end
+
+  describe '.send_verification_email and .get_job', vcr: true do
+    let(:user) do
+      client.create_user(
+        username,
+        'email' => email,
+        'password' => Faker::Internet.password,
+        'connection' => UP_AUTH
+      )
+    end
+    let(:email_verification_job) { client.send_verification_email(user['user_id']) }
+    let(:email_job_id) { email_verification_job['id'] }
+
+    it 'should create a new verification_email job' do
+      expect(
+        email_verification_job
+      ).to include('status' => 'pending', 'type' => 'verification_email')
+    end
+
+    it 'should get the completed verification_email' do
+      expect(client.get_job(email_job_id)).to include(
+        'type' => 'verification_email',
+        'id' => email_job_id
+      )
+    end
+
+    it 'should reject an invalid client_id' do
+      expect do
+        client.send_verification_email(user['user_id'], Random.new(32).to_s)
+      end.to raise_error Auth0::BadRequest
+    end
+  end
+
+  after(:all) do
+    VCR.use_cassette('Auth0_Api_V2_Jobs/delete_imported_user') do
       new_client = Auth0Client.new(v2_creds)
-      delete_user_id = new_client.get_users(q: 'email:@example.com').first['user_id']
-      new_client.delete_user(delete_user_id)
+      delete_user = new_client.get_users(q: "email:#{entity_suffix}*").first
+      new_client.delete_user(delete_user['user_id']) unless delete_user.nil?
     end
   end
 end

--- a/spec/integration/lib/auth0/api/v2/api_resource_servers_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_resource_servers_spec.rb
@@ -127,5 +127,4 @@ describe Auth0::Api::V2::ResourceServers do
     end
   end
 
-  
 end

--- a/spec/lib/auth0/api/v2/jobs_spec.rb
+++ b/spec/lib/auth0/api/v2/jobs_spec.rb
@@ -29,12 +29,11 @@ describe Auth0::Api::V2::Jobs do
     it { expect { @instance.export_users }.not_to raise_error }
     it 'sends post to /api/v2/jobs/users-exports with correct params' do
       expect(@instance).to receive(:post).with(
-        '/api/v2/jobs/users-exports', {
-          fields: [{ name: 'author' }],
-          connection_id: 'test-connection',
-          format: 'csv',
-          limit: 10
-        }
+        '/api/v2/jobs/users-exports',
+        fields: [{ name: 'author' }],
+        connection_id: 'test-connection',
+        format: 'csv',
+        limit: 10
       )
       @instance.export_users(
         fields: ['author'],
@@ -44,12 +43,37 @@ describe Auth0::Api::V2::Jobs do
       )
     end
   end
+
   context '.send_verification_email' do
-    it { expect(@instance).to respond_to(:send_verification_email) }
-    it 'expect client to send post to /api/v2/jobs/verification-email' do
-      expect(@instance).to receive(:post).with('/api/v2/jobs/verification-email', user_id: 'user_id')
-      expect { @instance.send_verification_email('user_id') }.not_to raise_error
+    it 'should respond to a send_verification_email method' do
+      expect(@instance).to respond_to(:send_verification_email)
     end
-    it { expect { @instance.send_verification_email('') }.to raise_error('Must specify a user id') }
+
+    it 'should post to the jobs email verification endpoint' do
+      expect(@instance).to receive(:post).with(
+        '/api/v2/jobs/verification-email',
+        user_id: 'test_user_id'
+      )
+      expect do
+        @instance.send_verification_email('test_user_id')
+      end.not_to raise_error
+    end
+
+    it 'should post to the jobs email verification endpoint with a client_id' do
+      expect(@instance).to receive(:post).with(
+        '/api/v2/jobs/verification-email',
+        user_id: 'test_user_id',
+        client_id: 'test_client_id'
+      )
+      expect do
+        @instance.send_verification_email('test_user_id', 'test_client_id')
+      end.not_to raise_error
+    end
+
+    it 'should raise an error if the user_id is empty' do
+      expect do
+        @instance.send_verification_email('')
+      end.to raise_error('Must specify a user id')
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ require 'vcr'
 VCR.configure do |config|
   # Uncomment the line below to record new VCR cassettes.
   # When this is commented out, VCR will reject all outbound HTTP calls.
-  # config.allow_http_connections_when_no_cassette = true
+  config.allow_http_connections_when_no_cassette = true
   config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   config.configure_rspec_metadata!
   config.hook_into :webmock


### PR DESCRIPTION
### Changes

- Add Add Client ID to `Auth0::Api::V2::Jobs.send_verification_email`
- Remove skipped Jobs tests and add VCR cassettes

### References

Fixes #92 

### Testing

[Failing tests for new feature](https://travis-ci.org/auth0/ruby-auth0/builds/499524045)

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby (2.5.1)

### Checklist

* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
