### PR TITLE
Release 4.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Change Log
 
+## [v4.10.0](https://github.com/auth0/ruby-auth0/tree/v4.10.0) (2020-04-23)
+
+[Full Changelog](https://github.com/auth0/ruby-auth0/compare/v4.9.0...v4.10.0)
+
+**Implemented enhancements:**
+
+- Gem prevents from replacing {app,user}\_metadata [\#191](https://github.com/auth0/ruby-auth0/issues/191)
+
+**Closed issues:**
+
+- Every 24 hours the management API starts returning unauthorized responses. [\#208](https://github.com/auth0/ruby-auth0/issues/208)
+- Update to include Prompts / should not be closed [\#204](https://github.com/auth0/ruby-auth0/issues/204)
+- Should not be closed [\#203](https://github.com/auth0/ruby-auth0/issues/203)
+- Unable to set audience [\#189](https://github.com/auth0/ruby-auth0/issues/189)
+
+**Merged pull requests:**
+
+- Update rack requirement from ~\> 1.6.4 to ~\> 2.1.2 [\#206](https://github.com/auth0/ruby-auth0/pull/206) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Added support for name\_filter parameter \[SDK-1607\] [\#214](https://github.com/auth0/ruby-auth0/pull/214) ([Widcket](https://github.com/Widcket))
+- Update dependencies and CI script [\#210](https://github.com/auth0/ruby-auth0/pull/210) ([lbalmaceda](https://github.com/lbalmaceda))
+- Pass client\_id, audience at Auth0::Api::V2::ClientGrants\#client\_grants [\#209](https://github.com/auth0/ruby-auth0/pull/209) ([hkdnet](https://github.com/hkdnet))
+- Update rake requirement from ~\> 10.4 to ~\> 13.0 [\#207](https://github.com/auth0/ruby-auth0/pull/207) ([dependabot[bot]](https://github.com/apps/dependabot))
+- Add rubocop-rails [\#200](https://github.com/auth0/ruby-auth0/pull/200) ([tknzk](https://github.com/tknzk))
+
 ## [v4.9.0](https://github.com/auth0/ruby-auth0/tree/v4.9.0) (2019-09-25)
 [Full Changelog](https://github.com/auth0/ruby-auth0/compare/v4.8.0...v4.9.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,25 +4,17 @@
 
 [Full Changelog](https://github.com/auth0/ruby-auth0/compare/v4.9.0...v4.10.0)
 
-**Implemented enhancements:**
+**Added**
 
-- Gem prevents from replacing {app,user}\_metadata [\#191](https://github.com/auth0/ruby-auth0/issues/191)
+- Added support for name\_filter parameter \[SDK-1607\] [\#214](https://github.com/auth0/ruby-auth0/pull/214) ([Widcket](https://github.com/Widcket))
+- Pass client\_id, audience at Auth0::Api::V2::ClientGrants\#client\_grants [\#209](https://github.com/auth0/ruby-auth0/pull/209) ([hkdnet](https://github.com/hkdnet))
+- Add rubocop-rails [\#200](https://github.com/auth0/ruby-auth0/pull/200) ([tknzk](https://github.com/tknzk))
 
-**Closed issues:**
-
-- Every 24 hours the management API starts returning unauthorized responses. [\#208](https://github.com/auth0/ruby-auth0/issues/208)
-- Update to include Prompts / should not be closed [\#204](https://github.com/auth0/ruby-auth0/issues/204)
-- Should not be closed [\#203](https://github.com/auth0/ruby-auth0/issues/203)
-- Unable to set audience [\#189](https://github.com/auth0/ruby-auth0/issues/189)
-
-**Merged pull requests:**
+**Security**
 
 - Update rack requirement from ~\> 1.6.4 to ~\> 2.1.2 [\#206](https://github.com/auth0/ruby-auth0/pull/206) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Added support for name\_filter parameter \[SDK-1607\] [\#214](https://github.com/auth0/ruby-auth0/pull/214) ([Widcket](https://github.com/Widcket))
-- Update dependencies and CI script [\#210](https://github.com/auth0/ruby-auth0/pull/210) ([lbalmaceda](https://github.com/lbalmaceda))
-- Pass client\_id, audience at Auth0::Api::V2::ClientGrants\#client\_grants [\#209](https://github.com/auth0/ruby-auth0/pull/209) ([hkdnet](https://github.com/hkdnet))
 - Update rake requirement from ~\> 10.4 to ~\> 13.0 [\#207](https://github.com/auth0/ruby-auth0/pull/207) ([dependabot[bot]](https://github.com/apps/dependabot))
-- Add rubocop-rails [\#200](https://github.com/auth0/ruby-auth0/pull/200) ([tknzk](https://github.com/tknzk))
+- Update dependencies and CI script [\#210](https://github.com/auth0/ruby-auth0/pull/210) ([lbalmaceda](https://github.com/lbalmaceda))
 
 ## [v4.9.0](https://github.com/auth0/ruby-auth0/tree/v4.9.0) (2019-09-25)
 [Full Changelog](https://github.com/auth0/ruby-auth0/compare/v4.8.0...v4.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auth0 (4.9.0)
+    auth0 (4.10.0)
       rest-client (~> 2.0.0)
 
 GEM
@@ -86,7 +86,7 @@ GEM
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    loofah (2.4.0)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.2.4)
@@ -105,7 +105,7 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     parallel (1.19.1)
-    parser (2.7.0.5)
+    parser (2.7.1.1)
       ast (~> 2.4.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -113,7 +113,7 @@ GEM
       slop (~> 3.4)
     pry-nav (0.2.4)
       pry (>= 0.9.10, < 0.11.0)
-    public_suffix (4.0.3)
+    public_suffix (4.0.4)
     rack (2.1.2)
     rack-test (0.8.3)
       rack (>= 1.0, < 3)
@@ -151,7 +151,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    rubocop (0.81.0)
+    rubocop (0.82.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
@@ -159,7 +159,7 @@ GEM
       rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-rails (2.5.0)
+    rubocop-rails (2.5.2)
       activesupport
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -179,7 +179,7 @@ GEM
     thread_safe (0.3.6)
     tins (1.24.1)
       sync
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext

--- a/lib/auth0/version.rb
+++ b/lib/auth0/version.rb
@@ -1,4 +1,4 @@
 # current version of gem
 module Auth0
-  VERSION = '4.9.0'.freeze
+  VERSION = '4.10.0'.freeze
 end


### PR DESCRIPTION
**Added**

- Added support for name\_filter parameter \[SDK-1607\] [\#214](https://github.com/auth0/ruby-auth0/pull/214) ([Widcket](https://github.com/Widcket))
- Pass client\_id, audience at Auth0::Api::V2::ClientGrants\#client\_grants [\#209](https://github.com/auth0/ruby-auth0/pull/209) ([hkdnet](https://github.com/hkdnet))
- Add rubocop-rails [\#200](https://github.com/auth0/ruby-auth0/pull/200) ([tknzk](https://github.com/tknzk))

**Security**

- Update rack requirement from ~\> 1.6.4 to ~\> 2.1.2 [\#206](https://github.com/auth0/ruby-auth0/pull/206) ([dependabot[bot]](https://github.com/apps/dependabot))
- Update rake requirement from ~\> 10.4 to ~\> 13.0 [\#207](https://github.com/auth0/ruby-auth0/pull/207) ([dependabot[bot]](https://github.com/apps/dependabot))
- Update dependencies and CI script [\#210](https://github.com/auth0/ruby-auth0/pull/210) ([lbalmaceda](https://github.com/lbalmaceda))