### PR TITLE
Add client secret to Passwordless flow since it is now required

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -186,7 +186,8 @@ module Auth0
         request_params = {
           phone_number: phone_number,
           connection: 'sms',
-          client_id: @client_id
+          client_id: @client_id,
+          client_secret: @client_secret
         }
         post('/passwordless/start', request_params)
       end

--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -170,7 +170,8 @@ module Auth0
           send: send,
           authParams: auth_params,
           connection: 'email',
-          client_id: @client_id
+          client_id: @client_id,
+          client_secret: @client_secret
         }
         post('/passwordless/start', request_params)
       end


### PR DESCRIPTION
Following https://community.auth0.com/t/passwordless-connection-not-working-for-tenants-created-after-jan-2-2020/36415/5 , it is now required to send `client_secret` through the passwordless endpoints.

This PR simply adds `client_secret` to the POST requests, following this spec.

PR tested on my app. Fails before (error `Auth0::AccessDenied: {"error":"unauthorized_client","error_description":"Client authentication is required"}`), pass after.