### PR TITLE
Add missing Permissions mixin

### DIFF
--- a/lib/auth0/api/v2/guardian.rb
+++ b/lib/auth0/api/v2/guardian.rb
@@ -1,5 +1,3 @@
-require 'auth0/mixins/validation'
-
 module Auth0
   module Api
     module V2

--- a/lib/auth0/api/v2/roles.rb
+++ b/lib/auth0/api/v2/roles.rb
@@ -1,5 +1,3 @@
-require 'auth0/mixins/validation'
-
 module Auth0
   module Api
     module V2

--- a/lib/auth0/api/v2/users.rb
+++ b/lib/auth0/api/v2/users.rb
@@ -1,5 +1,3 @@
-require 'auth0/mixins/validation'
-
 module Auth0
   module Api
     module V2

--- a/lib/auth0/mixins.rb
+++ b/lib/auth0/mixins.rb
@@ -1,14 +1,19 @@
 require 'base64'
 require 'rest-client'
 require 'uri'
-require 'auth0/mixins/httpproxy'
-require 'auth0/mixins/initializer'
-require 'auth0/mixins/headers'
+
 require 'auth0/mixins/access_token_struct'
 require 'auth0/mixins/api_token_struct'
+require 'auth0/mixins/headers'
+require 'auth0/mixins/httpproxy'
+require 'auth0/mixins/initializer'
+require 'auth0/mixins/permission_struct'
+require 'auth0/mixins/validation'
+
 require 'auth0/api/authentication_endpoints'
 require 'auth0/api/v1'
 require 'auth0/api/v2'
+
 module Auth0
   # Collecting dependencies here
   module Mixins

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_add_role_permissions/should_add_a_Permission_to_the_Role_successfully.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_add_role_permissions/should_add_a_Permission_to_the_Role_successfully.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_rSi7DH8MezaQ229K/permissions
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_Me7CwJxYruZRfq7q/permissions
     body:
       encoding: UTF-8
       string: '{"permissions":[{"permission_name":"rubytest-test-permission","resource_server_identifier":"rubytest-test-api-for-roles"}]}'
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Content-Length:
@@ -29,29 +29,31 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:36 GMT
+      - Wed, 25 Sep 2019 16:28:53 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 00b2c56e5846715b
+      - 1e7797637343dafb
       Ot-Tracer-Traceid:
-      - 3e8125b1094f3ea3
+      - 7dfc59340554541b
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '9'
+      - '4'
       X-Ratelimit-Reset:
-      - '1561749038'
+      - '1569428937'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
@@ -63,5 +65,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAA6uuBQBDv6ajAgAAAA==
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:37 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:53 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_add_role_users/should_add_a_User_to_the_Role_successfully.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_add_role_users/should_add_a_User_to_the_Role_successfully.yml
@@ -2,10 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_rSi7DH8MezaQ229K/users
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_Me7CwJxYruZRfq7q/users
     body:
       encoding: UTF-8
-      string: '{"users":["auth0|5d16662237b1960d45b50e7c"]}'
+      string: '{"users":["auth0|5d8b95c1d48d580ddc880536"]}'
     headers:
       Accept:
       - "*/*"
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Content-Length:
@@ -29,29 +29,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:32 GMT
+      - Wed, 25 Sep 2019 16:28:52 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - '095d0db570914f57'
+      - 63afc16a03cb3c38
       Ot-Tracer-Traceid:
-      - '009605b14993633d'
+      - 1d60153a4e9d6b5f
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '9'
+      - '6'
       X-Ratelimit-Reset:
-      - '1561749034'
+      - '1569428935'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
@@ -63,5 +65,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAA6uuBQBDv6ajAgAAAA==
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:32 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:52 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_delete_role/should_delete_the_Role_successfully.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_delete_role/should_delete_the_Role_successfully.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_rSi7DH8MezaQ229K
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_Me7CwJxYruZRfq7q
     body:
       encoding: US-ASCII
       string: ''
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Host:
@@ -27,27 +27,29 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:42 GMT
+      - Wed, 25 Sep 2019 16:28:53 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 11652af63de32e09
+      - 7c964a5a3bf32b2d
       Ot-Tracer-Traceid:
