### PR TITLE
Improve OIDC compliance [SDK-987]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,9 @@ PATH
   remote: .
   specs:
     auth0 (4.11.0)
+      jwt (~> 2.2.0)
       rest-client (~> 2.0.0)
+      zache (~> 0.12.0)
 
 GEM
   remote: https://rubygems.org/
@@ -83,6 +85,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     json (2.3.0)
+    jwt (2.2.1)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -192,6 +195,7 @@ GEM
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
     yard (0.9.25)
+    zache (0.12.0)
     zeitwerk (2.3.0)
 
 PLATFORMS

--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -17,6 +17,8 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'rest-client', '~> 2.0.0'
+  s.add_runtime_dependency 'jwt', '~> 2.2.0'
+  s.add_runtime_dependency 'zache', '~> 0.12.0'
 
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'fuubar', '~> 2.0'

--- a/lib/auth0.rb
+++ b/lib/auth0.rb
@@ -1,6 +1,7 @@
 require 'auth0/version'
 require 'auth0/mixins'
 require 'auth0/exception'
+require 'auth0/algorithm'
 require 'auth0/client'
 require 'auth0_client'
 # Namespace for ruby-auth0 logic

--- a/lib/auth0/algorithm.rb
+++ b/lib/auth0/algorithm.rb
@@ -1,0 +1,5 @@
+module Auth0
+  module Algorithm
+    include Auth0::Mixins::Validation::Algorithm
+  end
+end

--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -1,4 +1,8 @@
+# frozen_string_literal: true
 # rubocop:disable Metrics/ModuleLength
+
+require 'jwt'
+
 module Auth0
   module Api
     # {https://auth0.com/docs/api/authentication}
@@ -501,6 +505,45 @@ module Auth0
         }
         post('/unlink', request_params)
       end
+
+      # Validate an ID token (signature and expiration).
+      # @see https://auth0.com/docs/tokens/guides/validate-id-tokens
+      # @param id_token [string] The JWT to validate.
+      # @param algorithm [JWKAlgorithm] The expected signing algorithm.
+      #   Defaults to +Auth0::Algorithm::RS256.jwks_url("https://YOUR_AUTH0_DOMAIN/.well-known/jwks.json", lifetime: 10 * 60)+.
+      # @param leeway [integer] The clock skew to accept when verifying date related claims in seconds.
+      #   Must be a non-negative value. Defaults to *60 seconds*.
+      # @param nonce [string] The nonce value sent during authentication.
+      # @param max_age [integer] The max_age value sent during authentication.
+      #   Must be a non-negative value.
+      # @param issuer [string] The expected issuer claim value.
+      #   Defaults to +https://YOUR_AUTH0_DOMAIN/+.
+      # @param audience [string] The expected audience claim value.
+      #   Defaults to your *Auth0 Client ID*.
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/ParameterLists
+      def validate_id_token(id_token, algorithm: nil, leeway: 60, nonce: nil, max_age: nil, issuer: nil, audience: nil)
+        raise Auth0::InvalidParameter, 'Must supply a valid leeway' unless leeway.is_a?(Integer) && leeway >= 0
+        raise Auth0::InvalidParameter, 'Must supply a valid nonce' unless nonce.nil? || !nonce.to_s.empty?
+        raise Auth0::InvalidParameter, 'Must supply a valid issuer' unless issuer.nil? || !issuer.to_s.empty?
+        raise Auth0::InvalidParameter, 'Must supply a valid audience' unless audience.nil? || !audience.to_s.empty?
+
+        unless max_age.nil? || (max_age.is_a?(Integer) && max_age >= 0)
+          raise Auth0::InvalidParameter, 'Must supply a valid max_age'
+        end
+
+        context = {
+          issuer: issuer || "https://#{@domain}/",
+          audience: audience || @client_id,
+          algorithm: algorithm || Auth0::Algorithm::RS256.jwks_url("https://#{@domain}/.well-known/jwks.json"),
+          leeway: leeway
+        }
+
+        context[:nonce] = nonce unless nonce.nil?
+        context[:max_age] = max_age unless max_age.nil?
+
+        Auth0::Mixins::Validation::IdTokenValidator.new(context).validate(id_token)
+      end
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/ParameterLists
 
       private
 

--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -522,15 +522,6 @@ module Auth0
       #   Defaults to your *Auth0 Client ID*.
       # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/ParameterLists
       def validate_id_token(id_token, algorithm: nil, leeway: 60, nonce: nil, max_age: nil, issuer: nil, audience: nil)
