### PR TITLE
[SDK-1542] Add client secret to Passwordless flow since it is now required

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -170,7 +170,8 @@ module Auth0
           send: send,
           authParams: auth_params,
           connection: 'email',
-          client_id: @client_id
+          client_id: @client_id,
+          client_secret: @client_secret
         }
         post('/passwordless/start', request_params)
       end
@@ -185,7 +186,8 @@ module Auth0
         request_params = {
           phone_number: phone_number,
           connection: 'sms',
-          client_id: @client_id
+          client_id: @client_id,
+          client_secret: @client_secret
         }
         post('/passwordless/start', request_params)
       end

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -355,6 +355,7 @@ describe Auth0::Api::AuthenticationEndpoints do
       expect(@instance).to receive(:post).with(
         '/passwordless/start',
         client_id: @instance.client_id,
+        client_secret: @instance.client_secret,
         connection:  'email',
         email: 'test@test.com',
         send: 'code',
@@ -388,6 +389,7 @@ describe Auth0::Api::AuthenticationEndpoints do
       expect(@instance).to receive(:post).with(
         '/passwordless/start',
         client_id: @instance.client_id,
+        client_secret: @instance.client_secret,
         connection: 'sms',
         phone_number: phone_number
       )


### PR DESCRIPTION
### Changes

Following https://community.auth0.com/t/passwordless-connection-not-working-for-tenants-created-after-jan-2-2020/36415/5 , it is now required to send `client_secret` through the passwordless endpoints.

This PR simply adds `client_secret` to the POST requests, following this spec.

PR tested on my app. Fails before (error `Auth0::AccessDenied: {"error":"unauthorized_client","error_description":"Client authentication is required"}`), pass after.

### References

This PR replaces #213 

### Testing

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] Rubocop passes on all added/modified files
* [X] All active GitHub checks have passed
