### PR TITLE
Add log streaming endpoints

### DIFF
--- a/lib/auth0/api/v2.rb
+++ b/lib/auth0/api/v2.rb
@@ -16,6 +16,7 @@ require 'auth0/api/v2/user_blocks'
 require 'auth0/api/v2/tenants'
 require 'auth0/api/v2/tickets'
 require 'auth0/api/v2/logs'
+require 'auth0/api/v2/log_streams'
 require 'auth0/api/v2/resource_servers'
 require 'auth0/api/v2/guardian'
 
@@ -41,6 +42,7 @@ module Auth0
       include Auth0::Api::V2::Tenants
       include Auth0::Api::V2::Tickets
       include Auth0::Api::V2::Logs
+      include Auth0::Api::V2::LogStreams
       include Auth0::Api::V2::ResourceServers
       include Auth0::Api::V2::Guardian
     end

--- a/lib/auth0/api/v2/log_streams.rb
+++ b/lib/auth0/api/v2/log_streams.rb
@@ -1,0 +1,78 @@
+module Auth0
+  module Api
+    module V2
+      # Methods to use the log streams endpoints
+      module LogStreams
+        attr_reader :log_streams_path
+
+        # Retrieves a list of all log streams.
+        # @see https://auth0.com/docs/api/management/v2#!/Log_Streams/get_log_streams
+        # @return [json] Returns the log streams.
+        def log_streams()
+          get(log_streams_path)
+        end
+        alias get_log_streams log_streams
+
+        # Retrieves a log stream by its ID.
+        # @see https://auth0.com/docs/api/management/v2#!/Log_Streams/get_log_streams_by_id
+        # @param id [string] The id of the log stream to retrieve.
+        #
+        # @return [json] Returns the log stream.
+        def log_stream(id)
+          raise Auth0::InvalidParameter, 'Must supply a valid log stream id' if id.to_s.empty?
+          path = "#{log_streams_path}/#{id}"
+          get(path)
+        end
+        alias get_log_stream log_stream
+
+        # Creates a new log stream according to the JSON object received in body.
+        # @see https://auth0.com/docs/api/management/v2#!/Log_Streams/post_log_streams
+        # @param name [string] The name of the log stream.
+        # @param type [string] The type of log stream
+        # @param options [hash] The Hash options used to define the log streams's properties.
+        #
+        # @return [json] Returns the log stream.
+        def create_log_stream(name, type, options)
+          raise Auth0::InvalidParameter, 'Name must contain at least one character' if name.to_s.empty?
+          raise Auth0::InvalidParameter, 'Must specify a valid type' if type.to_s.empty?
+          raise Auth0::InvalidParameter, 'Must supply a valid hash for options' unless options.is_a? Hash
+
+          request_params = {}
+          request_params[:name] = name
+          request_params[:type] = type
+          request_params[:sink] = options
+          post(log_streams_path, request_params)
+        end
+
+        # Deletes a log stream by its ID.
+        # @see https://auth0.com/docs/api/management/v2#!/Log_Streams/delete_log_streams_by_id
+        # @param id [string] The id of the log stream to delete.
+        def delete_log_stream(id)
+          raise Auth0::InvalidParameter, 'Must supply a valid log stream id' if id.to_s.empty?
+          path = "#{log_streams_path}/#{id}"
+          delete(path)
+        end
+
+        # Updates a log stream.
+        # @see https://auth0.com/docs/api/management/v2#!/Log_Streams/patch_log_streams_by_id
+        # @param id [string] The id or audience of the log stream to update.
+        # @param status [string] The Hash options used to define the log streams's properties.
+        def patch_log_stream(id, status)
+          raise Auth0::InvalidParameter, 'Must specify a log stream id' if id.to_s.empty?
+          raise Auth0::InvalidParameter, 'Must specify a valid status' if status.to_s.empty?
+
+          request_params = {}
+          request_params[:status] = status
+          path = "#{log_streams_path}/#{id}"
+          patch(path, request_params)
+        end
+        
+        private
+        # Log Streams API path
+        def log_streams_path
+          @log_streams_path ||= '/api/v2/log-streams'
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/auth0/api/v2/log_streams_spec.rb
+++ b/spec/lib/auth0/api/v2/log_streams_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+describe Auth0::Api::V2::LogStreams do
+  before :all do
+    dummy_instance = DummyClass.new
+    dummy_instance.extend(Auth0::Api::V2::LogStreams)
+    dummy_instance.extend(Auth0::Mixins::Initializer)
+    @instance = dummy_instance
+  end
+
+  context '.log_streams' do
+    it { expect(@instance).to respond_to(:log_streams) }
+    it { expect(@instance).to respond_to(:get_log_streams) }
+    it 'is expected to call get /api/v2/log-streams' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/log-streams'
+      )
+      expect { @instance.log_streams }.not_to raise_error
+    end
+  end
+
+  context '.log_stream' do
+    it { expect(@instance).to respond_to(:log_stream) }
+    it 'is expected to call get /api/v2/log-streams/test' do
+      expect(@instance).to receive(:get).with('/api/v2/log-streams/test')
+      expect { @instance.log_stream('test') }.not_to raise_error
+    end
+    it 'expect to raise an error when calling with empty log stream id' do
+      expect { @instance.log_stream(nil) }.to raise_error 'Must supply a valid log stream id'
+    end
+  end
+
+  context '.create_log_stream' do
+    it { expect(@instance).to respond_to(:create_log_stream) }
+    it 'is expected to call post /api/v2/log-streams' do
+      expect(@instance).to receive(:post).with(
+        '/api/v2/log-streams',
+        name: 'test',
+        type: 'https',
+        sink: {
+          httpEndpoint: "https://mycompany.com",
+          httpContentType: "string",
+          httpContentFormat: "JSONLINES",
+          httpAuthorization: "string"
+        }
+      )
+
+      @instance.create_log_stream('test', 'https',
+        httpEndpoint: "https://mycompany.com",
+        httpContentType: "string",
+        httpContentFormat: "JSONLINES",
+        httpAuthorization: "string")
+    end
+    it 'expect to raise an error when calling with empty name' do
+      expect { @instance.create_log_stream('', '', '') }.to raise_error 'Name must contain at least one character'
+    end
+    it 'expect to raise an error when calling with empty type' do
+      expect { @instance.create_log_stream('name', '', '') }.to raise_error 'Must specify a valid type'
+    end
+    it 'expect to raise an error when calling without options' do
+      expect { @instance.create_log_stream('name', 'https', nil) }.to raise_error 'Must supply a valid hash for options'
+    end
+  end
+
+  context '.delete_log_stream' do
+    it { expect(@instance).to respond_to(:delete_log_stream) }
+    it 'is expected to call delete /api/v2/log-streams/test' do
+      expect(@instance).to receive(:delete).with('/api/v2/log-streams/test')
+      expect { @instance.delete_log_stream('test') }.not_to raise_error
+    end
+    it 'expect to raise an error when calling with empty log stream id' do
+      expect { @instance.delete_log_stream(nil) }.to raise_error 'Must supply a valid log stream id'
+    end
+  end
+
+  context '.patch_log_stream' do
+    it { expect(@instance).to respond_to(:patch_log_stream) }
+    it 'is expected to send patch to /api/v2/log_streams/test' do
+      expect(@instance).to receive(:patch).with('/api/v2/log-streams/test', status: 'paused')
+      expect { @instance.patch_log_stream('test', 'paused') }.not_to raise_error
+    end
+    it { expect { @instance.patch_log_stream('', nil) }.to raise_error 'Must specify a log stream id' }
+    it { expect { @instance.patch_log_stream('test', nil) }.to raise_error 'Must specify a valid status' }
+  end
+end


### PR DESCRIPTION
### Changes

Adding support for the log-streams endpoints:

GET /api/v2/log-streams
GET /api/v2/log-streams/{id}
POST /api/v2/log-streams
PATCH /api/v2/log-streams/{id}
DELETE /api/v2/log-streams/{id}

### References

- https://auth0.com/docs/api/management/v2#!/Log_Streams/get_log_streams
- https://auth0.com/docs/api/management/v2#!/Log_Streams/get_log_streams_by_id
- https://auth0.com/docs/api/management/v2#!/Log_Streams/post_log_streams
- https://auth0.com/docs/api/management/v2#!/Log_Streams/delete_log_streams_by_id
- https://auth0.com/docs/api/management/v2#!/Log_Streams/patch_log_streams_by_id

### Testing

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files => Lots of errors in my environment. 🤔 
* [ ] All active GitHub checks have passed
