### PR TITLE
Fix missing to_json

### DIFF
--- a/lib/auth0/mixins/httpproxy.rb
+++ b/lib/auth0/mixins/httpproxy.rb
@@ -21,7 +21,7 @@ module Auth0
                    elsif method == :delete
                      call(:delete, url(safe_path), timeout, add_headers({params: body}))
                    elsif method == :delete_with_body
-                     call(:delete, url(safe_path), timeout, headers, body)
+                     call(:delete, url(safe_path), timeout, headers, body.to_json)
                    elsif method == :post_file
                      body.merge!(multipart: true)
                      call(:post, url(safe_path), timeout, headers, body)


### PR DESCRIPTION
Fixes #193 

Tests are widely not working when running `rake test` and need massive rework (from what I can tell, there are missing `VCR Cassettes` calls). Or there is some config I miss (161 failures). So I couldn't have them pass.

Please let me know if there's a trick.