### PR TITLE
add rubocop-rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
 inherit_from: .rubocop_todo.yml
+require:
+  - rubocop-rails
 Rails:
   Enabled: true
 AllCops:

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :development do
   gem 'terminal-notifier-guard', require: false unless ENV['CIRCLECI']
   gem 'coveralls', require: false
   gem 'rubocop', require: false
+  gem 'rubocop-rails', require: false
   gem 'yard', require: false
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,9 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-rails (2.4.1)
+      rack (>= 1.1)
+      rubocop (>= 0.72.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     safe_yaml (1.0.5)
@@ -163,6 +166,7 @@ DEPENDENCIES
   rake (~> 10.4)
   rspec (~> 3.1, >= 3.1.0)
   rubocop
+  rubocop-rails
   simplecov
   terminal-notifier-guard
   vcr


### PR DESCRIPTION
### Changes

Fix Warning: unrecognized cop Rails found in .rubocop.yml

### References

- https://github.com/rubocop-hq/rubocop/pull/7071
- https://github.com/rubocop-hq/rubocop-rails

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
