### PR TITLE
Addressable URI Escape

### DIFF
--- a/lib/auth0/mixins/httpproxy.rb
+++ b/lib/auth0/mixins/httpproxy.rb
@@ -1,3 +1,5 @@
+require "addressable/uri"
+
 module Auth0
   module Mixins
     # here's the proxy for Rest calls based on rest-client, we're building all request on that gem
@@ -8,7 +10,7 @@ module Auth0
       # proxying requests from instance methods to HTTP class methods
       %i(get post post_file put patch delete delete_with_body).each do |method|
         define_method(method) do |path, body = {}, extra_headers = {}|
-          safe_path = URI.escape(path)
+          safe_path = Addressable::URI.escape(path)
           body = body.delete_if { |_, v| v.nil? }
           result = if method == :get
                      # Mutate the headers property to add parameters.

--- a/spec/lib/auth0/mixins/httpproxy_spec.rb
+++ b/spec/lib/auth0/mixins/httpproxy_spec.rb
@@ -141,7 +141,7 @@ describe Auth0::Mixins::HTTPProxy do
         expect { @instance.send(http_method, '/test') }.to raise_error(Auth0::ServerError)
       end
 
-      it 'should escape path with URI.escape' do
+      it 'should escape path with Addressable::URI.escape' do
         expect(RestClient::Request).to receive(:execute).with(method: http_method,
                                                               url: '/te%20st',
                                                               timeout: nil,
@@ -275,7 +275,7 @@ describe Auth0::Mixins::HTTPProxy do
         expect { @instance.send(http_method, '/test') }.to raise_error(Auth0::ServerError)
       end
 
-      it 'should escape path with URI.escape' do
+      it 'should escape path with Addressable::URI.escape' do
         expect(RestClient::Request).to receive(:execute).with(method: http_method,
                                                               url: '/te%20st',
                                                               timeout: nil,


### PR DESCRIPTION
URI.escape has been deprecated since version 2.7.0 https://ruby-doc.org/stdlib-2.7.0/libdoc/uri/rdoc/URI/Escape.html#method-i-escape-label-Description

Addressable gem covers what we need

Closes https://github.com/auth0/ruby-auth0/issues/202