-        raise Auth0::InvalidParameter, 'Must supply a valid leeway' unless leeway.is_a?(Integer) && leeway >= 0
-        raise Auth0::InvalidParameter, 'Must supply a valid nonce' unless nonce.nil? || !nonce.to_s.empty?
-        raise Auth0::InvalidParameter, 'Must supply a valid issuer' unless issuer.nil? || !issuer.to_s.empty?
-        raise Auth0::InvalidParameter, 'Must supply a valid audience' unless audience.nil? || !audience.to_s.empty?
-
-        unless max_age.nil? || (max_age.is_a?(Integer) && max_age >= 0)
-          raise Auth0::InvalidParameter, 'Must supply a valid max_age'
-        end
-
         context = {
           issuer: issuer || "https://#{@domain}/",
           audience: audience || @client_id,

--- a/lib/auth0/exception.rb
+++ b/lib/auth0/exception.rb
@@ -59,4 +59,6 @@ module Auth0
       Time.at(headers['X-RateLimit-Reset']).utc
     end
   end
+
+  class InvalidIdToken < Auth0::Exception; end
 end

--- a/lib/auth0/mixins/validation.rb
+++ b/lib/auth0/mixins/validation.rb
@@ -1,3 +1,11 @@
+require 'zache'
+
+class Zache
+  def last(key)
+    @hash[key][:value] if @hash.key?(key)
+  end
+end
+
 module Auth0
   module Mixins
     # Module to provide validation for specific data structures.
@@ -20,6 +28,187 @@ module Auth0
         permissions.map { |permission| permission.to_h }
       end
 
+      class IdTokenValidator
+        def initialize(context)
+          @context = context
+        end
+
+        def validate(id_token)
+          decoding_error = 'ID token could not be decoded'
+
+          unless !id_token.to_s.empty? && id_token.split('.').count == 3
+            raise Auth0::InvalidIdToken, decoding_error
+          end
+
+          begin
+            header = JWT::JSON.parse(JWT::Base64.url_decode(id_token.split('.').first))
+          rescue
+            raise Auth0::InvalidIdToken, decoding_error
+          end
+
+          claims = decode_and_validate_signature(id_token, header)
+          validate_claims(claims)
+        end
+
+        private
+
+        # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
+        def decode_and_validate_signature(id_token, header)
+          algorithm = @context[:algorithm]
+
+          unless algorithm.is_a?(Auth0::Mixins::Validation::JWTAlgorithm)
+            raise Auth0::InvalidIdToken, "Signature algorithm of \"#{algorithm}\" is not supported"
+          end
+
+          # The expiration verification will be performed in the validate_claims method
+          options = { algorithms: [algorithm.name], verify_expiration: false, verify_not_before: false }
+          secret = nil
+
+          case algorithm
+          when Auth0::Algorithm::RS256
+            kid = header['kid']
+            jwks = JSON.parse(JSON[algorithm.jwks], symbolize_names: true)
+
+            if !jwks[:keys].find { |key| key[:kid] == kid } && !algorithm.fetched_jwks?
+              jwks = JSON.parse(JSON[algorithm.jwks(force: true)], symbolize_names: true)
+            end
+
+            options[:jwks] = jwks
+          when Auth0::Algorithm::HS256
+            secret = algorithm.secret
+          end
+
+          begin
+            result = JWT.decode(id_token, secret, true, options)
+            result.first
+          rescue JWT::VerificationError
+            raise Auth0::InvalidIdToken, 'Invalid ID token signature'
+          rescue JWT::IncorrectAlgorithm
+            alg = header['alg']
+            raise Auth0::InvalidIdToken, "Signature algorithm of \"#{alg}\" is not supported. Expected the ID token to be signed with \"#{algorithm.name}\""
+          rescue JWT::DecodeError
+            raise Auth0::InvalidIdToken, "Could not find a public key for Key ID (kid) \"#{kid}\""
+          end
+        end
+        # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Metrics/CyclomaticComplexity
+
+        def validate_claims(decoded_id_token); end # TODO: Implement (in the next PR)
+      end
+
+      class JWTAlgorithm
+        private_class_method :new
+
+        def name
+          raise RuntimeError, 'Must be overriden by the subclasses'
+        end
+      end
+
+      module Algorithm
+        # Represents the HS256 algorithm, which rely on shared secrets.
+        # @see https://auth0.com/docs/tokens/concepts/signing-algorithms
+        class HS256 < JWTAlgorithm
+          class << self
+            private :new
+
+            # Create a new instance passing the shared secret.
+            # @param secret [string] The HMAC shared secret.
+            # @return [HS256] A new instance.
+            def secret(secret)
+              new secret
+            end
+          end
+
+          attr_accessor :secret
+
+          def initialize(secret)
+            raise Auth0::InvalidParameter, 'Must supply a valid secret' if secret.to_s.empty?
+
+            @secret = secret
+          end
+
+          # Returns the algorithm name.
+          # @return [string] The algorithm name.
+          def name
+            'HS256'
+          end
+        end
+
+        # Represents the RS256 algorithm, which rely on public key certificates.
+        # @see https://auth0.com/docs/tokens/concepts/signing-algorithms
+        class RS256 < JWTAlgorithm
+          include Auth0::Mixins::HTTPProxy
+
+          @@cache = Zache.new.freeze
+
+          class << self
+            private :new
+
+            # Create a new instance passing the JWK set url.
+            # @param url [string] The url where the JWK set is located.
+            # @param lifetime [integer] The lifetime of the JWK set in-memory cache in seconds.
+            #   Must be a non-negative value. Defaults to *600 seconds* (10 minutes).
+            # @return [RS256] A new instance.
+            def jwks_url(url, lifetime: 10 * 60)
+              new url, lifetime
+            end
+
+            # Clear the JWK set cache.
+            def remove_jwks
+              @@cache.remove(:jwks)
+            end
+          end
+
+          def initialize(jwks_url, lifetime)
+            raise Auth0::InvalidParameter, 'Must supply a valid jwks_url' if jwks_url.to_s.empty?
+            raise Auth0::InvalidParameter, 'Must supply a valid lifetime' unless lifetime.is_a?(Integer) && lifetime >= 0
+
+            @lifetime = lifetime
+            @jwks_url = jwks_url
+            @did_fetch_jwks = false
+          end
+
+          # Returns the algorithm name.
+          # @return [string] The algorithm name.
+          def name
+            'RS256'
+          end
+
+          # Fetches the JWK set from the in-memory cache or from the url.
+          # @return [hash] A JWK set.
+          def jwks(force: false)
+            result = fetch_jwks if force
+
+            if result
+              @@cache.put(:jwks, result, lifetime: @lifetime)
+              return result
+            end
+
+            previous_value = @@cache.last(:jwks)
+
+            @@cache.get(:jwks, lifetime: @lifetime, dirty: true) do
+              new_value = fetch_jwks
+
+              raise Auth0::InvalidIdToken, 'Could not fetch the JWK set' unless new_value || previous_value
+
+              new_value || previous_value
+            end
+          end
+
+          # Returns whether or not the JWK set was fetched from the url.
+          # @return [boolean] +true+ if a request to the JWK set url was made, +false+ otherwise.
+          def fetched_jwks?
+            @did_fetch_jwks
+          end
+
+          private
+
+          def fetch_jwks
+            result = get(@jwks_url)
+            @did_fetch_jwks = result.is_a?(Hash) && result.key?('keys')
+            result if @did_fetch_jwks
+          end
+        end
+      end
     end
   end
 end

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -678,55 +678,25 @@ describe Auth0::Api::AuthenticationEndpoints do
   context '.validate_id_token' do
     it { expect(@instance).to respond_to(:validate_id_token) }
 
-    it 'is expected to raise an error with a non-integer leeway' do
-      expect { @instance.validate_id_token('id token', leeway: '1') }.to raise_exception('Must supply a valid leeway')
+    it 'is expected not to raise an error with default values' do
+      stub_request(:get, 'https://test.auth0.com/.well-known/jwks.json').to_return(body: JWKS_RESPONSE_1.to_json)
+      token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5LTEifQ.eyJpc3MiOiJodHRwczovL3Rlc3QuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDEyMzQ1Njc4OSIsImF1ZCI6WyJfX3Rlc3RfYXVkaWVuY2VfXyIsIl9fdGVzdF9jbGllbnRfaWRfXyJdLCJleHAiOjI1MzgzMDExNDYsImlhdCI6MTU4NzU5MjU2MSwiYXpwIjoiX190ZXN0X2NsaWVudF9pZF9fIn0.X35Hfa1C9RtuJIj7Eky2iO4elY9XqCDRy8ieFAft63vGds9vhP38x8QHbJifmLs6vDEOySKfJMWhklp3oaXm6Tk6gyUQEaliW_pXUgZt8C3Xo125R8BMCDQeVJg8Abevbg6FpHpYztWpQuI609tmpoTczx7pXMmAneg6e4LNYvvtzaFD_0M0cxtjkm4OcevCJszNBru3tdXwRynkGbMYeXgoa_FumAshRvIvh-4dtkyNWsepo5IVTvixxF3FVoFaXOOycmFXh9gxOppG4lvE78AFB9AQ9LNS-DNhcXszbPs9KHMrg2bqhSL8Razqd3m2a1MXkdLMBD5DY499MVnb5w'
+
+      expect { @instance.validate_id_token(token) }.to_not raise_exception
     end
 
-    it 'is expected to raise an error with a negative leeway' do
-      expect { @instance.validate_id_token('id token', leeway: -1) }.to raise_exception('Must supply a valid leeway')
-    end
+    it 'is expected not to raise an error with custom values' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJpc3N1ZXIiLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsiYXVkaWVuY2UiLCJhbm90aGVyX2F1ZGllbmNlIl0sImV4cCI6MjUzODMwMTE0NiwiaWF0IjoxNTg3NTkyNTYxLCJub25jZSI6Im5vbmNlIiwiYXpwIjoiYXVkaWVuY2UiLCJhdXRoX3RpbWUiOjE1ODc2Nzg5NjF9.u39qTvuUmbzj5jsXjATXxjxJt0u064G1IAumoi18gm0'
 
-    it 'is expected to raise an error with an empty nonce' do
-      expect { @instance.validate_id_token('id token', nonce: '') }.to raise_exception('Must supply a valid nonce')
-    end
-
-    it 'is expected to raise an error with an empty issuer' do
-      expect { @instance.validate_id_token('id token', issuer: '') }.to raise_exception('Must supply a valid issuer')
-    end
-
-    it 'is expected to raise an error with an empty audience' do
-      expect { @instance.validate_id_token('id token', audience: '') }.to raise_exception('Must supply a valid audience')
-    end
-
-    it 'is expected to raise an error with a non-integer max_age' do
-      expect { @instance.validate_id_token('id token', max_age: '1') }.to raise_exception('Must supply a valid max_age')
-    end
-
-    it 'is expected to raise an error with a negative max_age' do
-      expect { @instance.validate_id_token('id token', max_age: -1) }.to raise_exception('Must supply a valid max_age')
-    end
-
-    it 'is expected not to raise an error with a valid token signed with HS256' do
-      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.Hn38QVtN_mWN0c-jOa-Fqq69kXpbBp0THsvE-CQ47Ps'
-
-      expect { @instance.validate_id_token(token, algorithm: Auth0::Algorithm::HS256.secret('secret')) }.to_not raise_exception
-    end
-
-    it 'is expected not to raise an error with a valid token signed with RS256' do
-      stub_jwks
-      token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5LTEifQ.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.jE00ARUiAwrKEoAMwbioKYj4bUZjmg31V7McDtIPsJJ16rYcvI-e5mtSSMgCmAom6t-WA7dsSWCJUlBCW2nAMvyCZ-hj8HG9Z0RmQEiwig9Fk22avoX94zdx65TwAeDfn2uMRaX_ps3TJcn4nymUtMp8Lps_vMw15eJerKThlSO4KuLTrvDDdRaCRamAd7jxuzhiwOt0mB0TVD55b5itA02pGuyapbjQXvvLYEx8OgpyIaAkB9Ry25abgjev0bSw2kjFZckG3lv9QgvZM85m9l3Rbrc6msNPGfMDFWGyT3Tu2ObqnSEA-57hZeuCbFrOya3vUwgSlc66rfvZj2xpzg'
-
-      expect { @instance.validate_id_token(token, algorithm: Auth0::Algorithm::RS256.jwks_url(JWKS_URL)) }.to_not raise_exception
       expect do
         @instance.validate_id_token(token,
-                                    algorithm: Auth0::Algorithm::RS256.jwks_url(JWKS_URL),
-                                    leeway: 10,
+                                    algorithm: Auth0::Algorithm::HS256.secret('secret'),
+                                    leeway: 100,
                                     nonce: 'nonce',
+                                    max_age: 2538301146,
                                     issuer: 'issuer',
-                                    audience: 'audience',
-                                    max_age: 10)
-      end .to_not raise_exception
-      expect(a_request(:get, JWKS_URL)).to have_been_made.once
+                                    audience: 'audience')
+      end.to_not raise_exception
     end
   end
 end

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Metrics/BlockLength
 require 'spec_helper'
 describe Auth0::Api::AuthenticationEndpoints do
