### PR TITLE
Addressable dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v4.17.1](https://github.com/auth0/ruby-auth0/tree/v4.17.1) (2020-10-21)
+
+[Full Changelog](https://github.com/auth0/ruby-auth0/compare/v4.17.0...v4.17.1)
+
+**Fixed**
+
+- Addressable dependency  [\#247](https://github.com/auth0/ruby-auth0/pull/247) ([davidpatrick](https://github.com/davidpatrick))
+
 
 ## [v4.17.0](https://github.com/auth0/ruby-auth0/tree/v4.17.0) (2020-10-19)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     auth0 (4.17.0)
+      addressable (~> 2.7.0)
       jwt (~> 2.2.0)
       rest-client (~> 2.0.0)
       zache (~> 0.12.0)

--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rest-client', '~> 2.0.0'
   s.add_runtime_dependency 'jwt', '~> 2.2.0'
   s.add_runtime_dependency 'zache', '~> 0.12.0'
+  s.add_runtime_dependency 'addressable', '~> 2.7.0'
 
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'fuubar', '~> 2.0'


### PR DESCRIPTION
### Changes
Addressable dependency was only avail in development environments through webmock.  It should be included in the Gemfile