### PR TITLE
Add missing User Management API endpoints

### DIFF
--- a/lib/auth0/api/v2/users.rb
+++ b/lib/auth0/api/v2/users.rb
@@ -257,7 +257,7 @@ module Auth0
         # @see https://auth0.com/docs/api/management/v2#!/Users/delete_permissions
         #
         # @param user_id [string] The user_id of the permissions to remove.
-        # @param permissions [array] An array of Permissions to remove.
+        # @param permissions [array] An array of Permission structs to remove.
         def remove_permissions(user_id, permissions)
           raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
           permissions = validate_permissions_array permissions
@@ -268,14 +268,14 @@ module Auth0
         # @see https://auth0.com/docs/api/management/v2#!/Users/post_permissions
         #
         # @param user_id [string] The user_id of the permissions to add.
-        # @param permissions [array] An array of Permissions to add.
+        # @param permissions [array] An array of Permission structs to add.
         def add_permissions(user_id, permissions)
           raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
           permissions = validate_permissions_array permissions
           post("#{users_path}/#{user_id}/permissions", permissions)
         end
 
-        # Removes the current Guardian recovery code and generates and returns a new one.
+        # Remove the current Guardian recovery code and generates and returns a new one.
         # @see https://auth0.com/docs/api/management/v2#!/Users/post_recovery_code_regeneration
         #
         # @param user_id [string] The user_id of the recovery codes to regenerate.
@@ -284,7 +284,7 @@ module Auth0
           post "#{users_path}/#{user_id}/recovery-code-generation"
         end
 
-        # Invalidates all remembered browsers for all authentication factors for a specific user.
+        # Invalidate all remembered browsers for all authentication factors for a specific user.
         # @see https://auth0.com/docs/api/management/v2#!/Users/post_invalidate_remember_browser
         #
         # @param user_id [string] The user_id of the browsers to invalidate.

--- a/lib/auth0/api/v2/users.rb
+++ b/lib/auth0/api/v2/users.rb
@@ -53,6 +53,7 @@ module Auth0
 
         # Delete all users - USE WITH CAUTION
         # @see https://auth0.com/docs/api/v2#!/Users/delete_users
+        # TODO: Deprecate, no longer provided
         def delete_users
           delete(users_path)
         end
@@ -96,7 +97,7 @@ module Auth0
         # If your are updating email or phone_number you need to specify the connection and the client_id properties.
         # @see https://auth0.com/docs/api/v2#!/Users/patch_users_by_id
         # @param user_id [string] The user_id of the user to update.
-        # @param body [hash] The optional parametes to update.
+        # @param body [hash] The optional parameters to update.
         #
         # @return [json] Returns the updated user.
         def patch_user(user_id, body)
