### PR TITLE
Expose rate limiting information

### DIFF
--- a/lib/auth0/exception.rb
+++ b/lib/auth0/exception.rb
@@ -33,4 +33,12 @@ module Auth0
   class InvalidCredentials < Auth0::Exception; end
   # Invalid Auth0 API namespace
   class InvalidApiNamespace < Auth0::Exception; end
+  # Auth0 API rate-limiting encountered
+  class RateLimitEncountered < Auth0::Exception
+    attr_reader :limit, :remaining, :reset
+    def initialize(message,limit,remaining,reset)
+      super(message)
+      @limit, @remaining, @reset = limit, remaining, reset
+    end
+  end
 end

--- a/lib/auth0/exception.rb
+++ b/lib/auth0/exception.rb
@@ -52,7 +52,7 @@ module Auth0
   # Auth0 API rate-limiting encountered
   class RateLimitEncountered < Auth0::HTTPError
     def reset
-      Time.at(headers['X-RateLimit-Reset'])
+      Time.at(headers['X-RateLimit-Reset']).utc
     end
   end
 end

--- a/lib/auth0/exception.rb
+++ b/lib/auth0/exception.rb
@@ -50,7 +50,11 @@ module Auth0
   # Invalid Auth0 API namespace
   class InvalidApiNamespace < Auth0::Exception; end
   # Auth0 API rate-limiting encountered
-  class RateLimitEncountered < Auth0::HTTPError
+  # TODO: When making API-breaking changes, make this a subclass
+  # of Auth0::HTTPError directly rather than Auth0::Unsupported.
+  # It's currently under Unsupported to avoid breaking compatibility
+  # with prior gem versions that treated 429 errors as unknown errors.
+  class RateLimitEncountered < Auth0::Unsupported
     def reset
       Time.at(headers['X-RateLimit-Reset']).utc
     end

--- a/lib/auth0/exception.rb
+++ b/lib/auth0/exception.rb
@@ -2,19 +2,35 @@ module Auth0
   # Default exception in namespace of Auth0
   # if you want to catch all exceptions, then you should use this one.
   # Network exceptions are not included
-  class Exception < StandardError; end
+  class Exception < StandardError
+    attr_reader :error_data
+    def initialize(message,error_data={})
+      super(message)
+      @error_data = error_data
+    end
+  end
+  # Parent for all exceptions that arise out of HTTP error responses.
+  class HTTPError < Auth0::Exception
+    def headers
+      error_data[:headers]
+    end
+
+    def http_code
+      error_data[:code]
+    end
+  end
   # exception for unauthorized requests, if you see it,
   # probably Bearer Token is not set correctly
-  class Unauthorized < Auth0::Exception; end
+  class Unauthorized < Auth0::HTTPError; end
   # exception for not found resource, you query for an
   # unexistent resource, or wrong path
-  class NotFound < Auth0::Exception; end
+  class NotFound < Auth0::HTTPError; end
   # exception for unknown error
-  class Unsupported < Auth0::Exception; end
+  class Unsupported < Auth0::HTTPError; end
   # exception for server error
-  class ServerError < Auth0::Exception; end
+  class ServerError < Auth0::HTTPError; end
   # exception for incorrect request, you've sent wrong params
-  class BadRequest < Auth0::Exception; end
+  class BadRequest < Auth0::HTTPError; end
   # exception for timeouts
   class RequestTimeout < Auth0::Exception; end
   # exception for unset user_id, this might cause removal of
@@ -25,7 +41,7 @@ module Auth0
   # exception for an unset parameter
   class MissingParameter < Auth0::Exception; end
   # Api v2 access denied
-  class AccessDenied < Auth0::Exception; end
+  class AccessDenied < Auth0::HTTPError; end
   # Invalid parameter passed, e.g. empty where ID is required
   class InvalidParameter < Auth0::Exception; end
   # Invalid Auth0 credentials either client_id/secret for API v1
@@ -34,11 +50,9 @@ module Auth0
   # Invalid Auth0 API namespace
   class InvalidApiNamespace < Auth0::Exception; end
   # Auth0 API rate-limiting encountered
-  class RateLimitEncountered < Auth0::Exception
-    attr_reader :limit, :remaining, :reset
-    def initialize(message,limit,remaining,reset)
-      super(message)
-      @limit, @remaining, @reset = limit, remaining, reset
+  class RateLimitEncountered < Auth0::HTTPError
+    def reset
+      Time.at(headers['X-RateLimit-Reset'])
     end
   end
 end

--- a/lib/auth0/mixins/httpproxy.rb
+++ b/lib/auth0/mixins/httpproxy.rb
@@ -30,18 +30,13 @@ module Auth0
                    end
           case result.code
           when 200...226 then safe_parse_json(result.body)