@@ -20,7 +22,7 @@ describe Auth0::Api::AuthenticationEndpoints do
         grant_type: 'client_credentials',
         client_id: @instance.client_id,
         client_secret: @instance.client_secret,
-        audience: @instance.audience,
+        audience: @instance.audience
       ).and_return('access_token' => 'AccessToken')
 
       expect(@instance.api_token.token).to eql 'AccessToken'
@@ -32,7 +34,7 @@ describe Auth0::Api::AuthenticationEndpoints do
         grant_type: 'client_credentials',
         client_id: @instance.client_id,
         client_secret: @instance.client_secret,
-        audience: '__test_audience__',
+        audience: '__test_audience__'
       ).and_return('access_token' => 'AccessToken')
 
       expect(
@@ -47,7 +49,7 @@ describe Auth0::Api::AuthenticationEndpoints do
       allow(@instance).to receive(:post).with(
         '/oauth/token', client_id: @instance.client_id, client_secret: @instance.client_secret, grant_type: 'client_credentials'
       )
-                            .and_return('access_token' => 'AccessToken')
+                                        .and_return('access_token' => 'AccessToken')
 
       expect(@instance).to receive(:post).with(
         '/oauth/token', client_id: @instance.client_id, client_secret: @instance.client_secret, grant_type: 'client_credentials'
@@ -89,7 +91,6 @@ describe Auth0::Api::AuthenticationEndpoints do
     it { expect { @instance.obtain_user_tokens('', '') }.to raise_error 'Must supply a valid code' }
     it { expect { @instance.obtain_user_tokens('code', '') }.to raise_error 'Must supply a valid redirect_uri' }
   end
-
 
   context '.exchange_auth_code_for_tokens' do
     it { is_expected.to respond_to(:exchange_auth_code_for_tokens) }
@@ -183,7 +184,6 @@ describe Auth0::Api::AuthenticationEndpoints do
       ).to eq 'AccessToken'
     end
 
-
     it 'is expected to make post request to /oauth/token with custom params' do
       allow(@instance).to receive(:post).with(
         '/oauth/token',
@@ -241,7 +241,6 @@ describe Auth0::Api::AuthenticationEndpoints do
     end
 
     it 'should make post to /oauth/token with custom params' do
-
       allow(@instance).to receive(:post).with(
         '/oauth/token',
         username: 'test@test.com',
@@ -356,7 +355,7 @@ describe Auth0::Api::AuthenticationEndpoints do
         '/passwordless/start',
         client_id: @instance.client_id,
         client_secret: @instance.client_secret,
-        connection:  'email',
+        connection: 'email',
         email: 'test@test.com',
         send: 'code',
         authParams: {
@@ -552,7 +551,7 @@ describe Auth0::Api::AuthenticationEndpoints do
   context '.userinfo' do
     it { is_expected.to respond_to(:user_info) }
     it 'is expected to make a GET request to /userinfo' do
-      is_expected.to receive(:get).with('/userinfo', {}, {'Authorization' => 'Bearer access-token'})
+      is_expected.to receive(:get).with('/userinfo', {}, { 'Authorization' => 'Bearer access-token' })
       subject.userinfo 'access-token'
     end
   end
@@ -605,7 +604,7 @@ describe Auth0::Api::AuthenticationEndpoints do
 
     it 'is expected to return a logout url with a client ID' do
       expect(@instance.logout_url(return_to, include_client: true).to_s).to eq(
-        "https://#{@instance.domain}/v2/logout" +
+        "https://#{@instance.domain}/v2/logout" \
           "?returnTo=http%3A%2F%2Freturnto.com&client_id=#{@instance.client_id}"
       )
     end
@@ -655,7 +654,7 @@ describe Auth0::Api::AuthenticationEndpoints do
     end
 
     it 'is expected to get the wsfed url with wctx' do
-      expect(@instance.wsfed_url(UP_AUTH, {wctx: 'wctx_test'}).to_s).to eq(
+      expect(@instance.wsfed_url(UP_AUTH, { wctx: 'wctx_test' }).to_s).to eq(
         "https://#{@instance.domain}/wsfed/#{@instance.client_id}" \
           "?whr=#{UP_AUTH}&wctx=wctx_test"
       )
@@ -672,6 +671,62 @@ describe Auth0::Api::AuthenticationEndpoints do
         "https://#{@instance.domain}/wsfed/?whr=#{UP_AUTH}" \
           '&wtrealm=wtrealm_test&wreply=wreply_test'
       )
+    end
+  end
+
+  # Auth0::API::AuthenticationEndpoints.validate_id_token
+  context '.validate_id_token' do
+    it { expect(@instance).to respond_to(:validate_id_token) }
+
+    it 'is expected to raise an error with a non-integer leeway' do
+      expect { @instance.validate_id_token('id token', leeway: '1') }.to raise_exception('Must supply a valid leeway')
+    end
+
+    it 'is expected to raise an error with a negative leeway' do
+      expect { @instance.validate_id_token('id token', leeway: -1) }.to raise_exception('Must supply a valid leeway')
+    end
+
+    it 'is expected to raise an error with an empty nonce' do
+      expect { @instance.validate_id_token('id token', nonce: '') }.to raise_exception('Must supply a valid nonce')
+    end
+
+    it 'is expected to raise an error with an empty issuer' do
+      expect { @instance.validate_id_token('id token', issuer: '') }.to raise_exception('Must supply a valid issuer')
+    end
+
+    it 'is expected to raise an error with an empty audience' do
+      expect { @instance.validate_id_token('id token', audience: '') }.to raise_exception('Must supply a valid audience')
+    end
+
+    it 'is expected to raise an error with a non-integer max_age' do
+      expect { @instance.validate_id_token('id token', max_age: '1') }.to raise_exception('Must supply a valid max_age')
+    end
+
+    it 'is expected to raise an error with a negative max_age' do
+      expect { @instance.validate_id_token('id token', max_age: -1) }.to raise_exception('Must supply a valid max_age')
+    end
+
+    it 'is expected not to raise an error with a valid token signed with HS256' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.Hn38QVtN_mWN0c-jOa-Fqq69kXpbBp0THsvE-CQ47Ps'
+
+      expect { @instance.validate_id_token(token, algorithm: Auth0::Algorithm::HS256.secret('secret')) }.to_not raise_exception
+    end
+
+    it 'is expected not to raise an error with a valid token signed with RS256' do
+      stub_jwks
+      token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5LTEifQ.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.jE00ARUiAwrKEoAMwbioKYj4bUZjmg31V7McDtIPsJJ16rYcvI-e5mtSSMgCmAom6t-WA7dsSWCJUlBCW2nAMvyCZ-hj8HG9Z0RmQEiwig9Fk22avoX94zdx65TwAeDfn2uMRaX_ps3TJcn4nymUtMp8Lps_vMw15eJerKThlSO4KuLTrvDDdRaCRamAd7jxuzhiwOt0mB0TVD55b5itA02pGuyapbjQXvvLYEx8OgpyIaAkB9Ry25abgjev0bSw2kjFZckG3lv9QgvZM85m9l3Rbrc6msNPGfMDFWGyT3Tu2ObqnSEA-57hZeuCbFrOya3vUwgSlc66rfvZj2xpzg'
+
+      expect { @instance.validate_id_token(token, algorithm: Auth0::Algorithm::RS256.jwks_url(JWKS_URL)) }.to_not raise_exception
+      expect do
+        @instance.validate_id_token(token,
+                                    algorithm: Auth0::Algorithm::RS256.jwks_url(JWKS_URL),
+                                    leeway: 10,
+                                    nonce: 'nonce',
+                                    issuer: 'issuer',
+                                    audience: 'audience',
+                                    max_age: 10)
+      end .to_not raise_exception
+      expect(a_request(:get, JWKS_URL)).to have_been_made.once
     end
   end
 end

--- a/spec/lib/auth0/mixins/validation_spec.rb
+++ b/spec/lib/auth0/mixins/validation_spec.rb
@@ -1,0 +1,308 @@
+# rubocop:disable Metrics/BlockLength
+require 'spec_helper'
+
+RSA_PUB_KEY_JWK_1 = { 'kty': "RSA", 'use': 'sig', 'n': "uGbXWiK3dQTyCbX5xdE4yCuYp0AF2d15Qq1JSXT_lx8CEcXb9RbDddl8jGDv-spi5qPa8qEHiK7FwV2KpRE983wGPnYsAm9BxLFb4YrLYcDFOIGULuk2FtrPS512Qea1bXASuvYXEpQNpGbnTGVsWXI9C-yjHztqyL2h8P6mlThPY9E9ue2fCqdgixfTFIF9Dm4SLHbphUS2iw7w1JgT69s7of9-I9l5lsJ9cozf1rxrXX4V1u_SotUuNB3Fp8oB4C1fLBEhSlMcUJirz1E8AziMCxS-VrRPDM-zfvpIJg3JljAh3PJHDiLu902v9w-Iplu1WyoB2aPfitxEhRN0Yw", 'e': 'AQAB', 'kid': 'test-key-1' }.freeze
+RSA_PUB_KEY_JWK_2 = { 'kty': "RSA", 'use': 'sig', 'n': "uGbXWiK3dQTyCbX5xdE4yCuYp0AF2d15Qq1JSXT_lx8CEcXb9RbDddl8jGDv-spi5qPa8qEHiK7FwV2KpRE983wGPnYsAm9BxLFb4YrLYcDFOIGULuk2FtrPS512Qea1bXASuvYXEpQNpGbnTGVsWXI9C-yjHztqyL2h8P6mlThPY9E9ue2fCqdgixfTFIF9Dm4SLHbphUS2iw7w1JgT69s7of9-I9l5lsJ9cozf1rxrXX4V1u_SotUuNB3Fp8oB4C1fLBEhSlMcUJirz1E8AziMCxS-VrRPDM-zfvpIJg3JljAh3PJHDiLu902v9w-Iplu1WyoB2aPfitxEhRN0Yw", 'e': 'AQAB', 'kid': 'test-key-2' }.freeze
+JWKS_RESPONSE_1 = { 'keys': [RSA_PUB_KEY_JWK_1] }.freeze
+JWKS_RESPONSE_2 = { 'keys': [RSA_PUB_KEY_JWK_2] }.freeze
+JWKS_URL = 'https://tokens-test.auth0.com/.well-known/jwks.json'.freeze
+HMAC_SHARED_SECRET = 'secret'.freeze
+
+MOCKED_CLOCK = 1587592561 # Apr 22 2020 21:56:01 UTC
+DEFAULT_LEEWAY = 60
+
+describe Auth0::Mixins::Validation::IdTokenValidator do
+  subject { @instance }
+
+  context 'instance' do
+    it 'is expected respond to :validate' do
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new({})
+
+      expect(instance).to respond_to(:validate)
+    end
+  end
+
+  context 'ID token decoding' do
+    expected_error = 'ID token could not be decoded'
+    instance = Auth0::Mixins::Validation::IdTokenValidator.new({})
+
+    it 'is expected to raise an error with a nil id_token' do
+      expect { instance.validate(nil) }.to raise_exception(expected_error)
+    end
+
+    it 'is expected to raise an error with an empty id_token' do
+      expect { instance.validate('') }.to raise_exception(expected_error)
+    end
+
+    it 'is expected to raise an error with an invalid format' do
+      expect { instance.validate('a.b') }.to raise_exception(expected_error)
+      expect { instance.validate('a.b.') }.to raise_exception(expected_error)
+      expect { instance.validate('a.b.c.d') }.to raise_exception(expected_error)
+    end
+
+    it 'is expected to raise an error with an invalid encoding' do
+      expect { instance.validate('a.b.c') }.to raise_exception(expected_error)
+    end
+  end
+
+  context 'algorithm verification' do
+    token = 'eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.Hn38QVtN_mWN0c-jOa-Fqq69kXpbBp0THsvE-CQ47Ps'
+
+    it 'is expected to raise an error with an unsupported algorithm' do
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new({ algorithm: 'ES256' })
+
+      expect { instance.validate(token) }.to raise_exception('Signature algorithm of "ES256" is not supported')
+    end
+
+    it 'is expected to raise an error when the algorithm does not match the alg header value' do
+      algorithm = Auth0::Algorithm::HS256.secret(HMAC_SHARED_SECRET)
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new({ algorithm: algorithm })
+
+      expect { instance.validate(token) }.to raise_exception('Signature algorithm of "ES256" is not supported. Expected the ID token to be signed with "HS256"')
+    end
+  end
+
+  context 'HS256 signature verification' do
+    before :each do
+      algorithm = Auth0::Algorithm::HS256.secret(HMAC_SHARED_SECRET)
+      @instance = Auth0::Mixins::Validation::IdTokenValidator.new({ algorithm: algorithm })
+    end
+
+    it 'is expected not to raise an error with a valid signature' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.Hn38QVtN_mWN0c-jOa-Fqq69kXpbBp0THsvE-CQ47Ps'
+
+      expect { @instance.validate(token) }.not_to raise_exception
+    end
+
+    it 'is expected to raise an error with an invalid signature' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.invalidsignature'
+
+      expect { @instance.validate(token) }.to raise_exception('Invalid ID token signature')
+    end
+  end
+
+  context 'RS256 signature verification' do
+    before :each do
+      stub_jwks
+      algorithm = Auth0::Algorithm::RS256.jwks_url(JWKS_URL)
+      @instance = Auth0::Mixins::Validation::IdTokenValidator.new({ algorithm: algorithm })
+    end
+
+    after :each do
+      Auth0::Algorithm::RS256.remove_jwks
+      WebMock.reset!
+    end
+
+    it 'is expected not to raise an error with a valid signature' do
+      token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5LTEifQ.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.jE00ARUiAwrKEoAMwbioKYj4bUZjmg31V7McDtIPsJJ16rYcvI-e5mtSSMgCmAom6t-WA7dsSWCJUlBCW2nAMvyCZ-hj8HG9Z0RmQEiwig9Fk22avoX94zdx65TwAeDfn2uMRaX_ps3TJcn4nymUtMp8Lps_vMw15eJerKThlSO4KuLTrvDDdRaCRamAd7jxuzhiwOt0mB0TVD55b5itA02pGuyapbjQXvvLYEx8OgpyIaAkB9Ry25abgjev0bSw2kjFZckG3lv9QgvZM85m9l3Rbrc6msNPGfMDFWGyT3Tu2ObqnSEA-57hZeuCbFrOya3vUwgSlc66rfvZj2xpzg'
+
+      expect { @instance.validate(token) }.not_to raise_exception
+    end
+
+    it 'is expected to raise an error with an invalid signature' do
+      token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5LTEifQ.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.invalidsignature'
+
+      expect { @instance.validate(token) }.to raise_exception('Invalid ID token signature')
+    end
+
+    it 'is expected to raise an error when the public key cannot be found' do
+      token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5LTIifQ.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.r2ksgiiM8zGJ6byea_Fq_zWWEmUdOnwQLVdb5JzgdBv1GUQFp-4LNaRhcga4FIrbKgxaPeewGLTq2VqfjmNJUNfARcE3QEacQ_JEHkC6zKZIiqcu4msHl8X9HXyHxOPHMTTjYMjauPzET7UH_oLxF68DDDQqvKX9VqLsncpyC-KdTCFTLGlFSq6pxmYt6gwrF2Uo15Gzc6qe2I9-MTXCYd44VW1zQi6GhNJNKbXH6U3bf7nof0ot1PSjBXXuLgf6d3qumTStECCjIUmdBb6FiEX4SSRI4MgHWj4q0LyN28baRpYwYPhVnjzUxOP7OLjKiHs45ORBhuAWhrJnuR_uBQ'
+
+      expect { @instance.validate(token) }.to raise_exception('Could not find a public key for Key ID (kid) "test-key-2"')
+    end
+
+    it 'is expected to fetch the JWK set from the url if the public key cannot be found and the cache is not empty' do
+      token = 'eyJhbGciOiJSUzI1NiIsImtpZCI6InRlc3Qta2V5LTIifQ.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.r2ksgiiM8zGJ6byea_Fq_zWWEmUdOnwQLVdb5JzgdBv1GUQFp-4LNaRhcga4FIrbKgxaPeewGLTq2VqfjmNJUNfARcE3QEacQ_JEHkC6zKZIiqcu4msHl8X9HXyHxOPHMTTjYMjauPzET7UH_oLxF68DDDQqvKX9VqLsncpyC-KdTCFTLGlFSq6pxmYt6gwrF2Uo15Gzc6qe2I9-MTXCYd44VW1zQi6GhNJNKbXH6U3bf7nof0ot1PSjBXXuLgf6d3qumTStECCjIUmdBb6FiEX4SSRI4MgHWj4q0LyN28baRpYwYPhVnjzUxOP7OLjKiHs45ORBhuAWhrJnuR_uBQ'
+      Auth0::Algorithm::RS256.jwks_url(JWKS_URL).jwks
+      stub_jwks(JWKS_RESPONSE_2)
+      @instance.validate(token)
+
+      expect(a_request(:get, JWKS_URL)).to have_been_made.twice
+    end
+  end
+end
+
+describe Auth0::Algorithm::HS256 do
+  context 'class' do
+    it 'is expected to respond to :secret' do
+      expect(Auth0::Algorithm::HS256).to respond_to(:secret)
+    end
+
+    it 'is expected not to respond to :new' do
+      expect(Auth0::Algorithm::HS256).not_to respond_to(:new)
+    end
+  end
+
+  context 'instance' do
+    it 'is expected to respond to :secret' do
+      instance = Auth0::Algorithm::HS256.secret('secret')
+
+      expect(instance).to respond_to(:secret)
+    end
+
+    it 'is expected to return the secret' do
+      instance = Auth0::Algorithm::HS256.secret('secret')
+
+      expect(instance.secret).to eq('secret')
+    end
+
+    it 'is expected to return the algorithm name' do
+      instance = Auth0::Algorithm::HS256.secret('secret')
+
+      expect(instance.name).to eq('HS256')
+    end
+  end
+
+  context 'parameters' do
+    expected_error = 'Must supply a valid secret'
+
+    it 'is expected to raise an error with a nil secret' do
+      expect { Auth0::Algorithm::HS256.secret(nil) }.to raise_exception(expected_error)
+    end
+
+    it 'is expected to raise an error with an empty secret' do
+      expect { Auth0::Algorithm::HS256.secret('') }.to raise_exception(expected_error)
+    end
+  end
+end
+
+describe Auth0::Algorithm::RS256 do
+  before :each do
+    stub_jwks
+  end
+
+  after :each do
+    Auth0::Algorithm::RS256.remove_jwks
+    WebMock.reset!
+  end
+
+  context 'class' do
+    it 'is expected to respond to :jwks_url' do
+      expect(Auth0::Algorithm::RS256).to respond_to(:jwks_url)
+    end
+
+    it 'is expected not to respond to :new' do
+      expect(Auth0::Algorithm::RS256).not_to respond_to(:new)
+    end
+  end
+
+  context 'instance' do
+    it 'is expected to respond to :jwks' do
+      instance = Auth0::Algorithm::RS256.jwks_url('jwks url')
+
+      expect(instance).to respond_to(:jwks)
+    end
+
+    it 'is expected to respond to :fetched_jwks?' do
+      instance = Auth0::Algorithm::RS256.jwks_url('jwks url')
+
+      expect(instance).to respond_to(:fetched_jwks?)
+    end
+
+    it 'is expected to return a jwks' do
+      instance = Auth0::Algorithm::RS256.jwks_url(JWKS_URL)
+
+      expect(instance.jwks).to have_key('keys') and contain_exactly(a_hash_including(kid: 'test-key-1'))
+    end
+
+    it 'is expected to return if the jwks was fetched from the url' do
+      instance = Auth0::Algorithm::RS256.jwks_url(JWKS_URL)
+      instance.jwks
+
+      expect(instance.fetched_jwks?).to eq(true)
+    end
+
+    it 'is expected to return if the jwks was fetched from the cache' do
+      Auth0::Algorithm::RS256.jwks_url(JWKS_URL).jwks
+      instance = Auth0::Algorithm::RS256.jwks_url(JWKS_URL)
+      instance.jwks
+
+      expect(instance.fetched_jwks?).to eq(false)
+    end
+
+    it 'is expected to return the algorithm name' do
+      instance = Auth0::Algorithm::RS256.jwks_url('jwks url')
+
+      expect(instance.name).to eq('RS256')
+    end
+  end
+
+  context 'parameters' do
+    it 'is expected to raise an error with a nil jwks_url' do
+      expect { Auth0::Algorithm::RS256.jwks_url(nil) }.to raise_exception('Must supply a valid jwks_url')
+    end
+
+    it 'is expected to raise an error with an empty jwks_url' do
+      expect { Auth0::Algorithm::RS256.jwks_url('') }.to raise_exception('Must supply a valid jwks_url')
+    end
+
+    it 'is expected to raise an error with a non-integer lifetime' do
+      expect { Auth0::Algorithm::RS256.jwks_url('jwks url', lifetime: '1') }.to raise_exception('Must supply a valid lifetime')
+    end
+
+    it 'is expected to raise an error with a negative lifetime' do
+      expect { Auth0::Algorithm::RS256.jwks_url('jwks url', lifetime: -1) }.to raise_exception('Must supply a valid lifetime')
+    end
+  end
+
+  context 'cache' do
+    it 'is expected to fetch the jwks from the url when the cache is empty' do
+      instance = Auth0::Algorithm::RS256.jwks_url(JWKS_URL)
+      instance.jwks
+
+      expect(a_request(:get, JWKS_URL)).to have_been_made.once
+    end
+
+    it 'is expected to fetch the jwks from the url when the cache is expired' do
+      instance = Auth0::Algorithm::RS256.jwks_url(JWKS_URL, lifetime: 0)
+      instance.jwks
+      instance.jwks
+
+      expect(a_request(:get, JWKS_URL)).to have_been_made.twice
+    end
+
+    it 'is not expected to fetch the jwks from the url when there is a value cached' do
+      instance = Auth0::Algorithm::RS256.jwks_url(JWKS_URL)
+      instance.jwks
+      instance.jwks
+
+      expect(a_request(:get, JWKS_URL)).to have_been_made.once
+    end
+
+    it 'is expected to forcibly fetch the jwks from the url' do
+      instance = Auth0::Algorithm::RS256.jwks_url(JWKS_URL)
+      instance.jwks
+      instance.jwks(force: true)
+
+      expect(a_request(:get, JWKS_URL)).to have_been_made.twice
+    end
+
+    it 'is expected to forcibly fetch the jwks from the url and cache it' do
+      instance = Auth0::Algorithm::RS256.jwks_url(JWKS_URL)
+      instance.jwks(force: true)
+      instance.jwks
+
+      expect(a_request(:get, JWKS_URL)).to have_been_made.once
+    end
+
+    it 'is expected to return the last cached value if the jwks could not be fetched' do
+      Auth0::Algorithm::RS256.jwks_url(JWKS_URL).jwks
+      stub_request(:get, JWKS_URL).to_return(body: 'invalid')
+      instance = Auth0::Algorithm::RS256.jwks_url(JWKS_URL)
+
+      expect(instance.jwks).to have_key('keys') and contain_exactly(a_hash_including(kid: 'test-key-1'))
+    end
+
+    it 'is expected to raise an error if the jwks could not be fetched and the cache is empty' do
+      stub_request(:get, JWKS_URL).to_return(body: 'invalid')
+      instance = Auth0::Algorithm::RS256.jwks_url(JWKS_URL)
+
+      expect { instance.jwks }.to raise_exception('Could not fetch the JWK set')
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength
+
+def stub_jwks(stub = JWKS_RESPONSE_1)
+  stub_request(:get, JWKS_URL).to_return(body: stub.to_json)
+end

--- a/spec/lib/auth0/mixins/validation_spec.rb
+++ b/spec/lib/auth0/mixins/validation_spec.rb
@@ -8,8 +8,9 @@ JWKS_RESPONSE_2 = { 'keys': [RSA_PUB_KEY_JWK_2] }.freeze
 JWKS_URL = 'https://tokens-test.auth0.com/.well-known/jwks.json'.freeze
 HMAC_SHARED_SECRET = 'secret'.freeze
 
-MOCKED_CLOCK = 1587592561 # Apr 22 2020 21:56:01 UTC
-DEFAULT_LEEWAY = 60
+LEEWAY = 60
+CLOCK = 1587592561 # Apr 22 2020 21:56:01 UTC
+CONTEXT = { algorithm: Auth0::Algorithm::HS256.secret(HMAC_SHARED_SECRET), leeway: LEEWAY, audience: 'tokens-test-123', issuer: 'https://tokens-test.auth0.com/', clock: CLOCK }.freeze
 
 describe Auth0::Mixins::Validation::IdTokenValidator do
   subject { @instance }
@@ -65,7 +66,7 @@ describe Auth0::Mixins::Validation::IdTokenValidator do
   context 'HS256 signature verification' do
     before :each do
       algorithm = Auth0::Algorithm::HS256.secret(HMAC_SHARED_SECRET)
-      @instance = Auth0::Mixins::Validation::IdTokenValidator.new({ algorithm: algorithm })
+      @instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ algorithm: algorithm }))
     end
 
     it 'is expected not to raise an error with a valid signature' do
@@ -85,7 +86,7 @@ describe Auth0::Mixins::Validation::IdTokenValidator do
     before :each do
       stub_jwks
       algorithm = Auth0::Algorithm::RS256.jwks_url(JWKS_URL)
-      @instance = Auth0::Mixins::Validation::IdTokenValidator.new({ algorithm: algorithm })
+      @instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ algorithm: algorithm }))
     end
 
     after :each do
