### PR TITLE
Change new Role and User methods to avoid collision

### DIFF
--- a/lib/auth0/api/v2.rb
+++ b/lib/auth0/api/v2.rb
@@ -6,6 +6,7 @@ require 'auth0/api/v2/device_credentials'
 require 'auth0/api/v2/emails'
 require 'auth0/api/v2/jobs'
 require 'auth0/api/v2/rules'
+require 'auth0/api/v2/roles'
 require 'auth0/api/v2/stats'
 require 'auth0/api/v2/users'
 require 'auth0/api/v2/users_by_email'
@@ -27,6 +28,7 @@ module Auth0
       include Auth0::Api::V2::Emails
       include Auth0::Api::V2::Jobs
       include Auth0::Api::V2::Rules
+      include Auth0::Api::V2::Roles
       include Auth0::Api::V2::Stats
       include Auth0::Api::V2::Users
       include Auth0::Api::V2::UsersByEmail

--- a/lib/auth0/api/v2/roles.rb
+++ b/lib/auth0/api/v2/roles.rb
@@ -88,7 +88,7 @@ module Auth0
         #   - per_page: Number of Roles to return.
         #   - page: Page number to return, zero-based.
         #   - include_totals: True to include query summary in the result, false or nil otherwise.
-        def get_users(role_id, options = {})
+        def get_role_users(role_id, options = {})
           raise Auth0::MissingParameter, 'Must supply a valid role_id' if role_id.to_s.empty?
 
           request_params = {
@@ -105,7 +105,7 @@ module Auth0
         #
         # @param role_id [string] Role ID to add Users.
         # @param users [array] Array of string User IDs to add to the Role.
-        def add_users(role_id, users = [])
+        def add_role_users(role_id, users = [])
           raise Auth0::MissingParameter, 'Must supply a valid role_id' if role_id.to_s.empty?
 
           validate_strings_array(users)
@@ -123,7 +123,7 @@ module Auth0
         #   - include_totals: True to include query summary in the result, false or nil otherwise.
         #
         # @return [json] All permissions matching the query.
-        def get_permissions(role_id, options = {})
+        def get_role_permissions(role_id, options = {})
           raise Auth0::MissingParameter, 'Must supply a valid role_id' if role_id.to_s.empty?
 
           request_params = {
@@ -140,7 +140,7 @@ module Auth0
         #
         # @param role_id [string] Role ID to add permissions.
         # @param permissions [array] Array of Permission structs to add.
-        def add_permissions(role_id, permissions)
+        def add_role_permissions(role_id, permissions)
           raise Auth0::MissingParameter, 'Must supply a valid role_id' if role_id.to_s.empty?
 
           permissions = validate_permissions_array(permissions)
@@ -153,7 +153,7 @@ module Auth0
         #
         # @param role_id [string] Role ID to remove permissions.
         # @param permissions [array] Array of Permission structs to remove.
-        def remove_permissions(role_id, permissions)
+        def remove_role_permissions(role_id, permissions)
           raise Auth0::MissingParameter, 'Must supply a valid role_id' if role_id.to_s.empty?
 
           permissions = validate_permissions_array(permissions)

--- a/lib/auth0/api/v2/users.rb
+++ b/lib/auth0/api/v2/users.rb
@@ -200,7 +200,7 @@ module Auth0
         #   * :sort [string] The field to use for sorting. 1 == ascending and -1 == descending.
         #
         # @return [json] Returns roles for the given user_id.
-        def get_roles(user_id, options = {})
+        def get_user_roles(user_id, options = {})
           raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
           path = "#{users_path}/#{user_id}/roles"
           request_params = {
@@ -228,7 +228,7 @@ module Auth0
         #
         # @param user_id [string] The user_id of the roles to add.
         # @param roles [array] An array of role names to add.
-        def add_roles(user_id, roles)
+        def add_user_roles(user_id, roles)
           raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
           validate_strings_array roles
           path = "#{users_path}/#{user_id}/roles"
@@ -252,7 +252,7 @@ module Auth0
         # @param user_id [string] The user_id of the permissions to get.
         #
         # @return [json] Returns permissions for the given user_id.
-        def get_permissions(user_id)
+        def get_user_permissions(user_id)
           raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
           get "#{users_path}/#{user_id}/permissions"
         end
@@ -262,7 +262,7 @@ module Auth0
         #
         # @param user_id [string] The user_id of the permissions to remove.
         # @param permissions [array] An array of Permission structs to remove.
-        def remove_permissions(user_id, permissions)
+        def remove_user_permissions(user_id, permissions)
           raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
           permissions = validate_permissions_array permissions
           delete "#{users_path}/#{user_id}/permissions", permissions: permissions
@@ -273,7 +273,7 @@ module Auth0
         #
         # @param user_id [string] The user_id of the permissions to add.
         # @param permissions [array] An array of Permission structs to add.
-        def add_permissions(user_id, permissions)
+        def add_user_permissions(user_id, permissions)
           raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
           permissions = validate_permissions_array permissions
           post "#{users_path}/#{user_id}/permissions", permissions: permissions

--- a/spec/lib/auth0/api/v2/roles_spec.rb
+++ b/spec/lib/auth0/api/v2/roles_spec.rb
@@ -135,13 +135,13 @@ describe Auth0::Api::V2::Roles do
 
   context '.get_users' do
     it 'is expected to exist' do
-      expect(@instance).to respond_to(:get_users)
+      expect(@instance).to respond_to(:get_role_users)
     end
 
     it 'is expected to raise an exception if an empty Role ID is passed' do
       expect(@instance).not_to receive(:get)
       expect do
-        @instance.get_users('')
+        @instance.get_role_users('')
       end.to raise_exception Auth0::MissingParameter
     end
 
@@ -152,7 +152,7 @@ describe Auth0::Api::V2::Roles do
         page: nil,
         include_totals: nil
       )
-      expect { @instance.get_users('ROLE_ID') }.not_to raise_error
+      expect { @instance.get_role_users('ROLE_ID') }.not_to raise_error
     end
 
     it 'is expected to get Users for a Role with custom parameters' do
@@ -163,34 +163,34 @@ describe Auth0::Api::V2::Roles do
         include_totals: true
       )
       expect do
-        @instance.get_users('ROLE_ID', per_page: 30, page: 4, include_totals: true)
+        @instance.get_role_users('ROLE_ID', per_page: 30, page: 4, include_totals: true)
       end.not_to raise_error
     end
   end
 
   context '.add_users' do
     it 'is expected to exist' do
-      expect(@instance).to respond_to(:add_users)
+      expect(@instance).to respond_to(:add_role_users)
     end
 
     it 'is expected to raise an exception if an empty Role ID is passed' do
       expect(@instance).not_to receive(:post)
       expect do
-        @instance.add_users('', [])
+        @instance.add_role_users('', [])
       end.to raise_exception Auth0::MissingParameter
     end
 
     it 'is expected to raise an exception if an array is not passed for Users' do
       expect(@instance).not_to receive(:post)
       expect do
-        @instance.add_users('ROLE_ID', 'USERS')
+        @instance.add_role_users('ROLE_ID', 'USERS')
       end.to raise_exception Auth0::InvalidParameter
     end
 
     it 'is expected to raise an exception if no User IDs are passed' do
       expect(@instance).not_to receive(:post)
       expect do
-        @instance.add_users('ROLE_ID', [])
+        @instance.add_role_users('ROLE_ID', [])
       end.to raise_exception Auth0::MissingParameter
     end
 
@@ -200,20 +200,20 @@ describe Auth0::Api::V2::Roles do
         users: %w[test|user-01 test|user-02]
       )
       expect do
