### PR TITLE
[WIP] Replace rest-client with HTTPrb

### DIFF
--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'rest-client', '~> 2.0'
+  s.add_runtime_dependency 'http'
 
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'fuubar', '~> 2.0'

--- a/lib/auth0/mixins.rb
+++ b/lib/auth0/mixins.rb
@@ -1,5 +1,5 @@
 require 'base64'
-require 'rest-client'
+require 'http'
 require 'uri'
 require 'auth0/mixins/httpproxy'
 require 'auth0/mixins/initializer'

--- a/lib/auth0/mixins/httpproxy.rb
+++ b/lib/auth0/mixins/httpproxy.rb
@@ -54,10 +54,10 @@ module Auth0
       end
 
       def call(method, url, timeout, headers, body = nil)
-        RestClient::Request.execute(method: method, url: url, timeout: timeout, headers: headers, payload: body)
-      rescue RestClient::Exception => e
+        HTTP::Request.execute(method: method, url: url, timeout: timeout, headers: headers, payload: body)
+      rescue HTTP::Error => e
         case e
-        when RestClient::RequestTimeout
+        when HTTP::TimeoutError
           raise Auth0::RequestTimeout
         else
           return e.response

--- a/spec/support/dummy_class_for_restclient.rb
+++ b/spec/support/dummy_class_for_restclient.rb
@@ -1,2 +1,0 @@
-class DummyClassForRestClient < RestClient::Exception
-end


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

rest-client has not been actively maintained in ~2 years.
HTTPrb is a strong alternative - https://github.com/httprb/http

- Endpoints added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