@@ -168,7 +169,6 @@ module Auth0
           raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
           path = "#{users_path}/#{user_id}/logs"
           request_params = {
-            user_id:        user_id,
             per_page:       options.fetch(:per_page, nil),
             page:           options.fetch(:page, nil),
             include_totals: options.fetch(:include_totals, nil),

--- a/lib/auth0/mixins/permission_struct.rb
+++ b/lib/auth0/mixins/permission_struct.rb
@@ -1,0 +1,3 @@
+Permission = Struct.new :permission_name, :resource_server_identifier do
+
+end

--- a/spec/lib/auth0/api/v2/users_spec.rb
+++ b/spec/lib/auth0/api/v2/users_spec.rb
@@ -243,7 +243,6 @@ describe Auth0::Api::V2::Users do
     it 'is expected to get /api/v2/USER_ID/logs' do
       expect(@instance).to receive(:get).with(
         '/api/v2/users/USER_ID/logs',
-        user_id: 'USER_ID',
         per_page: nil,
         page: nil,
         include_totals: nil,
@@ -318,11 +317,14 @@ describe Auth0::Api::V2::Users do
       expect { @instance.remove_roles('USER_ID', []) }.to raise_exception(Auth0::InvalidParameter)
     end
 
+    it 'is expected to raise an exception when the roles are empty' do
+      expect { @instance.remove_roles('USER_ID', [1, 2]) }.to raise_exception(Auth0::InvalidParameter)
+    end
+
     it 'is expected to remove roles' do
       expect(@instance).to receive(:delete).with(
         '/api/v2/users/USER_ID/roles',
-        'USER_ID',
-        %w[test-role-01 test-role-02]
+        roles: %w[test-role-01 test-role-02]
       )
       expect do
         @instance.remove_roles('USER_ID', %w[test-role-01 test-role-02])
@@ -344,14 +346,13 @@ describe Auth0::Api::V2::Users do
     end
 
     it 'is expected to raise an exception when the roles are empty' do
-      expect { @instance.add_roles('USER_ID', []) }.to raise_exception(Auth0::InvalidParameter)
+      expect { @instance.add_roles('USER_ID', [3, 4]) }.to raise_exception(Auth0::InvalidParameter)
     end
 
     it 'is expected to add roles' do
       expect(@instance).to receive(:post).with(
         '/api/v2/users/USER_ID/roles',
-        'USER_ID',
-        %w[test-role-03 test-role-04]
+        roles: %w[test-role-03 test-role-04]
       )
       expect do
         @instance.add_roles('USER_ID', %w[test-role-03 test-role-04])
@@ -369,10 +370,7 @@ describe Auth0::Api::V2::Users do
     end
 
     it 'is expected to get enrollments' do
-      expect(@instance).to receive(:get).with(
-        '/api/v2/users/USER_ID/enrollments',
-        'USER_ID'
-      )
+      expect(@instance).to receive(:get).with('/api/v2/users/USER_ID/enrollments')
       expect do
         @instance.get_enrollments('USER_ID')
       end.not_to raise_error
@@ -389,10 +387,7 @@ describe Auth0::Api::V2::Users do
     end
 
     it 'is expected to get permissions' do
-      expect(@instance).to receive(:get).with(
-        '/api/v2/users/USER_ID/permissions',
-        'USER_ID'
-      )
+      expect(@instance).to receive(:get).with('/api/v2/users/USER_ID/permissions')
       expect do
         @instance.get_permissions('USER_ID')
       end.not_to raise_error
@@ -412,7 +407,7 @@ describe Auth0::Api::V2::Users do
       expect { @instance.remove_permissions('USER_ID', []) }.to raise_exception(Auth0::InvalidParameter)
     end
 
-    it 'is expected to raise an exception when the permissions are not Permission structs' do
+    it 'is expected to raise an exception when the array does not consist of Permissions' do
       expect do
         @instance.remove_permissions('USER_ID', %w[permission-01 permission02])
       end.to raise_exception(Auth0::InvalidParameter)
@@ -421,24 +416,23 @@ describe Auth0::Api::V2::Users do
     it 'is expected to remove permissions' do
       expect(@instance).to receive(:delete).with(
         '/api/v2/users/USER_ID/permissions',
-        'USER_ID',
         [
-          Permission.new('permission-name-1', 'server-id-1'),
-          Permission.new('permission-name-2', 'server-id-2')
+          {
+            permission_name: 'permission-name-1',
+            resource_server_identifier: 'server-id-1'
+          },
+          {
+            permission_name: 'permission-name-2',
+            resource_server_identifier: 'server-id-2'
+          }
         ]
       )
       expect do
         @instance.remove_permissions(
           'USER_ID',
           [
-            {
-              permission_name: 'permission-name-1',
-              resource_server_identifier: 'server-id-1'
-            },
-            {
-              permission_name: 'permission-name-2',
-              resource_server_identifier: 'server-id-2'
-            }
+            Permission.new('permission-name-1', 'server-id-1'),
+            Permission.new('permission-name-2', 'server-id-2')
           ]
         )
       end.not_to raise_error
@@ -464,27 +458,26 @@ describe Auth0::Api::V2::Users do
       end.to raise_exception(Auth0::InvalidParameter)
     end
 
-    it 'is expected to remove permissions' do
+    it 'is expected to add permissions' do
       expect(@instance).to receive(:post).with(
         '/api/v2/users/USER_ID/permissions',
-        'USER_ID',
         [
-          Permission.new('permission-name-1', 'server-id-1'),
-          Permission.new('permission-name-2', 'server-id-2')
+          {
+            permission_name: 'permission-name-1',
+            resource_server_identifier: 'server-id-1'
+          },
+          {
+            permission_name: 'permission-name-2',
+            resource_server_identifier: 'server-id-2'
+          }
         ]
       )
       expect do
         @instance.add_permissions(
           'USER_ID',
           [
-            {
-              permission_name: 'permission-name-1',
-              resource_server_identifier: 'server-id-1'
-            },
-            {
-              permission_name: 'permission-name-2',
-              resource_server_identifier: 'server-id-2'
-            }
+            Permission.new('permission-name-1', 'server-id-1'),
+            Permission.new('permission-name-2', 'server-id-2')
           ]
         )
       end.not_to raise_error
@@ -501,10 +494,7 @@ describe Auth0::Api::V2::Users do
     end
 
     it 'is expected to get generate a recovery code' do
-      expect(@instance).to receive(:post).with(
-        '/api/v2/users/USER_ID/recovery-code-generation',
-        'USER_ID'
-      )
+      expect(@instance).to receive(:post).with('/api/v2/users/USER_ID/recovery-code-generation')
       expect do
         @instance.generate_recovery_code('USER_ID')
       end.not_to raise_error
@@ -522,8 +512,7 @@ describe Auth0::Api::V2::Users do
 
     it 'is expected to invalidate remembered browsers' do
       expect(@instance).to receive(:post).with(
-        '/api/v2/users/USER_ID/multifactor/actions/invalidate-remember-browser',
-        'USER_ID'
+        '/api/v2/users/USER_ID/multifactor/actions/invalidate-remember-browser'
       )
       expect do
         @instance.invalidate_browsers('USER_ID')

--- a/spec/lib/auth0/api/v2/users_spec.rb
+++ b/spec/lib/auth0/api/v2/users_spec.rb
@@ -7,10 +7,15 @@ describe Auth0::Api::V2::Users do
   end
 
   context '.users' do
-    it { expect(@instance).to respond_to(:users) }
-    it { expect(@instance).to respond_to(:get_users) }
+    it 'is expected to respond to a users method' do
+      expect(@instance).to respond_to(:users)
+    end
 
-    it 'is expected to call /api/v2/users' do
+    it 'is expected to respond to a get_users method' do
+      expect(@instance).to respond_to(:get_users)
+    end
+
+    it 'is expected to get /api/v2/users' do
       expect(@instance).to receive(:get).with(
         '/api/v2/users',
         per_page: nil,
@@ -26,35 +31,57 @@ describe Auth0::Api::V2::Users do
       expect { @instance.users }.not_to raise_error
     end
 
-    it 'is expected to call /api/v2/users with a search engine' do
+    it 'is expected to get /api/v2/users with custom parameters' do
       expect(@instance).to receive(:get).with(
         '/api/v2/users',
-        per_page: nil,
-        page: nil,
-        include_totals: nil,
+        per_page: 10,
+        page: 1,
+        include_totals: true,
         sort: nil,
-        connection: nil,
-        fields: nil,
+        connection: 'auth0',
+        fields: 'name,email',
         include_fields: nil,
         q: nil,
         search_engine: 'v3'
       )
-      expect { @instance.users(search_engine: 'v3') }.not_to raise_error
+      expect do
+        @instance.users(
+          search_engine: 'v3',
+          per_page: 10,
+          page: 1,
+          include_totals: true,
+          connection: 'auth0',
+          fields: 'name,email'
+        )
+      end.not_to raise_error
     end
   end
 
   context '.user' do
-    it { expect(@instance).to respond_to(:user) }
+    it 'is expected to respond to a user method' do
+      expect(@instance).to respond_to(:user)
+    end
+
     it 'is expected to call get request to /api/v2/users/USER_ID' do
-      expect(@instance).to receive(:get).with('/api/v2/users/USER_ID', fields: nil, include_fields: true)
+      expect(@instance).to receive(:get).with(
+        '/api/v2/users/USER_ID',
+        fields: nil,
+        include_fields: true
+      )
       expect { @instance.user('USER_ID') }.not_to raise_error
     end
-    it { expect { @instance.user('') }.to raise_error 'Must supply a valid user_id' }
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.user(nil) }.to raise_exception(Auth0::MissingUserId)
+    end
   end
 
   context '.create_user' do
-    it { expect(@instance).to respond_to(:create_user) }
-    it 'is expected to call post to /api/v2/users' do
+    it 'is expected to respond to a create_user method' do
+      expect(@instance).to respond_to(:create_user)
+    end
+
+    it 'is expected to post to /api/v2/users' do
       expect(@instance).to receive(:post).with(
         '/api/v2/users',
         email: 'test@test.com',
@@ -62,104 +89,158 @@ describe Auth0::Api::V2::Users do
         connection: 'conn',
         name: 'name'
       )
-      @instance.create_user(
-        'name',
-        email: 'test@test.com',
-        password: 'password',
-        connection: 'conn'
-      )
+      expect do
+        @instance.create_user(
+          'name',
+          email: 'test@test.com',
+          password: 'password',
+          connection: 'conn'
+        )
+      end.not_to raise_error
     end
   end
 
   context '.delete_users' do
-    it { expect(@instance).to respond_to :delete_users }
+    it 'is expected to respond to a delete_users method' do
+      expect(@instance).to respond_to :delete_users
+    end
+
     it 'is expected to call delete to /api/v2/users' do
       expect(@instance).to receive(:delete).with('/api/v2/users')
-      @instance.delete_users
+      expect { @instance.delete_users }.not_to raise_error
     end
   end
 
   context '.delete_user' do
-    it { expect(@instance).to respond_to(:delete_user) }
-    it 'is expected to call delete to /api/v2/users/userId' do
-      expect(@instance).to receive(:delete).with('/api/v2/users/userId')
-      @instance.delete_user('userId')
+    it 'is expected to respond to a delete_user method' do
+      expect(@instance).to respond_to(:delete_user)
     end
 
-    it 'is expected not to call delete to /api/v2/users if user_id is blank' do
+    it 'is expected to delete /api/v2/users/USER_ID' do
+      expect(@instance).to receive(:delete).with('/api/v2/users/USER_ID')
+      @instance.delete_user('USER_ID')
+    end
+
+    it 'is expected not to delete /api/v2/users if user_id is blank' do
       expect(@instance).not_to receive(:delete)
-      expect { @instance.delete_user('') }.to raise_exception(
+      expect { @instance.delete_user(nil) }.to raise_exception(
         Auth0::MissingUserId
       )
     end
   end
 
   context '.delete_user_provider' do
-    it { expect(@instance).to respond_to(:delete_user_provider) }
-    it 'is expected to call delete to /api/v2/users/userId/multifactor/provider' do
-      expect(@instance).to receive(:delete).with('/api/v2/users/userId/multifactor/provider')
-      @instance.delete_user_provider('userId', 'provider')
+    it 'is expected to respond to a delete_user_provider method' do
+      expect(@instance).to respond_to(:delete_user_provider)
+    end
+
+    it 'is expected to delete /api/v2/users/userId/multifactor/provider' do
+      expect(@instance).to receive(:delete).with('/api/v2/users/USER_ID/multifactor/PROVIDER_NAME')
+      @instance.delete_user_provider('USER_ID', 'PROVIDER_NAME')
+    end
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.delete_user_provider(nil, 'PROVIDER_NAME') }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to raise an exception when the provider name is empty' do
+      expect { @instance.delete_user_provider('USER_ID', nil) }.to raise_error 'Must supply a valid provider name'
     end
   end
 
   context '.patch_user' do
-    it { expect(@instance).to respond_to(:patch_user) }
-    it 'is expected to call patch to /api/v2/users/userID' do
+    it 'is expected to respond to a patch_user method' do
+      expect(@instance).to respond_to(:patch_user)
+    end
+
+    it 'is expected to respond to a update_user method' do
+      expect(@instance).to respond_to(:update_user)
+    end
+
+    it 'is expected to patch /api/v2/users/USER_ID' do
       expect(@instance).to receive(:patch).with(
-        '/api/v2/users/UserID',
+        '/api/v2/users/USER_ID',
         email: 'test@test.com',
         password: 'password',
         connection: 'conn',
         name: 'name'
       )
       @instance.patch_user(
-        'UserID',
+        'USER_ID',
         email: 'test@test.com',
         password: 'password',
         connection: 'conn',
         name: 'name'
       )
     end
-    it { expect { @instance.patch_user('', 'body') }.to raise_error 'Must supply a valid user_id' }
-    it { expect { @instance.patch_user('UserId', '') }.to raise_error 'Must supply a valid body' }
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.patch_user(nil, 'BODY') }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to raise an error when the body is empty' do
+      expect { @instance.patch_user('USER_ID', nil) }.to raise_error 'Must supply a valid body'
+    end
   end
 
   context '.link_user_account' do
-    it { expect(@instance).to respond_to(:link_user_account) }
-    it 'is expected to call post to /api/v2/users/UserId/identities' do
-      expect(@instance).to receive(:post).with('/api/v2/users/UserID/identities', body: 'json body')
-      @instance.link_user_account('UserID', body: 'json body')
+    it 'is expected to respond to a link_user_account method' do
+      expect(@instance).to respond_to(:link_user_account)
     end
-    it { expect { @instance.link_user_account('', 'body') }.to raise_error 'Must supply a valid user_id' }
-    it { expect { @instance.link_user_account('UserId', '') }.to raise_error 'Must supply a valid body' }
+
+    it 'is expected to post to /api/v2/users/UserId/identities' do
+      expect(@instance).to receive(:post).with('/api/v2/users/USER_ID/identities', body: 'json body')
+      @instance.link_user_account('USER_ID', body: 'json body')
+    end
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.link_user_account(nil, 'BODY') }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to raise an error when the body is empty' do
+      expect { @instance.link_user_account('USER_ID', nil) }.to raise_error 'Must supply a valid body'
+    end
   end
 
   context '.unlink_users_account' do