-        @instance.add_users('ROLE_ID', %w[test|user-01 test|user-02])
+        @instance.add_role_users('ROLE_ID', %w[test|user-01 test|user-02])
       end.not_to raise_error
     end
   end
 
   context '.get_permissions' do
     it 'is expected to exist' do
-      expect(@instance).to respond_to(:get_permissions)
+      expect(@instance).to respond_to(:get_role_permissions)
     end
 
     it 'is expected to raise an exception if an empty Role ID is passed' do
       expect(@instance).not_to receive(:get)
       expect do
-        @instance.get_permissions('')
+        @instance.get_role_permissions('')
       end.to raise_exception Auth0::MissingParameter
     end
 
@@ -224,7 +224,7 @@ describe Auth0::Api::V2::Roles do
         page: nil,
         include_totals: nil
       )
-      expect { @instance.get_permissions('ROLE_ID') }.not_to raise_error
+      expect { @instance.get_role_permissions('ROLE_ID') }.not_to raise_error
     end
 
     it 'is expected to get Roles with custom parameters' do
@@ -235,41 +235,41 @@ describe Auth0::Api::V2::Roles do
         include_totals: true
       )
       expect do
-        @instance.get_permissions('ROLE_ID', per_page: 15, page: 5, include_totals: true)
+        @instance.get_role_permissions('ROLE_ID', per_page: 15, page: 5, include_totals: true)
       end.not_to raise_error
     end
   end
 
   context '.add_permissions' do
     it 'is expected to exist' do
