### PR TITLE
Release 4.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## [v4.9.0](https://github.com/auth0/ruby-auth0/tree/v4.9.0) (2019-09-25)
+[Full Changelog](https://github.com/auth0/ruby-auth0/compare/v4.8.0...v4.9.0)
+
+
+**Closed issues:**
+
+- Dot in role name makes description disappear [\#194](https://github.com/auth0/ruby-auth0/issues/194)
+- Missing require Permission [\#192](https://github.com/auth0/ruby-auth0/issues/192)
+- Token required even when not necessary [\#190](https://github.com/auth0/ruby-auth0/issues/190)
+
+**Fixed:**
+
+- Fix request timeout [\#188](https://github.com/auth0/ruby-auth0/pull/188) ([makoto-matsumoto](https://github.com/makoto-matsumoto))
+- Fix missing Permissions mixin [\#196](https://github.com/auth0/ruby-auth0/pull/196) ([joshcanhelp](https://github.com/joshcanhelp))
+
+**Added:**
+
+- Add Management API Guardian enrollments endpoint [\#182](https://github.com/auth0/ruby-auth0/pull/182) ([tomgi](https://github.com/tomgi))
+
 ## [v4.8.0](https://github.com/auth0/ruby-auth0/tree/v4.8.0) (2019-08-01)
 [Full Changelog](https://github.com/auth0/ruby-auth0/compare/v4.7.0...v4.8.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 PATH
   remote: .
   specs:
-    auth0 (4.8.0)
-      rest-client (~> 2.0)
+    auth0 (4.9.0)
+      rest-client (~> 2.0.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     codecov (0.1.14)
       json
@@ -16,12 +16,12 @@ GEM
       url
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
+    coveralls (0.7.1)
+      multi_json (~> 1.3)
+      rest-client
+      simplecov (>= 0.7)
+      term-ansicolor
+      thor
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
@@ -39,7 +39,7 @@ GEM
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
     gem-release (0.7.4)
-    guard (2.15.0)
+    guard (2.15.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
       lumberjack (>= 1.0.12, < 2.0)
@@ -66,16 +66,17 @@ GEM
       ruby_dep (~> 1.2)
     lumberjack (1.0.13)
     method_source (0.8.2)
-    mime-types (3.2.2)
+    mime-types (3.3)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2019.0331)
+    mime-types-data (3.2019.0904)
+    multi_json (1.13.1)
     nenv (0.3.0)
     netrc (0.11.0)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
     parallel (1.17.0)
-    parser (2.6.3.0)
+    parser (2.6.4.1)
       ast (~> 2.4.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -83,7 +84,7 @@ GEM
       slop (~> 3.4)
     pry-nav (0.2.4)
       pry (>= 0.9.10, < 0.11.0)
-    public_suffix (3.1.1)
+    public_suffix (4.0.1)
     rack (1.6.11)
     rack-test (0.8.3)
       rack (>= 1.0, < 3)
@@ -120,7 +121,7 @@ GEM
     ruby_dep (1.5.0)
     safe_yaml (1.0.5)
     shellany (0.0.1)
-    simplecov (0.16.1)
+    simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -137,7 +138,7 @@ GEM
     unicode-display_width (1.6.0)
     url (0.3.2)
     vcr (5.0.0)
-    webmock (3.6.2)
+    webmock (3.7.5)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)

--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'rest-client', '~> 2.0'
+  s.add_runtime_dependency 'rest-client', '~> 2.0.0'
 
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'fuubar', '~> 2.0'

--- a/lib/auth0/version.rb
+++ b/lib/auth0/version.rb
@@ -1,4 +1,4 @@
 # current version of gem
 module Auth0
-  VERSION = '4.8.0'.freeze
+  VERSION = '4.9.0'.freeze
 end


### PR DESCRIPTION
See [milestone](https://github.com/auth0/ruby-auth0/issues?q=is%3Aclosed+milestone%3Av4.9.0) or CHANGELOG below for fixes and additions in this release. 

This PR also includes updates to development gems.