-      - 4310301d4e1c7c32
+      - 15d9978a5056db4c
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '9'
+      - '1'
       X-Ratelimit-Reset:
-      - '1561749043'
+      - '1569428939'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Strict-Transport-Security:
       - max-age=15724800
       X-Robots-Tag:
@@ -56,5 +58,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:42 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:53 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_get_role/should_get_the_Role_successfully.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_get_role/should_get_the_Role_successfully.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_rSi7DH8MezaQ229K
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_Me7CwJxYruZRfq7q
     body:
       encoding: US-ASCII
       string: ''
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Host:
@@ -27,29 +27,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:29 GMT
+      - Wed, 25 Sep 2019 16:28:52 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 29d59d014f04514c
+      - 39ff4b9528693457
       Ot-Tracer-Traceid:
-      - 23d7e3cf35ba0ed8
+      - 6d6a7dfc1414253e
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '9'
+      - '8'
       X-Ratelimit-Reset:
-      - '1561749030'
+      - '1569428934'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
@@ -59,7 +61,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA6tWykxRslIqys+JLwrONHfxsPBNrUoMNDKy9FbSUcpLzE0FyZYmVZakFpfoggmg2lSgXEpqcXJRZkFJZn4eUEkIUEYBJKOALF4LAIwSdAlfAAAA
+        H4sIAAAAAAAAA6tWykxRslIqys+J9001dy73qogsKo0KSis0L1TSUcpLzE0FyZYmVZakFpfoggmg2lSgXEpqcXJRZkFJZn4eUEkIUEYBJKOALF4LADvySGBfAAAA
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:29 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:52 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_get_role_permissions/should_get_exactly_1_Permission.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_get_role_permissions/should_get_exactly_1_Permission.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_rSi7DH8MezaQ229K/permissions
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_Me7CwJxYruZRfq7q/permissions
     body:
       encoding: US-ASCII
       string: ''
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Host:
@@ -27,29 +27,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:38 GMT
+      - Wed, 25 Sep 2019 16:28:53 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 2ef7a3554c0d3d37
+      - 2b424a85236be19b
       Ot-Tracer-Traceid:
-      - 264a88200375ff52
+      - 719c34c5274983d4
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '9'
+      - '3'
       X-Ratelimit-Reset:
-      - '1561749039'
+      - '1569428937'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
@@ -61,5 +63,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAA4WMSwqAMBBD7zJrewGvIiJaIwxoWzKtIOLd/WzcCG4CyeOl2SWBi5ppDF3oF0gtLMOWYdk98XKpZIR5asp3q+UaCIuFHp2BK/h90Sd1U6RjnGEfko4IWScFf9SjPQGSemtTsQAAAA==
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:38 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:53 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_get_role_permissions/should_get_the_added_Permission_from_the_Role_successfully.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_get_role_permissions/should_get_the_added_Permission_from_the_Role_successfully.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_rSi7DH8MezaQ229K/permissions
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_Me7CwJxYruZRfq7q/permissions
     body:
       encoding: US-ASCII
       string: ''
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Host:
@@ -27,29 +27,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:39 GMT
+      - Wed, 25 Sep 2019 16:28:53 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 5073dec72ed81075
+      - 3045a3192399c970
       Ot-Tracer-Traceid:
-      - 74571f82431ad586
+      - 18a77052568068f0
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '9'
+      - '2'
       X-Ratelimit-Reset:
