### PR TITLE
Don't define structs as top-level constants

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -27,7 +27,7 @@ module Auth0
           audience: audience
         }
         response = post('/oauth/token', request_params)
-        ApiToken.new(response['access_token'], response['scope'], response['expires_in'])
+        ::Auth0::ApiToken.new(response['access_token'], response['scope'], response['expires_in'])
       end
 
       # Get access and ID tokens using an Authorization Code.
@@ -37,7 +37,7 @@ module Auth0
       #   Required only if it was set at the GET /authorize endpoint
       # @param client_id [string] Client ID for the Application
       # @param client_secret [string] Client Secret for the Application.
-      # @return [AccessToken] Returns the access_token and id_token
+      # @return [Auth0::AccessToken] Returns the access_token and id_token
       def exchange_auth_code_for_tokens(
         code,
         redirect_uri: nil,
@@ -53,7 +53,7 @@ module Auth0
           code: code,
           redirect_uri: redirect_uri
         }
-        AccessToken.from_response post('/oauth/token', request_params)
+        ::Auth0::AccessToken.from_response post('/oauth/token', request_params)
       end
 
       # Get access and ID tokens using a refresh token.
@@ -64,7 +64,7 @@ module Auth0
       # @param client_secret [string] Client Secret for the Application.
       #   Required when the Application's Token Endpoint Authentication Method
       #   is Post or Basic.
-      # @return [AccessToken] Returns tokens allowed in the refresh_token
+      # @return [Auth0::AccessToken] Returns tokens allowed in the refresh_token
       def exchange_refresh_token(
         refresh_token,
         client_id: @client_id,
@@ -78,7 +78,7 @@ module Auth0
           client_secret: client_secret,
           refresh_token: refresh_token
         }
-        AccessToken.from_response post('/oauth/token', request_params)
+        ::Auth0::AccessToken.from_response post('/oauth/token', request_params)
       end
 
       # rubocop:disable Metrics/ParameterLists
@@ -118,7 +118,7 @@ module Auth0
           audience: audience,
           grant_type: realm ? 'http://auth0.com/oauth/grant-type/password-realm' : 'password'
         }
-        AccessToken.from_response post('/oauth/token', request_params)
+        ::Auth0::AccessToken.from_response post('/oauth/token', request_params)
       end
       # rubocop:enable Metrics/ParameterLists
 

--- a/lib/auth0/mixins/access_token_struct.rb
+++ b/lib/auth0/mixins/access_token_struct.rb
@@ -1,4 +1,4 @@
-AccessToken = Struct.new(
+Auth0::AccessToken = Struct.new(
   :access_token,
   :expires_in,
   :refresh_token,

--- a/lib/auth0/mixins/api_token_struct.rb
+++ b/lib/auth0/mixins/api_token_struct.rb
@@ -1,4 +1,4 @@
-ApiToken = Struct.new :access_token, :scope, :expires_in do
+Auth0::ApiToken = Struct.new :access_token, :scope, :expires_in do
 
   def token
     access_token

--- a/lib/auth0/mixins/permission_struct.rb
+++ b/lib/auth0/mixins/permission_struct.rb
@@ -1,3 +1,3 @@
-Permission = Struct.new :permission_name, :resource_server_identifier do
+Auth0::Permission = Struct.new :permission_name, :resource_server_identifier do
 
 end

--- a/lib/auth0/mixins/validation.rb
+++ b/lib/auth0/mixins/validation.rb
@@ -23,7 +23,7 @@ module Auth0
         raise Auth0::InvalidParameter, 'Must supply an array of Permissions' unless permissions.kind_of?(Array)
         raise Auth0::MissingParameter, 'Must supply an array of Permissions' if permissions.empty?
         raise Auth0::InvalidParameter, 'All array elements must be Permissions' unless permissions.all? do |permission|
-          permission.kind_of? Permission
+          permission.kind_of? ::Auth0::Permission
         end
         permissions.map { |permission| permission.to_h }
       end

--- a/spec/integration/lib/auth0/api/v2/api_roles_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_roles_spec.rb
@@ -14,7 +14,7 @@ describe Auth0::Api::V2::Roles do
     @test_role_name = "#{entity_suffix}-test-role"
 
     @test_permission_name = "#{entity_suffix}-test-permission"
-    @test_permission = Permission.new(@test_permission_name, @test_api_name)
+    @test_permission = ::Auth0::Permission.new(@test_permission_name , @test_api_name)
 
     VCR.use_cassette('Auth0_Api_V2_Roles/create_test_user') do
       @test_user ||= client.create_user(

--- a/spec/integration/lib/auth0/api/v2/api_users_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_users_spec.rb
@@ -14,7 +14,7 @@ describe Auth0::Api::V2::Users do
     @test_api_scope = 'test:scope'
 
     @test_permission_name = "#{entity_suffix}-test-permission-for-users"
-    @test_permission = Permission.new("#{entity_suffix}-test-permission-for-users", @test_api_name)
+    @test_permission = ::Auth0::Permission.new("#{entity_suffix}-test-permission-for-users", @test_api_name)
 
     VCR.use_cassette('Auth0_Api_V2_Users/create_test_user') do
       @test_user ||= client.create_user(

--- a/spec/lib/auth0/api/v2/roles_spec.rb
+++ b/spec/lib/auth0/api/v2/roles_spec.rb
@@ -293,8 +293,8 @@ describe Auth0::Api::V2::Roles do
         @instance.add_role_permissions(
           'ROLE_ID',
           [
-            Permission.new('permission-name-1', 'server-id-1'),
-            Permission.new('permission-name-2', 'server-id-2')
+            Auth0::Permission.new('permission-name-1', 'server-id-1'),
+            Auth0::Permission.new('permission-name-2', 'server-id-2')
           ]
         )
       end.not_to raise_error
@@ -352,8 +352,8 @@ describe Auth0::Api::V2::Roles do
         @instance.remove_role_permissions(
           'ROLE_ID',
           [
-            Permission.new('permission-name-3', 'server-id-3'),
-            Permission.new('permission-name-4', 'server-id-4')
+            Auth0::Permission.new('permission-name-3', 'server-id-3'),
+            Auth0::Permission.new('permission-name-4', 'server-id-4')
           ]
         )
       end.not_to raise_error

--- a/spec/lib/auth0/api/v2/users_spec.rb
+++ b/spec/lib/auth0/api/v2/users_spec.rb
@@ -451,8 +451,8 @@ describe Auth0::Api::V2::Users do
         @instance.remove_user_permissions(
           'USER_ID',
           [
-            Permission.new('permission-name-1', 'server-id-1'),
-            Permission.new('permission-name-2', 'server-id-2')
+            Auth0::Permission.new('permission-name-1', 'server-id-1'),
+            Auth0::Permission.new('permission-name-2', 'server-id-2')
           ]
         )
       end.not_to raise_error
@@ -496,8 +496,8 @@ describe Auth0::Api::V2::Users do
         @instance.add_user_permissions(
           'USER_ID',
           [
-            Permission.new('permission-name-1', 'server-id-1'),
-            Permission.new('permission-name-2', 'server-id-2')
+            Auth0::Permission.new('permission-name-1', 'server-id-1'),
+            Auth0::Permission.new('permission-name-2', 'server-id-2')
           ]
         )
       end.not_to raise_error


### PR DESCRIPTION
### Changes
Structs defined in lib/auth0/mixins are currently defined as top-level
constants (e.g. `AccessToken`). However, these names are popular and can
conflict with existing classes and break the client application.
Therefore, I'd like to put them as children of `Auth0` module.

### References

Closes #201 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
