### PR TITLE
Deprecate mgmt v1 calls

### DIFF
--- a/lib/auth0/api/v1/clients.rb
+++ b/lib/auth0/api/v1/clients.rb
@@ -4,7 +4,10 @@ module Auth0
       # {https://auth0.com/docs/api#applications}
       module Clients
         # {https://auth0.com/docs/api#!#get--api-clients}
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Clients
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def clients
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = '/api/clients'
           get(path)
         end
@@ -12,7 +15,10 @@ module Auth0
         alias get_clients clients
 
         # {https://auth0.com/docs/api#!#post--api-clients}
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Clients
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def create_client(name, callbacks = '')
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = '/api/clients'
           request_params = {
             name: name,
@@ -21,10 +27,11 @@ module Auth0
           post(path, request_params)
         end
 
-        # @deprecated use {#patch_client}
         # {https://auth0.com/docs/api#!#put--api-clients--client-id-}
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Clients
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def update_client(name, callbacks = '', client_id = @client_id)
-          warn 'This endpoint has been deprecated in favor of PATCH.'
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/clients/#{client_id}"
           request_params = {
             name: name,
@@ -34,7 +41,10 @@ module Auth0
         end
 
         # {https://auth0.com/docs/api#!#patch--api-clients--client-id-}
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Clients
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def patch_client(name, callbacks = '', client_id = @client_id)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/clients/#{client_id}"
           request_params = {
             name: name,

--- a/lib/auth0/api/v1/connections.rb
+++ b/lib/auth0/api/v1/connections.rb
@@ -4,26 +4,38 @@ module Auth0
       # {https://auth0.com/docs/api#connections}
       module Connections
         # {https://auth0.com/docs/api#!#get--api-connections}
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Connections
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def connections
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           get('/api/connections')
         end
         alias get_connections connections
 
         # {https://auth0.com/docs/api#!#get--api-connections--connection-name-}
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Connections
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def connection(connection_name)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/connections/#{connection_name}"
           get(path)
         end
         alias get_connection connection
 
         # {https://auth0.com/docs/api#!#delete--api-connections--connection-name-}
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Connections
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def delete_connection(connection_name)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/connections/#{connection_name}"
           delete(path)
         end
 
         # {https://auth0.com/docs/api#!#post--api-connections}
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Connections
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def create_connection(connection_name, strategy, tenant_domain, domain_aliases = nil)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = '/api/connections'
           request_params = {
             name: connection_name,
@@ -37,7 +49,10 @@ module Auth0
         end
 
         # {https://auth0.com/docs/api#!#put--api-connections--connection-name-}
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Connections
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def update_connection(connection_name, tenant_domain, status = true)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/connections/#{connection_name}"
           request_params = {
             status: status,

--- a/lib/auth0/api/v1/logs.rb
+++ b/lib/auth0/api/v1/logs.rb
@@ -4,7 +4,10 @@ module Auth0
       # {https://auth0.com/docs/api#logs}
       module Logs
         # https://auth0.com/docs/api/v1#!#logs
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Logs
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def logs(options = {})
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           acceptable_params = %i(take from search_criteria page per_page sort fields exclude_fields)
           options.reject! do |key, value|
             next unless key.nil? || value.nil? || !acceptable_params.include?(key.to_sym)
@@ -18,13 +21,19 @@ module Auth0
         alias search_logs logs
 
         # {https://auth0.com/docs/api#!#get--api-logs--_id-}
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Logs
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def log(id)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/logs/#{id}"
           get(path)
         end
 
         # {https://auth0.com/docs/api#!#get--api-users--user_id--logs-page--number--per_page--items-}
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Logs
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def user_logs(user_id, page = 0, per_page = 50)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/users/#{user_id}/logs?page=#{page}&per_page=#{per_page}"
           get(path)
         end

--- a/lib/auth0/api/v1/rules.rb
+++ b/lib/auth0/api/v1/rules.rb
@@ -4,7 +4,10 @@ module Auth0
       # https://auth0.com/docs/api#rules
       module Rules
         # https://auth0.com/docs/api#!#get--api-rules
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Rules
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def rules
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = '/api/rules'
           get(path)
         end
@@ -12,7 +15,10 @@ module Auth0
         alias get_rules rules
 
         # https://auth0.com/docs/api#!#post--api-rules
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Rules
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def create_rule(name, script, order = nil, status = true)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = '/api/rules'
           request_params = {
             name: name,
@@ -24,7 +30,10 @@ module Auth0
         end
 
         # https://auth0.com/docs/api#!#put--api-rules--rule-name-
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Rules
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def update_rule(name, script, order = nil, status = true)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/rules/#{name}"
           request_params = {
             status: status,
@@ -35,7 +44,10 @@ module Auth0
         end
 
         # https://auth0.com/docs/api#!#delete--api-rules--rule-name-
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Rules
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def delete_rule(name)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/rules/#{name}"
           delete(path)
         end

--- a/lib/auth0/api/v1/users.rb
+++ b/lib/auth0/api/v1/users.rb
@@ -7,7 +7,10 @@ module Auth0
         # {https://auth0.com/docs/api#!#get--api-users}
         #
         # {https://auth0.com/docs/api#!#get--api-users-search--criteria-}
+        # @deprecated - 4.14.0, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def users(search = nil)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = '/api/users'
           path += "?search=#{search}" unless search.to_s.empty?
           get(path)
@@ -17,7 +20,10 @@ module Auth0
         alias get_users users
 
         # {https://auth0.com/docs/api#!#get--api-users--user_id-}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def user(user_id)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/users/#{user_id}"
           get(path)
         end
@@ -25,14 +31,20 @@ module Auth0
         alias get_user user
 
         # {https://auth0.com/docs/api#!#get--api-users--user_id--devices}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def user_devices(user_id)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/users/#{user_id}/devices"
           get(path)
         end
 
         # {https://auth0.com/docs/api#!#get--api-connections--connection--users}
         # {https://auth0.com/docs/api#!#get--api-connections--connection--users-search--criteria-}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def connection_users(connection_name, search = nil)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/connections/#{connection_name}/users"
           path += "?search=#{search}" unless search.to_s.empty?
           get(path)
@@ -41,25 +53,37 @@ module Auth0
         alias search_connection_users connection_users
 
         # {https://auth0.com/docs/api#!#get--api-enterpriseconnections-users-search--criteria-}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def enterpriseconnections_users(search_criteria = nil, per_page = 500)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/enterpriseconnections/users?search=#{search_criteria}&per_page=#{per_page.to_i}"
           get(path)
         end
 
         # {https://auth0.com/docs/api#!#get--api-socialconnections-users-search--criteria-}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def socialconnections_users(search_criteria = nil, per_page = 500)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/socialconnections/users?search=#{search_criteria}&per_page=#{per_page.to_i}"
           get(path)
         end
 
         # {https://auth0.com/docs/api#!#get--api-clients--client-id--users}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def client_users(client_id = @client_id)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/clients/#{client_id}/users"
           get(path)
         end
 
         # {https://auth0.com/docs/api#!#post--api-users}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def create_user(email, password, connection_name, request_params = {})
+        warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           options = { email: email, password: password, connection: connection_name }
           request_params.merge!(options)
           path = '/api/users'
@@ -67,55 +91,79 @@ module Auth0
         end
 
         # {https://auth0.com/docs/api#!#post--api-users--user_id--send_verification_email}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def send_verification_email(user_id)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/users/#{user_id}/send_verification_email"
           post(path)
         end
 
         # {https://auth0.com/docs/api#!#post--api-users--user_id--change_password_ticket}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def change_password_ticket(user_id, new_password, result_url = nil)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           request_params = { 'newPassword' => new_password, 'resultUrl' => result_url }
           path = "/api/users/#{user_id}/change_password_ticket"
           post(path, request_params)
         end
 
         # {https://auth0.com/docs/api#!#post--api-users--user_id--verification_ticket}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def verification_ticket(user_id, result_url = nil)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           request_params = { 'resultUrl' => result_url }
           path = "/api/users/#{user_id}/verification_ticket"
           post(path, request_params)
         end
 
         # {https://auth0.com/docs/api#!#post--api-users--user_id--publickey}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def create_public_key(user_id, device, public_key)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/users/#{user_id}/public_key"
           request_params = { device: device, public_key: public_key }
           post(path, request_params)
         end
 
         # {https://auth0.com/docs/api#!#put--api-users--user_id--email}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def update_user_email(user_id, email, verify = true)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/users/#{user_id}/email"
           request_params = { email: email, verify: verify }
           put(path, request_params)
         end
 
         # {https://auth0.com/docs/api#!#put--api-users--user_id--metadata}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         # This will overwrite user's metadata, be really carefull, preffer using patch instead
         def update_user_metadata(user_id, metadata = {})
+        warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/users/#{user_id}/metadata"
           put(path, metadata)
         end
 
         # {https://auth0.com/docs/api#!#put--api-users--user_id--password}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def update_user_password(user_id, password, verify = true)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/users/#{user_id}/password"
           request_params = { password: password, verify: verify }
           put(path, request_params)
         end
 
         # {https://auth0.com/docs/api#!#put--api-users--email--password}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def update_user_password_using_email(email, password, connection_name, verify = true)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           request_params = {
             email:      email,
             password:   password,
@@ -127,34 +175,49 @@ module Auth0
         end
 
         # {https://auth0.com/docs/api#!#patch--api-users--user_id--metadata}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def patch_user_metadata(user_id, metadata = {})
+        warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/users/#{user_id}/metadata"
           patch(path, metadata)
         end
 
         # {https://auth0.com/docs/api#!#delete--api-users}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         #
         # This will remove all your users
         def delete_users
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = '/api/users/'
           delete(path)
         end
 
         # {https://auth0.com/docs/api#!#delete--api-users--user_id-}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def delete_user(user_id)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           raise Auth0::MissingUserId, 'if you want to remove all users use delete_users method' if user_id.to_s.empty?
           path = "/api/users/#{user_id}"
           delete(path)
         end
 
         # {https://auth0.com/docs/api#!#delete--api-users--user_id--refresh_tokens--refresh_token-}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def revoke_user_refresh_token(user_id, refresh_token)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/users/#{user_id}/refresh_tokens/#{refresh_token}"
           delete(path)
         end
 
         # {https://auth0.com/docs/api#!#delete--api-users--user_id--publickey-device--device-}
+        # @deprecated - 4.14.0, API v1 is no longer in use, please use Auth0::Api::V2::Users
+        # @see - https://auth0.com/docs/migrations/guides/management-api-v1-v2
         def revoke_user_device_public_key(user_id, device)
+          warn "[DEPRECATION] Api::V1 is deprecated please use Api::V2"
           path = "/api/users/#{user_id}/publickey?device=#{device}"
           delete(path)
         end


### PR DESCRIPTION
### Changes
Added warning to v1 calls.  These endpoints are no longer available for public saas customers