-    it { expect(@instance).to respond_to(:unlink_users_account) }
-    it 'is expected to call delete to /api/v2/users/UserId/identities' do
-      expect(@instance).to receive(:delete).with('/api/v2/users/UserID/identities/provider_name/Secondary_User_ID')
-      @instance.unlink_users_account('UserID', 'provider_name', 'Secondary_User_ID')
+    it 'is expected to respond to a unlink_users_account method' do
+      expect(@instance).to respond_to(:unlink_users_account)
     end
-    it { expect { @instance.unlink_users_account('', 'pro', 'SUserID') }.to raise_error 'Must supply a valid user_id' }
-    it { expect { @instance.unlink_users_account('UID', nil, 'SUID') }.to raise_error 'Must supply a valid provider' }
-    it do
-      expect { @instance.unlink_users_account('UID', 'pro', nil) }.to raise_error 'Must supply a valid secondary user_id'
-    end
-  end
 
-  context '.delete_user_provider' do
-    it { expect(@instance).to respond_to(:delete_user_provider) }
-    it 'is expected to call delete to /api/v2/users/User_ID/multifactor/provider_name' do
-      expect(@instance).to receive(:delete).with('/api/v2/users/User_ID/multifactor/provider_name')
-      @instance.delete_user_provider('User_ID', 'provider_name')
+    it 'is expected to delete /api/v2/users/UserId/identities' do
+      expect(@instance).to receive(:delete).with('/api/v2/users/USER_ID_1/identities/PROVIDER_NAME/USER_ID_2')
+      @instance.unlink_users_account('USER_ID_1', 'PROVIDER_NAME', 'USER_ID_2')
     end