-      expect(@instance).to respond_to(:add_permissions)
+      expect(@instance).to respond_to(:add_role_permissions)
     end
 
     it 'is expected to raise an exception if an empty Role ID is passed' do
       expect(@instance).not_to receive(:post)
       expect do
-        @instance.add_permissions('', [])
+        @instance.add_role_permissions('', [])
       end.to raise_exception Auth0::MissingParameter
     end
 
     it 'is expected to raise an exception if an array is not passed for permissions' do
       expect(@instance).not_to receive(:post)
       expect do
-        @instance.add_permissions('ROLE_ID', 'PERMISSIONS')
+        @instance.add_role_permissions('ROLE_ID', 'PERMISSIONS')
       end.to raise_exception Auth0::InvalidParameter
     end
 
     it 'is expected to raise an exception if an empty permissions array is passed' do
       expect(@instance).not_to receive(:post)
       expect do
-        @instance.add_permissions('ROLE_ID', [])
+        @instance.add_role_permissions('ROLE_ID', [])
       end.to raise_exception Auth0::MissingParameter
     end
 
     it 'is expected to raise an exception if the permissions array does not contain Permission structs' do
       expect(@instance).not_to receive(:post)
       expect do
-        @instance.add_permissions('ROLE_ID', [1, 2, 3])
+        @instance.add_role_permissions('ROLE_ID', [1, 2, 3])
       end.to raise_exception Auth0::InvalidParameter
     end
 
@@ -288,7 +288,7 @@ describe Auth0::Api::V2::Roles do
         ]
       )
       expect do
