### PR TITLE
Added support for name_filter parameter [SDK-1607]

### DIFF
--- a/lib/auth0/api/v2/roles.rb
+++ b/lib/auth0/api/v2/roles.rb
@@ -13,13 +13,15 @@ module Auth0
         #   - per_page: Number of Roles to return.
         #   - page: Page number to return, zero-based.
         #   - include_totals: True to include query summary in the result, false or nil otherwise.
+        #   - name_filter: Optional filter on name (case-insensitive).
         #
         # @return [json] All Roles matching the query.
         def get_roles(options = {})
           request_params = {
             per_page: options.fetch(:per_page, nil),
             page: options.fetch(:page, nil),
-            include_totals: options.fetch(:include_totals, nil)
+            include_totals: options.fetch(:include_totals, nil),
+            name_filter: options.fetch(:name_filter, nil)
           }
           get roles_path, request_params
         end

--- a/spec/lib/auth0/api/v2/roles_spec.rb
+++ b/spec/lib/auth0/api/v2/roles_spec.rb
@@ -20,7 +20,8 @@ describe Auth0::Api::V2::Roles do
         '/api/v2/roles',
         per_page: nil,
         page: nil,
-        include_totals: nil
+        include_totals: nil,
+        name_filter: nil
       )
       expect { @instance.get_roles }.not_to raise_error
     end
@@ -30,10 +31,11 @@ describe Auth0::Api::V2::Roles do
         '/api/v2/roles',
         per_page: 10,
         page: 3,
-        include_totals: true
+        include_totals: true,
+        name_filter: 'test'
       )
       expect do
-        @instance.get_roles(per_page: 10, page: 3, include_totals: true)
+        @instance.get_roles(per_page: 10, page: 3, include_totals: true, name_filter: 'test')
       end.not_to raise_error
     end
   end


### PR DESCRIPTION
### Changes

This PR adds support for the `name_filter` parameter on the `get_roles` [endpoint](https://auth0.com/docs/api/management/v2#!/Roles/get_roles) to filter roles by name.

### Testing

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [X] All active GitHub checks have passed
