### PR TITLE
New Email Verification Fields

### DIFF
--- a/lib/auth0/api/v2/jobs.rb
+++ b/lib/auth0/api/v2/jobs.rb
@@ -78,13 +78,23 @@ module Auth0
         # @see https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email
         # @param user_id [string] The user_id of the user to whom the email will be sent.
         # @param client_id [string] Client ID to send an Application-specific email.
+        # @param identity [hash] Used to verify secondary, federated, and passwordless-email identities.
+        #   * :user_id [string] user_id of the identity.
+        #   * :provider [string] provider of the identity.
         #
         # @return [json] Returns the job status and properties.
-        def send_verification_email(user_id, client_id = nil)
+        def send_verification_email(user_id, client_id = nil, identity: nil)
           raise Auth0::InvalidParameter, 'Must specify a user id' if user_id.to_s.empty?
 
           request_params = { user_id: user_id }
           request_params[:client_id] = client_id unless client_id.nil?
+
+          if identity
+            unless identity.is_a? Hash
+              raise Auth0::InvalidParameter, 'Identity must be a hash send an email verification'
+            end
+            request_params[:identity] = identity
+          end
 
           path = "#{jobs_path}/verification-email"
           post(path, request_params)

--- a/lib/auth0/api/v2/tickets.rb
+++ b/lib/auth0/api/v2/tickets.rb
@@ -12,9 +12,12 @@ module Auth0
         # @param ttl_sec [integer] The ticket's lifetime in seconds starting from the moment of creation.
         # After expiration, the ticket cannot be used to verify the user's email. If not specified or if
         # you send 0, the Auth0 default lifetime of five days will be applied
+        # @param identity [hash] Used to verify secondary, federated, and passwordless-email identities.
+        #   * :user_id [string] user_id of the identity.
+        #   * :provider [string] provider of the identity.
         #
         # @return [json] Returns the created ticket url.
-        def post_email_verification(user_id, result_url: nil, ttl_sec: nil)
+        def post_email_verification(user_id, result_url: nil, ttl_sec: nil, identity: nil)
           if user_id.to_s.empty?
             raise Auth0::InvalidParameter, 'Must supply a valid user id to post an email verification'
           end
@@ -24,6 +27,14 @@ module Auth0
             result_url: result_url,
             ttl_sec: ttl_sec.is_a?(Integer) ? ttl_sec : nil
           }
+
+          if identity
+            unless identity.is_a? Hash
+              raise Auth0::InvalidParameter, 'Identity must be a hash to post an email verification'
+            end
+            request_params[:identity] = identity
+          end
+
           post(path, request_params)
         end
 

--- a/spec/integration/lib/auth0/api/v2/api_jobs_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_jobs_spec.rb
@@ -100,6 +100,18 @@ describe Auth0::Api::V2::Jobs do
         client.send_verification_email(user['user_id'], Random.new(32).to_s)
       end.to raise_error Auth0::BadRequest
     end
+
+    it 'should raise an error if the user id is empty' do
+      expect do
+        client.send_verification_email( '' )
+      end.to raise_error Auth0::InvalidParameter, 'Must specify a user id'
+    end
+
+    it 'should raise an error if the identity supplied is not a Hash' do
+      expect do
+        client.send_verification_email( 'user_id', identity: 'not a hash')
+      end.to raise_error Auth0::InvalidParameter, 'Identity must be a hash send an email verification'
+    end
   end
 
   after(:all) do

--- a/spec/integration/lib/auth0/api/v2/api_tickets_spec.rb
+++ b/spec/integration/lib/auth0/api/v2/api_tickets_spec.rb
@@ -35,7 +35,13 @@ describe Auth0::Api::V2::Tickets do
     it 'should raise an error if the user id is empty' do
       expect do
         client.post_email_verification( '' )
-      end.to raise_error Auth0::InvalidParameter
+      end.to raise_error Auth0::InvalidParameter, 'Must supply a valid user id to post an email verification'
+    end
+
+    it 'should raise an error if the identity supplied is not a Hash' do
+      expect do
+        client.post_email_verification( '', identity: 'not a hash')
+      end.to raise_error Auth0::InvalidParameter, 'Must supply a valid user id to post an email verification'
     end
   end
 

--- a/spec/lib/auth0/api/v2/jobs_spec.rb
+++ b/spec/lib/auth0/api/v2/jobs_spec.rb
@@ -102,6 +102,23 @@ describe Auth0::Api::V2::Jobs do
       end.not_to raise_error
     end
 
+    it 'expect client to accept hash identity' do
+      expect(@instance).to receive(:post).with('/api/v2/jobs/verification-email', user_id: 'user_id',
+                                                                                  identity: {
+                                                                                    provider: "auth0",
+                                                                                    user_id: "user_id"
+                                                                                  })
+      expect {
+        @instance.send_verification_email('user_id', identity: { provider: "auth0", user_id: "user_id"}) 
+      }.not_to raise_error
+    end
+
+    it 'expect client to return nil when calling with a non-hash identity' do
+      expect { @instance.send_verification_email('user_id', identity: "nonhash") }.to raise_error(
+        'Identity must be a hash send an email verification'
+      )
+    end
+
     it 'should raise an error if the user_id is empty' do
       expect do
         @instance.send_verification_email('')

--- a/spec/lib/auth0/api/v2/tickets_spec.rb
+++ b/spec/lib/auth0/api/v2/tickets_spec.rb
@@ -21,6 +21,23 @@ describe Auth0::Api::V2::Tickets do
                                                                                      result_url: nil, ttl_sec: nil)
       expect { @instance.post_email_verification('user_id', ttl_sec: "noninteger") }.not_to raise_error
     end
+    it 'expect client to accept hash identity' do
+      expect(@instance).to receive(:post).with('/api/v2/tickets/email-verification', user_id: 'user_id',
+                                                                                     result_url: nil, 
+                                                                                     ttl_sec: nil,
+                                                                                     identity: {
+                                                                                      provider: "auth0",
+                                                                                      user_id: "user_id"
+                                                                                     })
+      expect {
+        @instance.post_email_verification('user_id', identity: { provider: "auth0", user_id: "user_id"}) 
+      }.not_to raise_error
+    end
+    it 'expect client to return nil when calling with a non-hash identity' do
+      expect { @instance.post_email_verification('user_id', identity: "nonhash") }.to raise_error(
+        'Identity must be a hash to post an email verification'
+      )
+    end
     it 'expect client to rasie error when calling with empty body' do
       expect { @instance.post_email_verification(nil) }.to raise_error(
         'Must supply a valid user id to post an email verification'


### PR DESCRIPTION
### Changes

Adds support for specifying the (optional) `identity` object when creating email verification tickets or jobs. This is needed when verifying emails when the primary is social, enterprise, or passwordless. Also needed to verify secondary identities.

### References

- https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification
- https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby