### PR TITLE
Remove iat claim value check

### DIFF
--- a/lib/auth0/mixins/validation.rb
+++ b/lib/auth0/mixins/validation.rb
@@ -171,14 +171,6 @@ module Auth0
           unless claims.key?('iat') && claims['iat'].is_a?(Integer)
             raise Auth0::InvalidIdToken, 'Issued At (iat) claim must be a number present in the ID token'
           end
-
-          now = @context[:clock] || Time.now.to_i
-          iat_time = claims['iat'] - leeway
-
-          unless now > iat_time
-            raise Auth0::InvalidIdToken, "Issued At (iat) claim mismatch in the ID token; current time \"#{now}\""\
-                                         " is before issued at time \"#{iat_time}\""
-          end
         end
 
         def validate_nonce(claims, expected)

--- a/spec/lib/auth0/mixins/validation_spec.rb
+++ b/spec/lib/auth0/mixins/validation_spec.rb
@@ -229,14 +229,6 @@ describe Auth0::Mixins::Validation::IdTokenValidator do
       expect { @instance.validate(token) }.to raise_exception('Issued At (iat) claim must be a number present in the ID token')
     end
 
-    it 'is expected to raise an error with a invalid iat' do
-      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc3NjUzNjEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.1AeRLTaExbKnmsfNduUl3HArsau4RcNrnmYOJnkPWi0'
-      clock = CLOCK - LEEWAY - 1
-      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ clock: clock }))
-
-      expect { instance.validate(token) }.to raise_exception("Issued At (iat) claim mismatch in the ID token; current time \"#{clock}\" is before issued at time \"1587765301\"")
-    end
-
     it 'is expected not to raise an error with a missing but not required nonce' do
       token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTg3NzY1MzYxLCJpYXQiOjE1ODc1OTI1NjEsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTU4NzY3ODk2MX0.-o5grnyODbBdRgzcrn7Sf9Hb6eOC0x_U2i3YjVgHN0U'
 


### PR DESCRIPTION
### Changes

According to the spec, checking this value should be optional. Presence check however is not. That remains.


### References
https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation

> The iat Claim **can** be used to reject tokens that were issued too far away from the current time, limiting the amount of time that nonces need to be stored to prevent attacks. The acceptable range is Client specific.

### Testing

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
