### PR TITLE
Pass client_id, audience at Auth0::Api::V2::ClientGrants#client_grants

### DIFF
--- a/lib/auth0/api/v2/client_grants.rb
+++ b/lib/auth0/api/v2/client_grants.rb
@@ -7,11 +7,13 @@ module Auth0
 
         # Retrieves a list of all client grants.
         # @see https://auth0.com/docs/api/management/v2#!/client_grants/get_client_grants
+        # @param client_id [string] The client_id of the client grant to retrieve.
         # @param page [int] Page number to get, 0-based.
         # @param per_page [int] Results per page if also passing a page number.
         # @return [json] Returns the client grants.
-        def client_grants (page: nil, per_page: nil)
+        def client_grants (client_id: nil, page: nil, per_page: nil)
           request_params = {
+            client_id: client_id,
             page: page,
             per_page: per_page
           }

--- a/lib/auth0/api/v2/client_grants.rb
+++ b/lib/auth0/api/v2/client_grants.rb
@@ -8,12 +8,14 @@ module Auth0
         # Retrieves a list of all client grants.
         # @see https://auth0.com/docs/api/management/v2#!/client_grants/get_client_grants
         # @param client_id [string] The client_id of the client grant to retrieve.
+        # @param audience [string] The audience of the client grant to retrieve.
         # @param page [int] Page number to get, 0-based.
         # @param per_page [int] Results per page if also passing a page number.
         # @return [json] Returns the client grants.
-        def client_grants (client_id: nil, page: nil, per_page: nil)
+        def client_grants (client_id: nil, audience: nil, page: nil, per_page: nil)
           request_params = {
             client_id: client_id,
+            audience: audience,
             page: page,
             per_page: per_page
           }

--- a/spec/lib/auth0/api/v2/client_grants_spec.rb
+++ b/spec/lib/auth0/api/v2/client_grants_spec.rb
@@ -14,6 +14,7 @@ describe Auth0::Api::V2::ClientGrants do
       expect(@instance).to receive(:get).with(
         '/api/v2/client-grants',
         client_id: nil,
+        audience: nil,
         page: nil,
         per_page: nil
       )
@@ -24,6 +25,7 @@ describe Auth0::Api::V2::ClientGrants do
       expect(@instance).to receive(:get).with(
         '/api/v2/client-grants',
         client_id: nil,
+        audience: nil,
         page: 1,
         per_page: 2
       )

--- a/spec/lib/auth0/api/v2/client_grants_spec.rb
+++ b/spec/lib/auth0/api/v2/client_grants_spec.rb
@@ -21,6 +21,19 @@ describe Auth0::Api::V2::ClientGrants do
       expect { @instance.client_grants }.not_to raise_error
     end
 
+    it 'is expected to send get /api/v2/client-grants/ with client_id and audience' do
+      audience = "https://samples.auth0.com/api/v2/"
+
+      expect(@instance).to receive(:get).with(
+        '/api/v2/client-grants',
+        client_id: '1',
+        audience: audience,
+        page: nil,
+        per_page: nil
+      )
+      expect { @instance.client_grants(client_id: '1', audience: audience) }.not_to raise_error
+    end
+
     it 'is expected to send get /api/v2/client-grants/ with pagination' do
       expect(@instance).to receive(:get).with(
         '/api/v2/client-grants',

--- a/spec/lib/auth0/api/v2/client_grants_spec.rb
+++ b/spec/lib/auth0/api/v2/client_grants_spec.rb
@@ -13,6 +13,7 @@ describe Auth0::Api::V2::ClientGrants do
     it 'is expected to get /api/v2/client-grants/' do
       expect(@instance).to receive(:get).with(
         '/api/v2/client-grants',
+        client_id: nil,
         page: nil,
         per_page: nil
       )
@@ -22,6 +23,7 @@ describe Auth0::Api::V2::ClientGrants do
     it 'is expected to send get /api/v2/client-grants/ with pagination' do
       expect(@instance).to receive(:get).with(
         '/api/v2/client-grants',
+        client_id: nil,
         page: 1,
         per_page: 2
       )


### PR DESCRIPTION
### Changes

I'd like to fetch a client grant by its client id. 
We can't call `Auth0::Api::V2::ClientGrants#client_grants` with `client_id` while `GET /api/v2/client-grants` accepts `client_id`.

### References

Public doc for `GET /api/v2/client-grants`
https://auth0.com/docs/api/management/v2#!/client_grants/get_client_grants

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
    - I'm very happy with adding integration tests for this but I can't run `master`'s integration tests on my local.
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
    * No. But `master` also fails.
* [x] All active GitHub checks have passed