-      - '1561749041'
+      - '1569428938'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
@@ -61,5 +63,5 @@ http_interactions:
       string: !binary |-
         H4sIAAAAAAAAA4WMSwqAMBBD7zJrewGvIiJaIwxoWzKtIOLd/WzcCG4CyeOl2SWBi5ppDF3oF0gtLMOWYdk98XKpZIR5asp3q+UaCIuFHp2BK/h90Sd1U6RjnGEfko4IWScFf9SjPQGSemtTsQAAAA==
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:39 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:53 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_get_role_users/should_get_exactly_1_User.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_get_role_users/should_get_exactly_1_User.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_rSi7DH8MezaQ229K/users
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_Me7CwJxYruZRfq7q/users
     body:
       encoding: US-ASCII
       string: ''
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Host:
@@ -27,29 +27,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:34 GMT
+      - Wed, 25 Sep 2019 16:28:52 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 205e9d613430dcc4
+      - 53f0c303554001e2
       Ot-Tracer-Traceid:
-      - 67c8c3eb43ddd0c8
+      - 565cff3e695dd6f3
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '9'
+      - '5'
       X-Ratelimit-Reset:
-      - '1561749035'
+      - '1569428936'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
@@ -59,7 +61,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA2WO2QrCMBBF/yVgn+yStE1boagv/oSIpMl0gW5MEkHUfzdVKIIwD3fgzplzfhCrAa+dIjsirGmjZ6oo55yxOKtowSOVpFUaQSbJlsAgut4V0VZ3A9r4a1ggoxjAryf0cepBHz60QE6DO5w7aSyCO22NmfUuDHXQoLgJI3CphN8YZrlMC0p5oYAmhaJMSJAsz3gdi5zTaq/LJI88LOfGU+WHtYmPG3ZyI9UYrD/d/kVql9AG89g4jcXwV//fmrwub+3Ac6QTAQAA
+        H4sIAAAAAAAAA2WOywrCMBBF/yVQV/aRtqlToagbf0JE0kysBftgkgii/rtpBRGEWdyBO2fO4cGc0XRqka2ZdPaSPAVCXQrFMQcUkCAqgERkBVsy3cn26ovk6rvVxobfMEF62enwPFBIw1Wb7UyL1ND5w7FV1pH2pxdrR7OOYxM1JG/SSpoq8SfGK1Ci5LwoUfO8RJ5KpVUKq+KcSSh4vTFVDsmCqrFZYDWzgmwXpHs/Cvvo+9PvH6TxiVw09o3XmAx/9f+t2ev4BvvO+5gTAQAA
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:34 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:52 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_get_role_users/should_get_the_added_User_from_the_Role_successfully.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_get_role_users/should_get_the_added_User_from_the_Role_successfully.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_rSi7DH8MezaQ229K/users
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_Me7CwJxYruZRfq7q/users
     body:
       encoding: US-ASCII
       string: ''
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Host:
@@ -27,29 +27,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:35 GMT
+      - Wed, 25 Sep 2019 16:28:52 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 51eecb694159f48d
+      - 654dc94c42bb7b63
       Ot-Tracer-Traceid:
-      - 466619e43a516d42
+      - 338dfeab2c4513d2
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '9'
+      - '4'
       X-Ratelimit-Reset:
-      - '1561749036'
+      - '1569428936'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
@@ -59,7 +61,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA2WO2QrCMBBF/yVgn+yStE1boagv/oSIpMl0gW5MEkHUfzdVKIIwD3fgzplzfhCrAa+dIjsirGmjZ6oo55yxOKtowSOVpFUaQSbJlsAgut4V0VZ3A9r4a1ggoxjAryf0cepBHz60QE6DO5w7aSyCO22NmfUuDHXQoLgJI3CphN8YZrlMC0p5oYAmhaJMSJAsz3gdi5zTaq/LJI88LOfGU+WHtYmPG3ZyI9UYrD/d/kVql9AG89g4jcXwV//fmrwub+3Ac6QTAQAA
+        H4sIAAAAAAAAA2WOywrCMBBF/yVQV/aRtqlToagbf0JE0kysBftgkgii/rtpBRGEWdyBO2fO4cGc0XRqka2ZdPaSPAVCXQrFMQcUkCAqgERkBVsy3cn26ovk6rvVxobfMEF62enwPFBIw1Wb7UyL1ND5w7FV1pH2pxdrR7OOYxM1JG/SSpoq8SfGK1Ci5LwoUfO8RJ5KpVUKq+KcSSh4vTFVDsmCqrFZYDWzgmwXpHs/Cvvo+9PvH6TxiVw09o3XmAx/9f+t2ev4BvvO+5gTAQAA
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:35 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:52 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_get_roles/should_get_the_Role_successfully.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_get_roles/should_get_the_Role_successfully.yml
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Host:
@@ -27,29 +27,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:30 GMT
+      - Wed, 25 Sep 2019 16:28:52 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 4b4a1f8c0535186b
+      - 10544ffb51d81425
       Ot-Tracer-Traceid:
-      - 5b02f0a47c3d78a0
+      - 7e4154cc68459a85
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '9'
+      - '7'
       X-Ratelimit-Reset:
-      - '1561749031'
+      - '1569428934'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
@@ -59,7 +61,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA4uuVspMUbJSKsrPiS8KzjR38bDwTa1KDDQysvRW0lHKS8xNBcmWJlWWpBaX6IIJoNpUoFxKanFyUWZBSWZ+HlBJCFBGASSjgCxeGwsACSqLE2EAAAA=
+        H4sIAAAAAAAAA4uuVspMUbJSKsrPifdNNXcu96qILCqNCkorNC9U0lHKS8xNBcmWJlWWpBaX6IIJoNpUoFxKanFyUWZBSWZ+HlBJCFBGASSjgCxeGwsAxjDnRmEAAAA=
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:30 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:52 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_remove_role_permissions/should_remove_a_Permission_from_the_Role_successfully.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_remove_role_permissions/should_remove_a_Permission_from_the_Role_successfully.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_rSi7DH8MezaQ229K/permissions
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_Me7CwJxYruZRfq7q/permissions
     body:
       encoding: UTF-8
       string: permissions[][permission_name]=rubytest-test-permission&permissions[][resource_server_identifier]=rubytest-test-api-for-roles
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/x-www-form-urlencoded
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Content-Length:
@@ -29,27 +29,29 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:40 GMT
+      - Wed, 25 Sep 2019 16:28:53 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 715f5e8a2e96400a
+      - 23f60e242e13f4d2
       Ot-Tracer-Traceid:
-      - 70818b535cddc217
+      - 230097b75c9aa897
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '9'
+      - '2'
       X-Ratelimit-Reset:
-      - '1561749042'
+      - '1569428938'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Strict-Transport-Security:
       - max-age=15724800
       X-Robots-Tag:
@@ -58,5 +60,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:40 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:53 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_update_role/should_update_the_Role_successfully.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/_update_role/should_update_the_Role_successfully.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: patch
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_rSi7DH8MezaQ229K
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/roles/rol_Me7CwJxYruZRfq7q
     body:
       encoding: UTF-8
       string: '{"name":"New name","description":"New description"}'
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Content-Length:
@@ -29,29 +29,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:31 GMT
+      - Wed, 25 Sep 2019 16:28:52 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 20c71ae449c24331
+      - 56b9e1f77e2b9784
       Ot-Tracer-Traceid:
-      - 0fadb49a7bfa27ea
+      - 247f6a2179c5d286
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '9'
+      - '6'
       X-Ratelimit-Reset:
-      - '1561749033'
+      - '1569428935'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
@@ -61,7 +63,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA6tWykxRslIqys+JLwrONHfxsPBNrUoMNDKy9FbSUcpLzE0FyvqlliuAmTpKKanFyUWZBSWZ+XlQCWSRWgAPVW4MTwAAAA==
+        H4sIAAAAAAAAA6tWykxRslIqys+J9001dy73qogsKo0KSis0L1TSUcpLzE0FyvqlliuAmTpKKanFyUWZBSWZ+XlQCWSRWgD0ZSapTwAAAA==
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:31 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:52 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/create_test_api.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/create_test_api.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers
     body:
       encoding: UTF-8
