### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -11,8 +11,6 @@ Gem::Specification.new do |s|
   s.summary     = 'Auth0 API Client'
   s.description = 'Ruby toolkit for Auth0 API https://auth0.com.'
 
-  s.rubyforge_project = 'auth0'
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }


### PR DESCRIPTION
### Changes

Gemspec: Drop EOL'd property rubyforge_project.

### References

The RubyGems property rubyforge_project is removed without a replacement.

### Testing

- Does `gem build` still work?