-    it { expect { @instance.delete_user_provider(nil, 'test') }.to raise_error 'Must supply a valid user_id' }
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect do
+        @instance.unlink_users_account(nil, 'PROVIDER_NAME', 'USER_ID_2')
+      end.to raise_error 'Must supply a valid user_id'
+    end
+
+    it 'is expected to raise an exception when the provider is empty' do
+      expect do
+        @instance.unlink_users_account('USER_ID_1', nil, 'USER_ID_2')
+      end.to raise_error 'Must supply a valid provider'
+    end
+
+    it 'is expected to raise an exception when the secondary user ID is empty' do
+      expect do
+        @instance.unlink_users_account('USER_ID_1', 'PROVIDER_NAME', nil)
+      end.to raise_error 'Must supply a valid secondary user_id'
+    end
   end
 
   context '.user_logs' do
-    it { expect(@instance).to respond_to(:user_logs) }
-    it { expect(@instance).to respond_to(:get_user_log_events) }
-    it 'is expected to call /api/v2/USER_ID/logs' do
+    it 'is expected to respond to a user_logs method' do
+      expect(@instance).to respond_to(:user_logs)
+    end
+
+    it 'is expected to respond to a get_user_log_events method' do
+      expect(@instance).to respond_to(:get_user_log_events)
+    end
+
+    it 'is expected to get /api/v2/USER_ID/logs' do
       expect(@instance).to receive(:get).with(
         '/api/v2/users/USER_ID/logs',
         user_id: 'USER_ID',
@@ -170,16 +251,283 @@ describe Auth0::Api::V2::Users do
       )
       expect { @instance.user_logs('USER_ID') }.not_to raise_error
     end