-      string: '{"name":"rubytest-test-api-for-roles","scopes":[{"value":"test:scope"}],"identifier":"rubytest-test-api-for-roles"}'
+      string: '{"name":"rubytest-test-api-for-roles","scopes":[{"value":"rubytest-test-permission"}],"identifier":"rubytest-test-api-for-roles"}'
     headers:
       Accept:
       - "*/*"
@@ -16,11 +16,11 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Content-Length:
-      - '115'
+      - '129'
       Host:
       - auth0-sdk-tests.auth0.com
   response:
@@ -29,29 +29,31 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:26 GMT
+      - Wed, 25 Sep 2019 16:28:50 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 1ece1bd1238ae75f
+      - 377712c43c3d3f0c
       Ot-Tracer-Traceid:
-      - '09cde2520aa156b8'
+      - 1808ccb97d180ded
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '8'
+      - '9'
       X-Ratelimit-Reset:
-      - '1561749028'
+      - '1569428932'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
@@ -61,7 +63,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA4WPsW7DMAxE/0VzDDhKo6b+jHYsCoKWKYMIKxmikiAI8u+lvRTo0oXD8e7w7uF4coM7TvsQgvfHsI+H0IfxEP3byaPbuYzfZI56Ge+NtHXbwYW7VGpXi5CaiSfKjRNT/deKIuUGJSXhTIAxkqobEorSzumZF4glq9WBpeBK1WpxFILEVRssWNsdorA5fnOtnCmDcKLGK+4pvPT9X3krvNHohle/fpXnzHkGlNmo3z9svfFpLIuBDp8Pd0W5rNvXHcOmu+fX8wfh5EpnMwEAAA==
+        H4sIAAAAAAAAA4WPQY7CMAxF7+I1laJCC/QYM0s0stLUrixMUsUBhBB3n8AGiVnMxgv7/a/nO8gEA3TTbtx3oeVN74jdtlszuXW7hxVEf6JK5PN4K2SleQ2/SMMpNzkpWYVkoliEhfK/qFdNV0zMKpHQh0BmMLBXoxXYURYMKVqtw5rCC+Va60clZMlWcPG53DCoVOKdK+lIEVWYijx1d/3Guc/1q/BKIwzb9nk1maPEGb3O1frru+366mchLVV0ONzh4vX89/eF8knMJEV4/Dx+ARDgi0BBAQAA
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:26 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:50 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/create_test_role.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/create_test_role.yml
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Content-Length:
@@ -29,29 +29,31 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:27 GMT
+      - Wed, 25 Sep 2019 16:28:51 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 7d7b46586ea44d7a
+      - 4965d1a63d1cd7b6
       Ot-Tracer-Traceid:
-      - 50bb4f735f294947
+      - 7b1239cb6df00d3e
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '7'
+      - '9'
       X-Ratelimit-Reset:
-      - '1561749029'
+      - '1569428933'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
@@ -61,7 +63,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA6tWykxRslIqys+JLwrONHfxsPBNrUoMNDKy9FbSUcpLzE0FyZYmVZakFpfoggmg2lSgXEpqcXJRZkFJZn4eUEkIUEYBJKOALF4LAIwSdAlfAAAA
+        H4sIAAAAAAAAA6tWykxRslIqys+J9001dy73qogsKo0KSis0L1TSUcpLzE0FyZYmVZakFpfoggmg2lSgXEpqcXJRZkFJZn4eUEkIUEYBJKOALF4LADvySGBfAAAA
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:27 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:51 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/create_test_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/create_test_user.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://auth0-sdk-tests.auth0.com/api/v2/users
     body:
       encoding: UTF-8