-        @instance.add_permissions(
+        @instance.add_role_permissions(
           'ROLE_ID',
           [
             Permission.new('permission-name-1', 'server-id-1'),
@@ -301,34 +301,34 @@ describe Auth0::Api::V2::Roles do
 
   context '.remove_permissions' do
     it 'is expected to exist' do
-      expect(@instance).to respond_to(:remove_permissions)
+      expect(@instance).to respond_to(:remove_role_permissions)
     end
 
     it 'is expected to raise an exception if an empty Role ID is passed' do
       expect(@instance).not_to receive(:delete)
       expect do
-        @instance.remove_permissions('', [])
+        @instance.remove_role_permissions('', [])
       end.to raise_exception Auth0::MissingParameter
     end
 
     it 'is expected to raise an exception if an array is not passed for permissions' do
       expect(@instance).not_to receive(:post)
       expect do
-        @instance.remove_permissions('ROLE_ID', 'PERMISSIONS')
+        @instance.remove_role_permissions('ROLE_ID', 'PERMISSIONS')
       end.to raise_exception Auth0::InvalidParameter
     end
 
     it 'is expected to raise an exception if an empty permissions array is passed' do
       expect(@instance).not_to receive(:delete)
       expect do
-        @instance.remove_permissions('ROLE_ID', [])
+        @instance.remove_role_permissions('ROLE_ID', [])
       end.to raise_exception Auth0::MissingParameter
     end
 
     it 'is expected to raise an exception if the permissions array does not contain Permission structs' do
       expect(@instance).not_to receive(:post)
       expect do
-        @instance.remove_permissions('ROLE_ID', [1, 2, 3])
+        @instance.remove_role_permissions('ROLE_ID', [1, 2, 3])
       end.to raise_exception Auth0::InvalidParameter
     end
 
@@ -347,7 +347,7 @@ describe Auth0::Api::V2::Roles do
         ]
       )
       expect do
-        @instance.remove_permissions(
+        @instance.remove_role_permissions(
           'ROLE_ID',
           [
             Permission.new('permission-name-3', 'server-id-3'),

--- a/spec/lib/auth0/api/v2/users_spec.rb
+++ b/spec/lib/auth0/api/v2/users_spec.rb
@@ -270,11 +270,11 @@ describe Auth0::Api::V2::Users do
 
   context '.get_roles' do
     it 'is expected to respond to a get_roles method' do
-      expect(@instance).to respond_to(:get_roles)
+      expect(@instance).to respond_to(:get_user_roles)
     end
 
     it 'is expected to raise an exception when the user ID is empty' do
-      expect { @instance.get_roles(nil) }.to raise_exception(Auth0::MissingUserId)
+      expect { @instance.get_user_roles(nil) }.to raise_exception(Auth0::MissingUserId)
     end
 
     it 'is expected to get roles with default parameters' do
@@ -284,7 +284,7 @@ describe Auth0::Api::V2::Users do
         page: nil,
         include_totals: nil
       )
-      expect { @instance.get_roles('USER_ID') }.not_to raise_error
+      expect { @instance.get_user_roles('USER_ID') }.not_to raise_error
     end
 
     it 'is expected to get roles with custom parameters' do
@@ -295,7 +295,7 @@ describe Auth0::Api::V2::Users do
         include_totals: true
       )
       expect do
-        @instance.get_roles('USER_ID', per_page: 20, page: 2, include_totals: true)
+        @instance.get_user_roles('USER_ID', per_page: 20, page: 2, include_totals: true)
       end.not_to raise_error
     end
   end
@@ -334,19 +334,19 @@ describe Auth0::Api::V2::Users do
 
   context '.add_roles' do
     it 'is expected to respond to a add_roles method' do
-      expect(@instance).to respond_to(:add_roles)
+      expect(@instance).to respond_to(:add_user_roles)
     end
 
     it 'is expected to raise an exception when the user ID is empty' do
-      expect { @instance.add_roles(nil, 'ROLES') }.to raise_exception(Auth0::MissingUserId)
+      expect { @instance.add_user_roles(nil, 'ROLES') }.to raise_exception(Auth0::MissingUserId)
     end
 
     it 'is expected to raise an exception when the user ID is empty' do
-      expect { @instance.add_roles('USER_ID', 'ROLES') }.to raise_exception(Auth0::InvalidParameter)
+      expect { @instance.add_user_roles('USER_ID', 'ROLES') }.to raise_exception(Auth0::InvalidParameter)
     end
 
     it 'is expected to raise an exception when the roles are empty' do
-      expect { @instance.add_roles('USER_ID', [3, 4]) }.to raise_exception(Auth0::InvalidParameter)
+      expect { @instance.add_user_roles('USER_ID', [3, 4]) }.to raise_exception(Auth0::InvalidParameter)
     end
 
     it 'is expected to add roles' do
@@ -355,7 +355,7 @@ describe Auth0::Api::V2::Users do
         roles: %w[test-role-03 test-role-04]
       )
       expect do
-        @instance.add_roles('USER_ID', %w[test-role-03 test-role-04])
+        @instance.add_user_roles('USER_ID', %w[test-role-03 test-role-04])
       end.not_to raise_error
     end
   end
@@ -379,37 +379,37 @@ describe Auth0::Api::V2::Users do
 
   context '.get_permissions' do
     it 'is expected to respond to a get_permissions method' do
-      expect(@instance).to respond_to(:get_permissions)
+      expect(@instance).to respond_to(:get_user_permissions)
     end
 
     it 'is expected to raise an exception when the user ID is empty' do
-      expect { @instance.get_permissions(nil) }.to raise_exception(Auth0::MissingUserId)
+      expect { @instance.get_user_permissions(nil) }.to raise_exception(Auth0::MissingUserId)
     end
 
     it 'is expected to get permissions' do
       expect(@instance).to receive(:get).with('/api/v2/users/USER_ID/permissions')
       expect do
-        @instance.get_permissions('USER_ID')
+        @instance.get_user_permissions('USER_ID')
       end.not_to raise_error
     end
   end
 
   context '.remove_permissions' do
     it 'is expected to respond to a remove_permissions method' do
-      expect(@instance).to respond_to(:remove_permissions)
+      expect(@instance).to respond_to(:remove_user_permissions)
     end
 
     it 'is expected to raise an exception when the user ID is empty' do
-      expect { @instance.remove_permissions(nil, 'PERMISSIONS') }.to raise_exception(Auth0::MissingUserId)
+      expect { @instance.remove_user_permissions(nil, 'PERMISSIONS') }.to raise_exception(Auth0::MissingUserId)
     end
 
     it 'is expected to raise an exception when the permissions are empty' do
-      expect { @instance.remove_permissions('USER_ID', []) }.to raise_exception(Auth0::MissingParameter)
+      expect { @instance.remove_user_permissions('USER_ID', []) }.to raise_exception(Auth0::MissingParameter)
     end
 
     it 'is expected to raise an exception when the array does not consist of Permissions' do
       expect do
-        @instance.remove_permissions('USER_ID', %w[permission-01 permission02])
+        @instance.remove_user_permissions('USER_ID', %w[permission-01 permission02])
       end.to raise_exception(Auth0::InvalidParameter)
     end
 
@@ -428,7 +428,7 @@ describe Auth0::Api::V2::Users do
         ]
       )
       expect do
