### PR TITLE
Remove reliance on .env values for tests

### DIFF
--- a/spec/integration/lib/auth0/auth0_client_spec.rb
+++ b/spec/integration/lib/auth0/auth0_client_spec.rb
@@ -44,19 +44,18 @@ describe Auth0::Client do
     api_version: 2, token: 'token'
   }, Auth0::InvalidApiNamespace
 
-  let(:token) { ENV['MASTER_JWT'] }
-  let(:v2_credentials) { { domain: ENV['DOMAIN'] } }
+  let(:v2_credentials) { { domain: 'test.auth0.com' } }
 
   shared_examples 'valid credentials' do
     it { expect { Auth0Client.new(credentials) }.to_not raise_error }
   end
 
   it_should_behave_like 'valid credentials' do
-    let(:credentials) { v2_credentials.merge(token: token) }
+    let(:credentials) { v2_credentials.merge(token: 'TEST_API_TOKEN') }
   end
 
   it_should_behave_like 'valid credentials' do
-    let(:credentials) { v2_credentials.merge(access_token: ENV['MASTER_JWT']) }
+    let(:credentials) { v2_credentials.merge(access_token: 'TEST_API_TOKEN') }
   end
 
   context 'client headers' do

--- a/spec/support/credentials.rb
+++ b/spec/support/credentials.rb
@@ -21,19 +21,10 @@ module Credentials
 
   def v2_creds
     {
-      client_id: ENV['CLIENT_ID'],
-      client_secret: ENV['CLIENT_SECRET'],
-      token: ENV['MASTER_JWT'],
-      domain: ENV['DOMAIN']
-    }
-  end
-
-  def v2_creds_with_secret
-    {
-      client_id: ENV['CLIENT_ID'],
-      client_secret: ENV['CLIENT_SECRET'],
-      token: ENV['MASTER_JWT'],
-      domain: ENV['DOMAIN']
+      domain: ENV.fetch( 'DOMAIN', 'DOMAIN' ),
+      client_id: ENV.fetch( 'CLIENT_ID', 'CLIENT_ID' ),
+      client_secret: ENV.fetch( 'CLIENT_SECRET', 'TEST_CLIENT_SECRET' ),
+      token: ENV.fetch( 'MASTER_JWT', 'TEST_MASTER_JWT' )
     }
   end
 end


### PR DESCRIPTION
### Changes

Hard-code test values when no `.env` is present or a required value is missing.

### References

Will allow forked PRs like #176 and #177 to run and pass. 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby (2.6.0)

### Checklist

* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed
