### PR TITLE
Added IDTV documentation to the README [SDK-1670]

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,51 @@ In addition to the Management API, this SDK also provides access to [Authenticat
 
 Please note that this module implements endpoints that might be deprecated for newer tenants. If you have any questions about how and when the endpoints should be used, consult the [documentation](https://auth0.com/docs/api/authentication) or ask in our [Community forums](https://community.auth0.com/tags/wordpress).
 
+## ID Token Validation
+
+As the result of the authentication and among the credentials received, an `id_token` might be present. This artifact contains information associated to the user that has just logged in, provided the scope used contained `openid`. You can read more about ID tokens [here](https://auth0.com/docs/tokens/concepts/id-tokens).
+
+Before accessing its contents, you must first validate the ID token to ensure it has not been tampered with and that it is meant for your application to consume. Use the `validate_id_token` method to do so:
+
+```ruby
+begin
+  @auth0_client.validate_id_token 'id_token'
+rescue Auth0::InvalidIdToken => e
+  # In this case the ID Token contents should not be trusted
+end
+```
+
+The method takes the following optional keyword parameters:
+
+| Parameter     | Type           | Description   | Default value             |
+| ------------- | -------------- | ------------- | ------------------------- |
+| `algorithm`   | `JWTAlgorithm` | The [signing algorithm](https://auth0.com/docs/tokens/concepts/signing-algorithms) used by your Auth0 application.  | `Auth0::Algorithm::RS256` |
+| `leeway`      | Integer        | Number of seconds to account for clock skew when validating the `exp`, `iat` and `azp` claims.  | `60`  |
+| `nonce`       | String         | The `nonce` value you sent in the call to `/authorize`, if any.  | `nil`  |
+| `max_age`     | Integer        | The `max_age` value you sent in the call to `/authorize`, if any.  | `nil`  |
+| `issuer`      | String         | By default the `iss` claim will be checked against the URL of your **Auth0 Domain**. Use this parameter to override that. | `nil`  |
+| `audience`    | String         | By default the `aud` claim will be compared to your **Auth0 Client ID**. Use this parameter to override that.  | `nil`  |
+
+You can check the signing algorithm value under **Advanced Settings > OAuth > JsonWebToken Signature Algorithm** in your Auth0 application settings panel. It is recommended that you make use of asymmetric signing algorithms like `RS256` as their keys are easier to rotate in case they need to be revoked.
+
+```ruby
+# HS256
+
+begin
+  @auth0_client.validate_id_token 'id_token', algorithm: Auth0::Algorithm::HS256.secret('secret')
+rescue Auth0::InvalidIdToken => e
+  # Handle error
+end
+
+# RS256 with a custom JWKS URL
+
+begin
+  @auth0_client.validate_id_token 'id_token', algorithm: Auth0::Algorithm::RS256.jwks_url('url')
+rescue Auth0::InvalidIdToken => e
+  # Handle error
+end
+```
+
 ## Development
 
 In order to set up the local environment you'd have to have Ruby installed and a few global gems used to run and record the unit tests. A working Ruby version can be taken from the [CI script](/.circleci/config.yml). At the moment of this writting we're using Ruby `2.5.7`.


### PR DESCRIPTION
### Changes

Added a section to the README documenting the new `validate_id_token` method. It's based on the [corresponding section](https://github.com/auth0/auth0-python#id-token-validation) of **auth0-python**'s README.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [X] All active GitHub checks have passed