-      string: '{"email":"rubytest-rubytest-username-for-roles@auth0.com","password":"6e13ZeM3V","connection":"Username-Password-Authentication","name":"rubytest-username-for-roles"}'
+      string: '{"email":"rubytest-rubytest-username-for-roles@auth0.com","password":"LlRwJrJ402J7UdX","connection":"Username-Password-Authentication","name":"rubytest-username-for-roles"}'
     headers:
       Accept:
       - "*/*"
@@ -16,11 +16,11 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Content-Length:
-      - '166'
+      - '172'
       Host:
       - auth0-sdk-tests.auth0.com
   response:
@@ -29,17 +29,19 @@ http_interactions:
       message: Created
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:26 GMT
+      - Wed, 25 Sep 2019 16:28:49 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 57b61bc248e2e114
+      - 3f68371e6cec83cf
       Ot-Tracer-Traceid:
-      - 5fa52f6668e15cb8
+      - 19e48fd614f086d2
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
@@ -47,11 +49,11 @@ http_interactions:
       X-Ratelimit-Remaining:
       - '9'
       X-Ratelimit-Reset:
-      - '1561749028'
+      - '1569428930'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
@@ -61,7 +63,7 @@ http_interactions:
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA41RXUvDMBT9L4HtaW2TbE2bwtC9+CyoL4qMNLndgl1SknQic//dtHMyFIaQh3PJ+bice0CwE7pFFXJ9/RHAh+QH9B6cETtIGusSZ1vwt6IPW5xKu0MzNHxd6v7SI2l0X+/B6UaDQlUjWg8z1HdKBFBrEaIDxYQnmCW0fCS8IriiLC14/hzlg+daRx0akz9zRRhjlM6LmnCG1SKvcwyFjNROy9C7YaNtCJ2vssynGyf2Igg3bJydYFaUMueEMK6ALLgiVEiQtCxYMxclI/WNXy5KPHXLbjNVy9FrMl9N6F18Upn0p4I4nyx9RK5PO7MZWtHy7Xcz1yvSCkzQQcehejkgaY0BGbQ10eLpLLgX3r9bp5JVjB/4UoyUy4qulePsPua4c5FDrH+wUov2+ybH1xmSDv5xleMXsu0GVjQCAAA=
+        H4sIAAAAAAAAA41RXWvCMBT9LwF9sh+pbU0Ksvmy58G2l40h8d5Uw2pSktQxnP99aZ0iDmSQh3PJ+bicuydyK1RDKmK71ZeXzkdn0DlptdjKqDY2sqaR7l50fpPGYLZkQvqvS91feiAN7sudtKpWEklVi8bJCelaFF7iUvjgkKWURymPsuKZllXGqpzHOWevQd57LlXQkSH5u0C24gVQzBkWLEUExtJiWgZqq8B3tt9o433rqiRx8dqKnfDC9hsnR5jMGBSc0pKjpDlHmgmQkLFZWU8FK+nqzs1zlo7tvF2PcT54jaaLUfYQHqCOzxWE+WjpArJd3Op134qCj+tmblekUGqvvApD9bYnYLSW4JXRweLlJHgUzn0ai9EixPd8EAPlsqJb5VizCzn2VGQf654MKNH83uTwPiFg5T+ucvgBoiwbUTQCAAA=
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:26 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:49 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/delete_test_api.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/delete_test_api.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers/5d166622561c3606b3c2982a
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/resource-servers/5d8b95c2f460ef0753fe0329
     body:
       encoding: US-ASCII
       string: ''
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Host:
@@ -27,27 +27,29 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:42 GMT
+      - Wed, 25 Sep 2019 16:28:55 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 6f62334427a74031
+      - 352f549921eeb010
       Ot-Tracer-Traceid:
-      - 42c809b470ac018d
+      - 2bb526c61a4a0513
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '7'
+      - '2'
       X-Ratelimit-Reset:
-      - '1561749044'
+      - '1569428940'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Strict-Transport-Security:
       - max-age=15724800
       X-Robots-Tag:
