### PR TITLE
Handle missing reset header [SDK-1683]

### DIFF
--- a/lib/auth0/exception.rb
+++ b/lib/auth0/exception.rb
@@ -56,7 +56,7 @@ module Auth0
   # with prior gem versions that treated 429 errors as unknown errors.
   class RateLimitEncountered < Auth0::Unsupported
     def reset
-      Time.at(headers['X-RateLimit-Reset']).utc
+      headers.key?('X-RateLimit-Reset') ? Time.at(headers['X-RateLimit-Reset']).utc : nil
     end
   end
 


### PR DESCRIPTION
### Changes

The exception class `RateLimitEncountered` has a `reset` method that used the value of the `X-RateLimit-Reset` header without a fallback, and produced a `can't convert nil into an exact number (TypeError)` error if that header was not present. hat was changed to return `nil` instead.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