@@ -118,6 +119,171 @@ describe Auth0::Mixins::Validation::IdTokenValidator do
       @instance.validate(token)
 
       expect(a_request(:get, JWKS_URL)).to have_been_made.twice
+    end
+  end
+
+  context 'context validation' do
+    token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.Hn38QVtN_mWN0c-jOa-Fqq69kXpbBp0THsvE-CQ47Ps'
+
+    it 'is expected to raise an error with a non-integer leeway' do
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ leeway: '1' }))
+
+      expect { instance.validate(token) }.to raise_exception('Must supply a valid leeway')
+    end
+
+    it 'is expected to raise an error with a negative leeway' do
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ leeway: -1 }))
+
+      expect { instance.validate(token) }.to raise_exception('Must supply a valid leeway')
+    end
+
+    it 'is expected to raise an error with an empty nonce' do
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ nonce: '' }))
+
+      expect { instance.validate(token) }.to raise_exception('Must supply a valid nonce')
+    end
+
+    it 'is expected to raise an error with an empty issuer' do
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ issuer: '' }))
+
+      expect { instance.validate(token) }.to raise_exception('Must supply a valid issuer')
+    end
+
+    it 'is expected to raise an error with an empty audience' do
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ audience: '' }))
+
+      expect { instance.validate(token) }.to raise_exception('Must supply a valid audience')
+    end
+
+    it 'is expected to raise an error with a non-integer max_age' do
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ max_age: '1' }))
+
+      expect { instance.validate(token) }.to raise_exception('Must supply a valid max_age')
+    end
+
+    it 'is expected to raise an error with a negative max_age' do
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ max_age: -1 }))
+
+      expect { instance.validate(token) }.to raise_exception('Must supply a valid max_age')
+    end
+  end
+
+  context 'claims validation' do
+    before :all do
+      @instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT)
+    end
+
+    it 'is expected to raise an error with a missing iss' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.QL2B2tqJhlW9rc8HQ3PQKkjDufBeSvtRBtJmRPdQ5K8'
+
+      expect { @instance.validate(token) }.to raise_exception('Issuer (iss) claim must be a string present in the ID token')
+    end
+
+    it 'is expected to raise an error with a invalid iss' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzb21ldGhpbmctZWxzZSIsInN1YiI6ImF1dGgwfDEyMzQ1Njc4OSIsImF1ZCI6WyJ0b2tlbnMtdGVzdC0xMjMiLCJleHRlcm5hbC10ZXN0LTk5OSJdLCJleHAiOjE1ODc3NjUzNjEsImlhdCI6MTU4NzU5MjU2MSwibm9uY2UiOiJhMWIyYzNkNGU1IiwiYXpwIjoidG9rZW5zLXRlc3QtMTIzIiwiYXV0aF90aW1lIjoxNTg3Njc4OTYxfQ.AhMMouDlGMdxTYrY9Cn-p8svJ8ssKmsHeT6JNRVTh10'
+
+      expect { @instance.validate(token) }.to raise_exception("Issuer (iss) claim mismatch in the ID token; expected \"#{CONTEXT[:issuer]}\", found \"something-else\"")
+    end
+
+    it 'is expected to raise an error with a missing sub' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0._4sUXtAZYpGrO3QaYArXnk2JivCqixa7hgHhH3w4SlY'
+
+      expect { @instance.validate(token) }.to raise_exception('Subject (sub) claim must be a string present in the ID token')
+    end
+
+    it 'is expected to raise an error with a missing aud' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJleHAiOjE1ODc3NjUzNjEsImlhdCI6MTU4NzU5MjU2MSwibm9uY2UiOiJhMWIyYzNkNGU1IiwiYXpwIjoidG9rZW5zLXRlc3QtMTIzIiwiYXV0aF90aW1lIjoxNTg3Njc4OTYxfQ.TlwnBmGUKe0SElSYKxPqsG1mujkK2t1CwDJGGiWRdXA'
+
+      expect { @instance.validate(token) }.to raise_exception('Audience (aud) claim must be a string or array of strings present in the ID token')
+    end
+
+    it 'is expected to raise an error with an invalid string aud' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOiJleHRlcm5hbC10ZXN0LTk5OSIsImV4cCI6MTU4Nzc2NTM2MSwiaWF0IjoxNTg3NTkyNTYxLCJub25jZSI6ImExYjJjM2Q0ZTUiLCJhenAiOiJ0b2tlbnMtdGVzdC0xMjMiLCJhdXRoX3RpbWUiOjE1ODc2Nzg5NjF9.-Tf5CIi2bZ51UdgqxFWQNXpJJmK5GgsetcVoVrQwHIA'
+
+      expect { @instance.validate(token) }.to raise_exception("Audience (aud) claim mismatch in the ID token; expected \"#{CONTEXT[:audience]}\", found \"external-test-999\"")
+    end
+
+    it 'is expected to raise an error with an invalid array aud' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsiZXh0ZXJuYWwtdGVzdC05OTgiLCJleHRlcm5hbC10ZXN0LTk5OSJdLCJleHAiOjE1ODc3NjUzNjEsImlhdCI6MTU4NzU5MjU2MSwibm9uY2UiOiJhMWIyYzNkNGU1IiwiYXpwIjoidG9rZW5zLXRlc3QtMTIzIiwiYXV0aF90aW1lIjoxNTg3Njc4OTYxfQ.Q1GRVL5g3RLQqG5sEV_cc8WW_oiZzFIAfzRfBdxMW2s'
+
+      expect { @instance.validate(token) }.to raise_exception("Audience (aud) claim mismatch in the ID token; expected \"#{CONTEXT[:audience]}\" but was not one of \"external-test-998, external-test-999\"")
+    end
+
+    it 'is expected to raise an error with a missing exp' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiaWF0IjoxNTg3NTkyNTYxLCJub25jZSI6ImExYjJjM2Q0ZTUiLCJhenAiOiJ0b2tlbnMtdGVzdC0xMjMiLCJhdXRoX3RpbWUiOjE1ODc2Nzg5NjF9.aoLiQX3sHsf1bEbc0axbjJ9qV6hhomtEzJq-FT8OGF0'
+
+      expect { @instance.validate(token) }.to raise_exception('Expiration Time (exp) claim must be a number present in the ID token')
+    end
+
+    it 'is expected to raise an error with a invalid exp' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NTkyNTYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.A8Pc0vlCG5Ufez7VIoRqXTYpJehalTEgGX9cR2xJLkU'
+      clock = CLOCK + LEEWAY + 1
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ clock: clock }))
+
+      expect { instance.validate(token) }.to raise_exception("Expiration Time (exp) claim mismatch in the ID token; current time \"#{clock}\" is after expiration time \"1587592621\"")
+    end
+
+    it 'is expected to raise an error with a missing iat' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJub25jZSI6ImExYjJjM2Q0ZTUiLCJhenAiOiJ0b2tlbnMtdGVzdC0xMjMiLCJhdXRoX3RpbWUiOjE1ODc2Nzg5NjF9.Jea6UVJsAK7Hnb494f_WIQCIbaLTnnCvMenSY1Y2toc'
+
+      expect { @instance.validate(token) }.to raise_exception('Issued At (iat) claim must be a number present in the ID token')
+    end
+
+    it 'is expected to raise an error with a invalid iat' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc3NjUzNjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.1AeRLTaExbKnmsfNduUl3HArsau4RcNrnmYOJnkPWi0'
+      clock = CLOCK - LEEWAY - 1
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ clock: clock }))
+
+      expect { instance.validate(token) }.to raise_exception("Issued At (iat) claim mismatch in the ID token; current time \"#{clock}\" is before issued at time \"1587765301\"")
+    end
+
+    it 'is expected not to raise an error with a missing but not required nonce' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.-o5grnyODbBdRgzcrn7Sf9Hb6eOC0x_U2i3YjVgHN0U'
+
+      expect { @instance.validate(token) }.not_to raise_exception
+    end
+
+    it 'is expected to raise an error with a missing but required nonce' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.-o5grnyODbBdRgzcrn7Sf9Hb6eOC0x_U2i3YjVgHN0U'
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ nonce: 'a1b2c3d4e5' }))
+
+      expect { instance.validate(token) }.to raise_exception('Nonce (nonce) claim must be a string present in the ID token')
+    end
+
+    it 'is expected to raise an error with an invalid nonce' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiMDAwOTk5IiwiYXpwIjoidG9rZW5zLXRlc3QtMTIzIiwiYXV0aF90aW1lIjoxNTg3Njc4OTYxfQ.XqQPdFN4m5kmTUQQi_mAJu0LQOeUTS9lF2J_xWc_j-0'
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ nonce: 'a1b2c3d4e5' }))
+
+      expect { instance.validate(token) }.to raise_exception('Nonce (nonce) claim mismatch in the ID token; expected "a1b2c3d4e5", found "000999"')
+    end
+
+    it 'is expected to raise an error with a missing azp' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.LrgYkIbWrxMq6jvvkL1lxWL237ii1IBhtN2o_tDxFns'
+
+      expect { @instance.validate(token) }.to raise_exception('Authorized Party (azp) claim must be a string present in the ID token')
+    end
+
+    it 'is expected to raise an error with an invalid azp' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6ImV4dGVybmFsLXRlc3QtOTk5IiwiYXV0aF90aW1lIjoxNTg3Njc4OTYxfQ.3DX-LY3B4UngDML-9nv11Sv89ECJpRpOLeWnkF1vAFY'
+
+      expect { @instance.validate(token) }.to raise_exception("Authorized Party (azp) claim mismatch in the ID token; expected \"tokens-test-123\", found \"external-test-999\"")
+    end
+
+    it 'is expected to raise an error with a missing auth_time' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyJ9.JqUotnjHbGW0FcHz1s1YsRkce9Sbpsv2AEBDMpcUhp8'
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ max_age: 120 }))
+
+      expect { instance.validate(token) }.to raise_exception('Authentication Time (auth_time) claim must be a number present in the ID token when Max Age (max_age) is specified')
+    end
+
+    it 'is expected to raise an error with a invalid auth_time' do
+      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzU5MjU2MX0.B7eWHJPHjhOh0ALjIQi0ro6zVsqGIeHd0gpRZsv6Hg8'
+      max_age = 120
+      auth_time = CLOCK + LEEWAY + max_age
+      clock = auth_time + 1
+      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ max_age: max_age, clock: clock }))
+
+      expect { instance.validate(token) }.to raise_exception("Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time \"#{clock}\" is after last auth at \"#{auth_time}\"")
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'pry'
 require 'rack/test'
 require 'faker'
+require 'json'
 require 'auth0'
 
 require 'simplecov'


### PR DESCRIPTION
### Changes

This update improves the SDK support for OpenID Connect. In particular, it modifies the sign in verification phase by substituting backchannel based checks with id_token validation.

**This PR aggregates a series of previously reviewed and approved PRs:**
- https://github.com/auth0/ruby-auth0/pull/224
- https://github.com/auth0/ruby-auth0/pull/223
- https://github.com/auth0/ruby-auth0/pull/222

#### Public surface area

##### Additions
- A new public method in `Auth0::Client` called `validate_id_token` that performs ID Token validation.
- `Auth0::Algorithm::HS256` and `Auth0::Algorithm::RS256`, classes that represent the signing algorithms and encapsulate the logic to obtain the respective secret/public keys.
- A new exception `Auth0::InvalidIdToken`.

##### Changes
None.

### Testing

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
