### PR TITLE
Add parameters for users imports

### DIFF
--- a/lib/auth0/api/v2/jobs.rb
+++ b/lib/auth0/api/v2/jobs.rb
@@ -20,15 +20,19 @@ module Auth0
         # @see https://auth0.com/docs/api/v2#!/Jobs/post_users_imports
         # @param users_file [file] A file containing the users to import.
         # @param connection_id [string] Database connection ID to import to.
+        # @param options [hash] upsert / external_id / send_completion_email.
         #
         # @return [json] Returns the job status and properties.
-        def import_users(users_file, connection_id)
+        def import_users(users_file, connection_id, **options)
           raise Auth0::InvalidParameter, 'Must specify a valid file' if users_file.to_s.empty?
           raise Auth0::InvalidParameter, 'Must specify a connection_id' if connection_id.to_s.empty?
 
           request_params = {
             users: users_file,
-            connection_id: connection_id
+            connection_id: connection_id,
+            upsert: options[:upsert].nil? ? false : options[:upsert],
+            external_id: options[:external_id],
+            send_completion_email: options[:send_completion_email].nil? ? true : options[:send_completion_email]
           }
           path = "#{jobs_path}/users-imports"
           post_file(path, request_params)

--- a/lib/auth0/api/v2/jobs.rb
+++ b/lib/auth0/api/v2/jobs.rb
@@ -20,19 +20,22 @@ module Auth0
         # @see https://auth0.com/docs/api/v2#!/Jobs/post_users_imports
         # @param users_file [file] A file containing the users to import.
         # @param connection_id [string] Database connection ID to import to.
-        # @param options [hash] upsert / external_id / send_completion_email.
-        #
+        # @param options [hash]
+        #   * :upsert [boolean] Update the user if already exists. False by default.
+        #   * :external_id [string] Customer defined id
+        #   * :send_completion_email [boolean] If true,
+        #     send the completion email to all tenant owners when the job is finished. True by default.
         # @return [json] Returns the job status and properties.
-        def import_users(users_file, connection_id, **options)
+        def import_users(users_file, connection_id, options = {})
           raise Auth0::InvalidParameter, 'Must specify a valid file' if users_file.to_s.empty?
           raise Auth0::InvalidParameter, 'Must specify a connection_id' if connection_id.to_s.empty?
 
           request_params = {
             users: users_file,
             connection_id: connection_id,
-            upsert: options[:upsert].nil? ? false : options[:upsert],
-            external_id: options[:external_id],
-            send_completion_email: options[:send_completion_email].nil? ? true : options[:send_completion_email]
+            upsert: options.fetch(:upsert, false),
+            external_id: options.fetch(:external_id, nil),
+            send_completion_email: options.fetch(:send_completion_email, true)
           }
           path = "#{jobs_path}/users-imports"
           post_file(path, request_params)

--- a/spec/lib/auth0/api/v2/jobs_spec.rb
+++ b/spec/lib/auth0/api/v2/jobs_spec.rb
@@ -17,9 +17,33 @@ describe Auth0::Api::V2::Jobs do
     it { expect(@instance).to respond_to(:import_users) }
     it 'expect client to send post to /api/v2/jobs/users-imports' do
       expect(@instance).to receive(:post_file).with(
-        '/api/v2/jobs/users-imports', users: 'file', connection_id: 'connnection_id'
+        '/api/v2/jobs/users-imports',
+        users: 'file',
+        connection_id: 'connnection_id',
+        upsert: false,
+        external_id: nil,
+        send_completion_email: true
       )
       expect { @instance.import_users('file', 'connnection_id') }.not_to raise_error
+    end
+    it 'expect client to send post to /api/v2/jobs/users-imports with options' do
+      expect(@instance).to receive(:post_file).with(
+        '/api/v2/jobs/users-imports',
+        users: 'file',
+        connection_id: 'connnection_id',
+        upsert: true,
+        external_id: 'external_1',
+        send_completion_email: false
+      )
+      expect do
+        @instance.import_users(
+          'file',
+          'connnection_id',
+          upsert: true,
+          external_id: 'external_1',
+          send_completion_email: false
+        )
+      end.not_to raise_error
     end
     it { expect { @instance.import_users('', 'connnection_id') }.to raise_error('Must specify a valid file') }
     it { expect { @instance.import_users('users', '') }.to raise_error('Must specify a connection_id') }


### PR DESCRIPTION
### Changes

Add request parameters for users imports endpoint.
(upsert / external_id / send_completion_email)

### References

https://auth0.com/docs/api/management/v2/#!/Jobs/post_users_imports

### Testing

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