-    it { expect { @instance.user_logs('') }.to raise_error 'Must supply a valid user_id' }
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.user_logs(nil) }.to raise_exception(Auth0::MissingUserId)
+    end
+
     it 'is expected to raise an error when per_page is higher than 100' do
       expect { @instance.user_logs('USER_ID', per_page: rand(101..2000)) }.to raise_error(
         'The total amount of entries per page should be less than 100'
       )
     end
+
     it 'is expected to raise an error when sort does not match pattern' do
       expect { @instance.user_logs('USER_ID', sort: 'no match') }.to raise_error(
         'Sort does not match pattern ^(([a-zA-Z0-9_\\.]+))\\:(1|-1)$'
       )
+    end
+  end
+
+  context '.get_roles' do
+    it 'is expected to respond to a get_roles method' do
+      expect(@instance).to respond_to(:get_roles)
+    end
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.get_roles(nil) }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to get roles with default parameters' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/users/USER_ID/roles',
+        per_page: nil,
+        page: nil,
+        include_totals: nil
+      )
+      expect { @instance.get_roles('USER_ID') }.not_to raise_error
+    end
+
+    it 'is expected to get roles with custom parameters' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/users/USER_ID/roles',
+        per_page: 20,
+        page: 2,
+        include_totals: true
+      )
+      expect do
+        @instance.get_roles('USER_ID', per_page: 20, page: 2, include_totals: true)
+      end.not_to raise_error
+    end
+  end
+
+  context '.remove_roles' do
+    it 'is expected to respond to a remove_roles method' do
+      expect(@instance).to respond_to(:remove_roles)
+    end
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.remove_roles(nil, 'ROLES') }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to raise an exception when the roles are not an array' do
+      expect { @instance.remove_roles('USER_ID', 'ROLES') }.to raise_exception(Auth0::InvalidParameter)
+    end
+
+    it 'is expected to raise an exception when the roles are empty' do
+      expect { @instance.remove_roles('USER_ID', []) }.to raise_exception(Auth0::InvalidParameter)
+    end
+
+    it 'is expected to remove roles' do
+      expect(@instance).to receive(:delete).with(
+        '/api/v2/users/USER_ID/roles',
+        'USER_ID',
+        %w[test-role-01 test-role-02]
+      )
+      expect do
+        @instance.remove_roles('USER_ID', %w[test-role-01 test-role-02])
+      end.not_to raise_error
+    end
+  end
+
+  context '.add_roles' do
+    it 'is expected to respond to a add_roles method' do
+      expect(@instance).to respond_to(:add_roles)
+    end
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.add_roles(nil, 'ROLES') }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.add_roles('USER_ID', 'ROLES') }.to raise_exception(Auth0::InvalidParameter)
+    end
+
+    it 'is expected to raise an exception when the roles are empty' do
+      expect { @instance.add_roles('USER_ID', []) }.to raise_exception(Auth0::InvalidParameter)
+    end
+
+    it 'is expected to add roles' do
+      expect(@instance).to receive(:post).with(
+        '/api/v2/users/USER_ID/roles',
+        'USER_ID',
+        %w[test-role-03 test-role-04]
+      )
+      expect do
+        @instance.add_roles('USER_ID', %w[test-role-03 test-role-04])
+      end.not_to raise_error
+    end
+  end
+
+  context '.get_enrollments' do
+    it 'is expected to respond to a get_enrollments method' do
+      expect(@instance).to respond_to(:get_enrollments)
+    end
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.get_enrollments(nil) }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to get enrollments' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/users/USER_ID/enrollments',
+        'USER_ID'
+      )
+      expect do
+        @instance.get_enrollments('USER_ID')
+      end.not_to raise_error
+    end
+  end
+
+  context '.get_permissions' do
+    it 'is expected to respond to a get_permissions method' do
+      expect(@instance).to respond_to(:get_permissions)
+    end
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.get_permissions(nil) }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to get permissions' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/users/USER_ID/permissions',
+        'USER_ID'
+      )
+      expect do
+        @instance.get_permissions('USER_ID')
+      end.not_to raise_error
+    end
+  end
+
+  context '.remove_permissions' do
+    it 'is expected to respond to a remove_permissions method' do
+      expect(@instance).to respond_to(:remove_permissions)
+    end
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.remove_permissions(nil, 'PERMISSIONS') }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to raise an exception when the permissions are empty' do
+      expect { @instance.remove_permissions('USER_ID', []) }.to raise_exception(Auth0::InvalidParameter)
+    end
+
+    it 'is expected to raise an exception when the permissions are not Permission structs' do
+      expect do
+        @instance.remove_permissions('USER_ID', %w[permission-01 permission02])
+      end.to raise_exception(Auth0::InvalidParameter)
+    end
+
+    it 'is expected to remove permissions' do
+      expect(@instance).to receive(:delete).with(
+        '/api/v2/users/USER_ID/permissions',
+        'USER_ID',
+        [
+          Permission.new('permission-name-1', 'server-id-1'),
+          Permission.new('permission-name-2', 'server-id-2')
+        ]
+      )
+      expect do
+        @instance.remove_permissions(
+          'USER_ID',
+          [
+            {
+              permission_name: 'permission-name-1',
+              resource_server_identifier: 'server-id-1'
+            },
+            {
+              permission_name: 'permission-name-2',
+              resource_server_identifier: 'server-id-2'
+            }
+          ]
+        )
+      end.not_to raise_error
+    end
+  end
+
+  context '.add_permissions' do
+    it 'is expected to respond to a add_permissions method' do
+      expect(@instance).to respond_to(:add_permissions)
+    end
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.add_permissions(nil, 'PERMISSIONS') }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to raise an exception when the permissions are empty' do
+      expect { @instance.add_permissions('USER_ID', []) }.to raise_exception(Auth0::InvalidParameter)
+    end
+
+    it 'is expected to raise an exception when the permissions are not Permission structs' do
+      expect do
+        @instance.add_permissions('USER_ID', %w[permission-01 permission02])
+      end.to raise_exception(Auth0::InvalidParameter)
+    end
+
+    it 'is expected to remove permissions' do
+      expect(@instance).to receive(:post).with(
+        '/api/v2/users/USER_ID/permissions',
+        'USER_ID',
+        [
+          Permission.new('permission-name-1', 'server-id-1'),
+          Permission.new('permission-name-2', 'server-id-2')
+        ]
+      )
+      expect do
+        @instance.add_permissions(
+          'USER_ID',
+          [
+            {
+              permission_name: 'permission-name-1',
+              resource_server_identifier: 'server-id-1'
+            },
+            {
+              permission_name: 'permission-name-2',
+              resource_server_identifier: 'server-id-2'
+            }
+          ]
+        )
+      end.not_to raise_error
+    end
+  end
+
+  context '.generate_recovery_code' do
+    it 'is expected to respond to a generate_recovery_code method' do
+      expect(@instance).to respond_to(:generate_recovery_code)
+    end
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.generate_recovery_code(nil) }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to get generate a recovery code' do
+      expect(@instance).to receive(:post).with(
+        '/api/v2/users/USER_ID/recovery-code-generation',
+        'USER_ID'
+      )
+      expect do
+        @instance.generate_recovery_code('USER_ID')
+      end.not_to raise_error
+    end
+  end
+
+  context '.invalidate_browsers' do
+    it 'is expected to respond to a invalidate_browsers method' do
+      expect(@instance).to respond_to(:invalidate_browsers)
+    end
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.invalidate_browsers(nil) }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to invalidate remembered browsers' do
+      expect(@instance).to receive(:post).with(
+        '/api/v2/users/USER_ID/multifactor/actions/invalidate-remember-browser',
+        'USER_ID'
+      )
+      expect do
+        @instance.invalidate_browsers('USER_ID')
+      end.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
### Changes

Adds all missing User endpoints:

- `Auth0::Api::V2::Users.get_roles`
- `Auth0::Api::V2::Users.remove_roles`
- `Auth0::Api::V2::Users.add_roles`
- `Auth0::Api::V2::Users.get_enrollments`
- `Auth0::Api::V2::Users.get_permissions`
- `Auth0::Api::V2::Users.remove_permissions`
- `Auth0::Api::V2::Users.add_permissions`
- `Auth0::Api::V2::Users.generate_recovery_code`
- `Auth0::Api::V2::Users.invalidate_browsers`

### Testing

Will add integration tests in another PR after Roles

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of Ruby (2.6.0)

### Checklist

* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