-        @instance.remove_permissions(
+        @instance.remove_user_permissions(
           'USER_ID',
           [
             Permission.new('permission-name-1', 'server-id-1'),
@@ -441,20 +441,20 @@ describe Auth0::Api::V2::Users do
 
   context '.add_permissions' do
     it 'is expected to respond to a add_permissions method' do
-      expect(@instance).to respond_to(:add_permissions)
+      expect(@instance).to respond_to(:add_user_permissions)
     end
 
     it 'is expected to raise an exception when the user ID is empty' do
-      expect { @instance.add_permissions(nil, 'PERMISSIONS') }.to raise_exception(Auth0::MissingUserId)
+      expect { @instance.add_user_permissions(nil, 'PERMISSIONS') }.to raise_exception(Auth0::MissingUserId)
     end
 
     it 'is expected to raise an exception when the permissions are empty' do
-      expect { @instance.add_permissions('USER_ID', []) }.to raise_exception(Auth0::MissingParameter)
+      expect { @instance.add_user_permissions('USER_ID', []) }.to raise_exception(Auth0::MissingParameter)
     end
 
     it 'is expected to raise an exception when the permissions are not Permission structs' do
       expect do
-        @instance.add_permissions('USER_ID', %w[permission-01 permission02])
+        @instance.add_user_permissions('USER_ID', %w[permission-01 permission02])
       end.to raise_exception(Auth0::InvalidParameter)
     end
 
@@ -473,7 +473,7 @@ describe Auth0::Api::V2::Users do
         ]
       )
       expect do
-        @instance.add_permissions(
+        @instance.add_user_permissions(
           'USER_ID',
           [
             Permission.new('permission-name-1', 'server-id-1'),


### PR DESCRIPTION
### Changes

Renaming a few unreleased `Auth0::Api::V2::Users` and `Auth0::Api::V2::Roles` methods to avoid collisions. 

### References

- Related to #169 
- Related to #172 