### PR TITLE
Improve OIDC compliance: add claims validation support [SDK-987]

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -522,15 +522,6 @@ module Auth0
       #   Defaults to your *Auth0 Client ID*.
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/ParameterLists
       def validate_id_token(id_token, algorithm: nil, leeway: 60, nonce: nil, max_age: nil, issuer: nil, audience: nil)
-        raise Auth0::InvalidParameter, 'Must supply a valid leeway' unless leeway.is_a?(Integer) && leeway >= 0
-        raise Auth0::InvalidParameter, 'Must supply a valid nonce' unless nonce.nil? || !nonce.to_s.empty?
-        raise Auth0::InvalidParameter, 'Must supply a valid issuer' unless issuer.nil? || !issuer.to_s.empty?
-        raise Auth0::InvalidParameter, 'Must supply a valid audience' unless audience.nil? || !audience.to_s.empty?
-
-        unless max_age.nil? || (max_age.is_a?(Integer) && max_age >= 0)
-          raise Auth0::InvalidParameter, 'Must supply a valid max_age'
-        end
-
         context = {
           issuer: issuer || "https://#{@domain}/",
           audience: audience || @client_id,

--- a/lib/auth0/mixins/validation.rb
+++ b/lib/auth0/mixins/validation.rb
@@ -149,7 +149,7 @@ module Auth0
                                          " found \"#{claims['aud']}\""
           elsif claims['aud'].is_a?(Array) && !claims['aud'].include?(expected)
             raise Auth0::InvalidIdToken, "Audience (aud) claim mismatch in the ID token; expected \"#{expected}\""\
-                                         " but was not one of \"#{claims['aud']}\""
+                                         " but was not one of \"#{claims['aud'].join ', '}\""
           end
         end
 

--- a/lib/auth0/mixins/validation.rb
+++ b/lib/auth0/mixins/validation.rb
@@ -158,7 +158,7 @@ module Auth0
             raise Auth0::InvalidIdToken, 'Expiration Time (exp) claim must be a number present in the ID token'
           end
 
-          now = @context[:clock] || Time.now
+          now = @context[:clock] || Time.now.to_i
           exp_time = claims['exp'] + leeway
 
           unless now < exp_time
@@ -172,7 +172,7 @@ module Auth0
             raise Auth0::InvalidIdToken, 'Issued At (iat) claim must be a number present in the ID token'
           end
 
-          now = @context[:clock] || Time.now
+          now = @context[:clock] || Time.now.to_i
           iat_time = claims['iat'] - leeway
 
           unless now > iat_time
@@ -209,7 +209,7 @@ module Auth0
                                          ' token when Max Age (max_age) is specified'
           end
 
-          now = @context[:clock] || Time.now
+          now = @context[:clock] || Time.now.to_i
           auth_valid_until = claims['auth_time'] + max_age + leeway
 
           unless now < auth_valid_until

--- a/lib/auth0/mixins/validation.rb
+++ b/lib/auth0/mixins/validation.rb
@@ -28,6 +28,7 @@ module Auth0
         permissions.map { |permission| permission.to_h }
       end
 
+      # rubocop:disable Metrics/ClassLength
       class IdTokenValidator
         def initialize(context)
           @context = context
@@ -85,15 +86,140 @@ module Auth0
             raise Auth0::InvalidIdToken, 'Invalid ID token signature'
           rescue JWT::IncorrectAlgorithm
             alg = header['alg']
-            raise Auth0::InvalidIdToken, "Signature algorithm of \"#{alg}\" is not supported. Expected the ID token to be signed with \"#{algorithm.name}\""
+            raise Auth0::InvalidIdToken, "Signature algorithm of \"#{alg}\" is not supported. Expected the ID token"\
+                                         " to be signed with \"#{algorithm.name}\""
           rescue JWT::DecodeError
             raise Auth0::InvalidIdToken, "Could not find a public key for Key ID (kid) \"#{kid}\""
           end
         end
-        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
 
-        def validate_claims(decoded_id_token); end # TODO: Implement (in the next PR)
+        # rubocop:disable Metrics/PerceivedComplexity
+        def validate_claims(claims)
+          leeway = @context[:leeway]
+          nonce = @context[:nonce]
+          issuer = @context[:issuer]
+          audience = @context[:audience]
+          max_age = @context[:max_age]
+
+          raise Auth0::InvalidParameter, 'Must supply a valid leeway' unless leeway.is_a?(Integer) && leeway >= 0
+          raise Auth0::InvalidParameter, 'Must supply a valid nonce' unless nonce.nil? || !nonce.to_s.empty?
+          raise Auth0::InvalidParameter, 'Must supply a valid issuer' unless issuer.nil? || !issuer.to_s.empty?
+          raise Auth0::InvalidParameter, 'Must supply a valid audience' unless audience.nil? || !audience.to_s.empty?
+
+          unless max_age.nil? || (max_age.is_a?(Integer) && max_age >= 0)
+            raise Auth0::InvalidParameter, 'Must supply a valid max_age'
+          end
+
+          validate_iss(claims, issuer)
+          validate_sub(claims)
+          validate_aud(claims, audience)
+          validate_exp(claims, leeway)
+          validate_iat(claims, leeway)
+          validate_nonce(claims, nonce) if nonce
+          validate_azp(claims, audience) if claims['aud'].is_a?(Array) && claims['aud'].count > 1
+          validate_auth_time(claims, max_age, leeway) if max_age
+        end
+        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+
+        def validate_iss(claims, expected)
+          unless claims.key?('iss') && claims['iss'].is_a?(String)
+            raise Auth0::InvalidIdToken, 'Issuer (iss) claim must be a string present in the ID token'
+          end
+
+          unless expected == claims['iss']
+            raise Auth0::InvalidIdToken, "Issuer (iss) claim mismatch in the ID token; expected \"#{expected}\","\
+                                         " found \"#{claims['iss']}\""
+          end
+        end
+
+        def validate_sub(claims)
+          unless claims.key?('sub') && claims['sub'].is_a?(String)
+            raise Auth0::InvalidIdToken, 'Subject (sub) claim must be a string present in the ID token'
+          end
+        end
+
+        def validate_aud(claims, expected)
+          unless claims.key?('aud') && (claims['aud'].is_a?(String) || claims['aud'].is_a?(Array))
+            raise Auth0::InvalidIdToken, 'Audience (aud) claim must be a string or array of strings present'\
+                                         ' in the ID token'
+          end
+
+          if claims['aud'].is_a?(String) && expected != claims['aud']
+            raise Auth0::InvalidIdToken, "Audience (aud) claim mismatch in the ID token; expected \"#{expected}\","\
+                                         " found \"#{claims['aud']}\""
+          elsif claims['aud'].is_a?(Array) && !claims['aud'].include?(expected)
+            raise Auth0::InvalidIdToken, "Audience (aud) claim mismatch in the ID token; expected \"#{expected}\""\
+                                         " but was not one of \"#{claims['aud']}\""
+          end
+        end
+
+        def validate_exp(claims, leeway)
+          unless claims.key?('exp') && claims['exp'].is_a?(Integer)
+            raise Auth0::InvalidIdToken, 'Expiration Time (exp) claim must be a number present in the ID token'
+          end
+
+          now = @context[:clock] || Time.now
+          exp_time = claims['exp'] + leeway
+
+          unless now < exp_time
+            raise Auth0::InvalidIdToken, 'Expiration Time (exp) claim mismatch in the ID token; current time'\
+                                         " \"#{now}\" is after expiration time \"#{exp_time}\""
+          end
+        end
+
+        def validate_iat(claims, leeway)
+          unless claims.key?('iat') && claims['iat'].is_a?(Integer)
+            raise Auth0::InvalidIdToken, 'Issued At (iat) claim must be a number present in the ID token'
+          end
+
+          now = @context[:clock] || Time.now
+          iat_time = claims['iat'] - leeway
+
+          unless now > iat_time
+            raise Auth0::InvalidIdToken, "Issued At (iat) claim mismatch in the ID token; current time \"#{now}\""\
+                                         " is before issued at time \"#{iat_time}\""
+          end
+        end
+
+        def validate_nonce(claims, expected)
+          unless claims.key?('nonce') && claims['nonce'].is_a?(String)
+            raise Auth0::InvalidIdToken, 'Nonce (nonce) claim must be a string present in the ID token'
+          end
+
+          unless expected == claims['nonce']
+            raise Auth0::InvalidIdToken, "Nonce (nonce) claim mismatch in the ID token; expected \"#{expected}\","\
+                                         " found \"#{claims['nonce']}\""
+          end
+        end
+
+        def validate_azp(claims, expected)
+          unless claims.key?('azp') && claims['azp'].is_a?(String)
+            raise Auth0::InvalidIdToken, 'Authorized Party (azp) claim must be a string present in the ID token'
+          end
+
+          unless expected == claims['azp']
+            raise Auth0::InvalidIdToken, 'Authorized Party (azp) claim mismatch in the ID token; expected'\
+                                         " \"#{expected}\", found \"#{claims['azp']}\""
+          end
+        end
+
+        def validate_auth_time(claims, max_age, leeway)
+          unless claims.key?('auth_time') && claims['auth_time'].is_a?(Integer)
+            raise Auth0::InvalidIdToken, 'Authentication Time (auth_time) claim must be a number present in the ID'\
+                                         ' token when Max Age (max_age) is specified'
+          end
+
+          now = @context[:clock] || Time.now
+          auth_valid_until = claims['auth_time'] + max_age + leeway
+
+          unless now < auth_valid_until
+            raise Auth0::InvalidIdToken, 'Authentication Time (auth_time) claim in the ID token indicates that too'\
+                                         ' much time has passed since the last end-user authentication. Current time'\
+                                         " \"#{now}\" is after last auth at \"#{auth_valid_until}\""
+          end
+        end
       end
+      # rubocop:enable Metrics/ClassLength
 
       class JWTAlgorithm
         private_class_method :new

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -677,57 +677,6 @@ describe Auth0::Api::AuthenticationEndpoints do
   # Auth0::API::AuthenticationEndpoints.validate_id_token
   context '.validate_id_token' do
     it { expect(@instance).to respond_to(:validate_id_token) }
-
-    it 'is expected to raise an error with a non-integer leeway' do
-      expect { @instance.validate_id_token('id token', leeway: '1') }.to raise_exception('Must supply a valid leeway')
-    end
-
-    it 'is expected to raise an error with a negative leeway' do
-      expect { @instance.validate_id_token('id token', leeway: -1) }.to raise_exception('Must supply a valid leeway')
-    end
-
-    it 'is expected to raise an error with an empty nonce' do
-      expect { @instance.validate_id_token('id token', nonce: '') }.to raise_exception('Must supply a valid nonce')
-    end
-
-    it 'is expected to raise an error with an empty issuer' do
-      expect { @instance.validate_id_token('id token', issuer: '') }.to raise_exception('Must supply a valid issuer')
-    end
-
-    it 'is expected to raise an error with an empty audience' do
-      expect { @instance.validate_id_token('id token', audience: '') }.to raise_exception('Must supply a valid audience')
-    end
-
-    it 'is expected to raise an error with a non-integer max_age' do
-      expect { @instance.validate_id_token('id token', max_age: '1') }.to raise_exception('Must supply a valid max_age')
-    end
-
-    it 'is expected to raise an error with a negative max_age' do
-      expect { @instance.validate_id_token('id token', max_age: -1) }.to raise_exception('Must supply a valid max_age')
-    end
-
-    it 'is expected not to raise an error with a valid token signed with HS256' do
-      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.Hn38QVtN_mWN0c-jOa-Fqq69kXpbBp0THsvE-CQ47Ps'
-
-      expect { @instance.validate_id_token(token, algorithm: Auth0::Algorithm::HS256.secret('secret')) }.to_not raise_exception
-    end
-
-    it 'is expected not to raise an error with a valid token signed with RS256' do
-      stub_jwks
-      token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5LTEifQ.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.jE00ARUiAwrKEoAMwbioKYj4bUZjmg31V7McDtIPsJJ16rYcvI-e5mtSSMgCmAom6t-WA7dsSWCJUlBCW2nAMvyCZ-hj8HG9Z0RmQEiwig9Fk22avoX94zdx65TwAeDfn2uMRaX_ps3TJcn4nymUtMp8Lps_vMw15eJerKThlSO4KuLTrvDDdRaCRamAd7jxuzhiwOt0mB0TVD55b5itA02pGuyapbjQXvvLYEx8OgpyIaAkB9Ry25abgjev0bSw2kjFZckG3lv9QgvZM85m9l3Rbrc6msNPGfMDFWGyT3Tu2ObqnSEA-57hZeuCbFrOya3vUwgSlc66rfvZj2xpzg'
-
-      expect { @instance.validate_id_token(token, algorithm: Auth0::Algorithm::RS256.jwks_url(JWKS_URL)) }.to_not raise_exception
-      expect do
-        @instance.validate_id_token(token,
-                                    algorithm: Auth0::Algorithm::RS256.jwks_url(JWKS_URL),
-                                    leeway: 10,
-                                    nonce: 'nonce',
-                                    issuer: 'issuer',
-                                    audience: 'audience',
-                                    max_age: 10)
-      end .to_not raise_exception
-      expect(a_request(:get, JWKS_URL)).to have_been_made.once
-    end
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -677,6 +677,27 @@ describe Auth0::Api::AuthenticationEndpoints do
   # Auth0::API::AuthenticationEndpoints.validate_id_token
   context '.validate_id_token' do
     it { expect(@instance).to respond_to(:validate_id_token) }
+
+    it 'is expected not to raise an error with default values' do
+      stub_request(:get, 'https://test.auth0.com/.well-known/jwks.json').to_return(body: JWKS_RESPONSE_1.to_json)
+      token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5LTEifQ.eyJpc3MiOiJodHRwczovL3Rlc3QuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDEyMzQ1Njc4OSIsImF1ZCI6WyJfX3Rlc3RfYXVkaWVuY2VfXyIsIl9fdGVzdF9jbGllbnRfaWRfXyJdLCJleHAiOjI1MzgzMDExNDYsImlhdCI6MTU4NzU5MjU2MSwiYXpwIjoiX190ZXN0X2NsaWVudF9pZF9fIn0.X35Hfa1C9RtuJIj7Eky2iO4elY9XqCDRy8ieFAft63vGds9vhP38x8QHbJifmLs6vDEOySKfJMWhklp3oaXm6Tk6gyUQEaliW_pXUgZt8C3Xo125R8BMCDQeVJg8Abevbg6FpHpYztWpQuI609tmpoTczx7pXMmAneg6e4LNYvvtzaFD_0M0cxtjkm4OcevCJszNBru3tdXwRynkGbMYeXgoa_FumAshRvIvh-4dtkyNWsepo5IVTvixxF3FVoFaXOOycmFXh9gxOppG4lvE78AFB9AQ9LNS-DNhcXszbPs9KHMrg2bqhSL8Razqd3m2a1MXkdLMBD5DY499MVnb5w'
+
+      expect { @instance.validate_id_token(token) }.to_not raise_exception
+    end
+
+    it 'is expected not to raise an error with custom values' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsiYXVkaWVuY2UiLCJhbm90aGVyX2F1ZGllbmNlIl0sImV4cCI6MjUzODMwMTE0NiwiaWF0IjoxNTg3NTkyNTYxLCJub25jZSI6Im5vbmNlIiwiYXpwIjoiYXVkaWVuY2UiLCJhdXRoX3RpbWUiOjE1ODc2Nzg5NjF9.u39qTvuUmbzj5jsXjATXxjxJt0u064G1IAumoi18gm0'
+
+      expect do
+        @instance.validate_id_token(token,
+                                    algorithm: Auth0::Algorithm::HS256.secret('secret'),
+                                    leeway: 100,
+                                    nonce: 'nonce',
+                                    max_age: 2538301146,
+                                    issuer: 'issuer',
+                                    audience: 'audience')
+      end.to_not raise_exception
+    end
   end
 end
 # rubocop:enable Metrics/BlockLength

--- a/spec/lib/auth0/mixins/validation_spec.rb
+++ b/spec/lib/auth0/mixins/validation_spec.rb
@@ -204,9 +204,9 @@ describe Auth0::Mixins::Validation::IdTokenValidator do
     end
 
     it 'is expected to raise an error with an invalid array aud' do
-      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.5wamOri6WdxTew3mm2PCKMiPjdCf7jwPUqaxjwkeJQU'
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsiZXh0ZXJuYWwtdGVzdC05OTgiLCJleHRlcm5hbC10ZXN0LTk5OSJdLCJleHAiOjE1ODc3NjUzNjEsImlhdCI6MTU4NzU5MjU2MSwibm9uY2UiOiJhMWIyYzNkNGU1IiwiYXpwIjoidG9rZW5zLXRlc3QtMTIzIiwiYXV0aF90aW1lIjoxNTg3Njc4OTYxfQ.Q1GRVL5g3RLQqG5sEV_cc8WW_oiZzFIAfzRfBdxMW2s'
 
-      expect { @instance.validate(token) }.to raise_exception("Audience (aud) claim mismatch in the ID token; expected \"#{CONTEXT[:audience]}\" but was not one of \"[\"external-test-999\"]\"")
+      expect { @instance.validate(token) }.to raise_exception("Audience (aud) claim mismatch in the ID token; expected \"#{CONTEXT[:audience]}\" but was not one of \"external-test-998, external-test-999\"")
     end
 
     it 'is expected to raise an error with a missing exp' do


### PR DESCRIPTION
### Changes

This update improves the SDK support for **OpenID Connect (OIDC)**. In particular, it adds support for **claims validation**.

#### What’s being added in this PR

- The implementation of the `validate_claims` method. Plus tests.

#### What’s being changed in this PR

- Moved the params validation to the validator class, along with its tests.
- Replaced the public API test cases with ones that test just the logic inside that method.

### Testing

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [X] All active GitHub checks have passed