@@ -56,5 +58,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:42 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:55 GMT
+recorded_with: VCR 5.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/delete_test_user.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Roles/delete_test_user.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C5d16662237b1960d45b50e7c
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C5d8b95c1d48d580ddc880536
     body:
       encoding: US-ASCII
       string: ''
@@ -16,7 +16,7 @@ http_interactions:
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjcuMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjguMCIsImVudiI6eyJydWJ5IjoiMi41LjEifX0=
       Authorization:
       - Bearer API_TOKEN
       Host:
@@ -27,27 +27,29 @@ http_interactions:
       message: No Content
     headers:
       Date:
-      - Fri, 28 Jun 2019 19:10:42 GMT
+      - Wed, 25 Sep 2019 16:28:53 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
       - keep-alive
+      Server:
+      - nginx
       Ot-Tracer-Spanid:
-      - 16c179630b124a9b
+      - 07f44a0152e1d4ed
       Ot-Tracer-Traceid:
-      - 68df15882c051abc
+      - 1d0a177317e17335
       Ot-Tracer-Sampled:
       - 'true'
       X-Ratelimit-Limit:
       - '10'
       X-Ratelimit-Remaining:
-      - '8'
+      - '1'
       X-Ratelimit-Reset:
-      - '1561749044'
+      - '1569428939'
       Vary:
       - origin,accept-encoding
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Strict-Transport-Security:
       - max-age=15724800
       X-Robots-Tag:
@@ -56,5 +58,5 @@ http_interactions:
       encoding: UTF-8
       string: ''
     http_version: 
-  recorded_at: Fri, 28 Jun 2019 19:10:42 GMT
-recorded_with: VCR 4.0.0
+  recorded_at: Wed, 25 Sep 2019 16:28:53 GMT
+recorded_with: VCR 5.0.0

--- a/spec/integration/lib/auth0/api/v2/api_roles_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_roles_spec.rb
@@ -10,11 +10,11 @@ describe Auth0::Api::V2::Roles do
     @test_user_email = "#{entity_suffix}-#{@test_user_name}@auth0.com"
 
     @test_api_name = "#{entity_suffix}-test-api-for-roles"
-    @test_api_scope = 'test:scope'
 
     @test_role_name = "#{entity_suffix}-test-role"
 
-    @test_permission = Permission.new("#{entity_suffix}-test-permission", @test_api_name)
+    @test_permission_name = "#{entity_suffix}-test-permission"
+    @test_permission = Permission.new(@test_permission_name, @test_api_name)
 
     VCR.use_cassette('Auth0_Api_V2_Roles/create_test_user') do
       @test_user ||= client.create_user(
@@ -29,7 +29,7 @@ describe Auth0::Api::V2::Roles do
       @test_api ||= client.create_resource_server(
         @test_api_name,
         name: @test_api_name,
-        scopes: [{ value: @test_api_scope }]
+        scopes: [{ value: @test_permission_name }]
       )
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,8 @@ end
 $LOAD_PATH.unshift File.expand_path('..', __FILE__)
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
-Dir['./lib/**/*.rb'].each { |f| require f }
+Dir['./lib/*.rb'].each { |f| require f }
+Dir['./lib/api/**/*.rb'].each { |f| require f }
 Dir['./spec/support/**/*.rb'].each { |f| require f }
 Dir['./spec/support/*.rb'].each { |f| require f }
 


### PR DESCRIPTION
### Changes

- Add the missing mixin to `lib/auth0/mixins.rb
- Move all mixin requires to that file and adjust order (aesthetic)

**Note for reviewers:** You can ignore everything in `spec/fixtures/vcr_cassettes`, just recorded HTTP interactions.

### References

Closes #192 

### Testing

Adjusted the `spec_helper` requires to catch missing required files in the future.

* [x] This change adds integration test coverage
* [x] This change has been tested on Ruby 2.6.0