### PR TITLE
Add failed job error details endpoint

### DIFF
--- a/lib/auth0/api/v2/jobs.rb
+++ b/lib/auth0/api/v2/jobs.rb
@@ -15,6 +15,18 @@ module Auth0
           get(path)
         end
 
+        # Retrieve error details based on the id of the job. Useful to check its status.
+        # @see https://auth0.com/docs/api/management/v2#!/Jobs/get_errors
+        # @param job_id [string] The ID of the job.
+        #
+        # @return [json] Returns the job error details.
+        def get_job_errors(job_id)
+          raise Auth0::InvalidParameter, 'Must specify a job id' if job_id.to_s.empty?
+
+          path = "#{jobs_path}/#{job_id}/errors"
+          get(path)
+        end
+
         # Imports users to a connection from a file using a long running job.
         # Documentation for the file format: https://docs.auth0.com/bulk-import
         # @see https://auth0.com/docs/api/v2#!/Jobs/post_users_imports

--- a/spec/lib/auth0/api/v2/jobs_spec.rb
+++ b/spec/lib/auth0/api/v2/jobs_spec.rb
@@ -13,6 +13,14 @@ describe Auth0::Api::V2::Jobs do
     end
     it { expect { @instance.get_job('') }.to raise_error('Must specify a job id') }
   end
+  context '.get_job_error_details' do
+    it { expect(@instance).to respond_to(:get_job_errors) }
+    it 'expect client to send get to /api/v2/jobs/3/errors' do
+      expect(@instance).to receive(:get).with('/api/v2/jobs/3/errors')
+      expect { @instance.get_job_errors(3) }.not_to raise_error
+    end
+    it { expect { @instance.get_job_errors('') }.to raise_error('Must specify a job id') }
+  end
   context '.import_users' do
     it { expect(@instance).to respond_to(:import_users) }
     it 'expect client to send post to /api/v2/jobs/users-imports' do

--- a/spec/lib/auth0/api/v2/jobs_spec.rb
+++ b/spec/lib/auth0/api/v2/jobs_spec.rb
@@ -13,7 +13,7 @@ describe Auth0::Api::V2::Jobs do
     end
     it { expect { @instance.get_job('') }.to raise_error('Must specify a job id') }
   end
-  context '.get_job_error_details' do
+  context '.get_job_errors' do
     it { expect(@instance).to respond_to(:get_job_errors) }
     it 'expect client to send get to /api/v2/jobs/3/errors' do
       expect(@instance).to receive(:get).with('/api/v2/jobs/3/errors')


### PR DESCRIPTION
### Changes

Add endpoint for failed job error details.

### References

https://auth0.com/docs/api/management/v2#!/Jobs/get_errors

### Testing

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