-          when 400       then raise Auth0::BadRequest, result.to_s
-          when 401       then raise Auth0::Unauthorized, result.body
-          when 403       then raise Auth0::AccessDenied, result.body
-          when 404       then raise Auth0::NotFound, result.body
-          when 429       then raise Auth0::RateLimitEncountered.new(
-                                result.body,
-                                result.headers['X-RateLimit-Limit'],
-                                result.headers['X-RateLimit-Remaining'],
-                                result.headers['X-RateLimit-Reset']
-                              )
-          when 500       then raise Auth0::ServerError, result.body
-          else                raise Auth0::Unsupported, result.body
+          when 400       then raise Auth0::BadRequest.new(result.body, code: result.code, headers: result.headers)
+          when 401       then raise Auth0::Unauthorized.new(result.body, code: result.code, headers: result.headers)
+          when 403       then raise Auth0::AccessDenied.new(result.body, code: result.code, headers: result.headers)
+          when 404       then raise Auth0::NotFound.new(result.body, code: result.code, headers: result.headers)
+          when 429       then raise Auth0::RateLimitEncountered.new(result.body, code: result.code, headers: result.headers)
+          when 500       then raise Auth0::ServerError.new(result.body, code: result.code, headers: result.headers)
+          else                raise Auth0::Unsupported.new(result.body, code: result.code, headers: result.headers)
           end
         end
       end

--- a/lib/auth0/mixins/httpproxy.rb
+++ b/lib/auth0/mixins/httpproxy.rb
@@ -34,6 +34,12 @@ module Auth0
           when 401       then raise Auth0::Unauthorized, result.body
           when 403       then raise Auth0::AccessDenied, result.body
           when 404       then raise Auth0::NotFound, result.body
+          when 429       then raise Auth0::RateLimitEncountered.new(
+                                result.body,
+                                result.headers['X-RateLimit-Limit'],
+                                result.headers['X-RateLimit-Remaining'],
+                                result.headers['X-RateLimit-Reset']
+                              )
           when 500       then raise Auth0::ServerError, result.body
           else                raise Auth0::Unsupported, result.body
           end

--- a/spec/lib/auth0/mixins/httpproxy_spec.rb
+++ b/spec/lib/auth0/mixins/httpproxy_spec.rb
@@ -106,7 +106,15 @@ describe Auth0::Mixins::HTTPProxy do
           .and_raise(@exception)
         expect { @instance.send(http_method, '/test') }.to raise_error { |error|
           expect(error).to be_a(Auth0::RateLimitEncountered)
-          expect(error).to have_attributes(reset: Time.at(1560564149))
+          expect(error).to have_attributes(
+            error_data: {
+              headers: headers,
+              code: 429
+            },
+            headers: headers,
+            http_code: 429,
+            reset: Time.at(1560564149)
+          )
         }
       end      
 
@@ -186,7 +194,15 @@ describe Auth0::Mixins::HTTPProxy do
           .and_raise(@exception)
         expect { @instance.send(http_method, '/test') }.to raise_error { |error|
           expect(error).to be_a(Auth0::RateLimitEncountered)
-          expect(error).to have_attributes(reset: Time.at(1560564149))
+          expect(error).to have_attributes(
+            error_data: {
+              headers: headers,
+              code: 429
+            },
+            headers: headers,
+            http_code: 429,
+            reset: Time.at(1560564149)
+          )
         }
       end
 

--- a/spec/lib/auth0/mixins/httpproxy_spec.rb
+++ b/spec/lib/auth0/mixins/httpproxy_spec.rb
@@ -106,7 +106,7 @@ describe Auth0::Mixins::HTTPProxy do
           .and_raise(@exception)
         expect { @instance.send(http_method, '/test') }.to raise_error { |error|
           expect(error).to be_a(Auth0::RateLimitEncountered)
-          expect(error).to have_attributes(limit: 10, remaining: 0, reset: 1560564149)
+          expect(error).to have_attributes(reset: Time.at(1560564149))
         }
       end      
 
@@ -186,7 +186,7 @@ describe Auth0::Mixins::HTTPProxy do
           .and_raise(@exception)
         expect { @instance.send(http_method, '/test') }.to raise_error { |error|
           expect(error).to be_a(Auth0::RateLimitEncountered)
-          expect(error).to have_attributes(limit: 10, remaining: 0, reset: 1560564149)
+          expect(error).to have_attributes(reset: Time.at(1560564149))
         }
       end
 

--- a/spec/support/stub_response.rb
+++ b/spec/support/stub_response.rb
@@ -1,1 +1,1 @@
-StubResponse = Struct.new(:body, :success?, :code)
+StubResponse = Struct.new(:body, :success?, :code, :headers)


### PR DESCRIPTION
### Changes

This PR adds a new exception class, Auth0::RateLimitEncountered. In addition to the message and backtrace, this exception has attributes to hold the values of the [Auth0 Rate Limiting Headers](https://auth0.com/docs/policies/rate-limits#http-response-headers).

Thus, you can get access to this information when you encountered rate limiting, for example:
```ruby
try_again = true
begin
  auth0.clients
rescue Auth0::RateLimitEncountered => e
  if try_again
    try_again = false
    warn("Rate limiting encountered, waiting until #{Time.at(e.reset)} to try again")
    sleep(e.reset - Time.now.to_i)
    retry
  else
    raise e
  end
end
```

### References

This pull request address #158 

A future improvement might incorporate (optional) automatic retry-after-wait into the gem itself, but for now exposing the required information to library users is enough.

### Testing

This test adds unit tests, but not integration tests. 

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
