### PR TITLE
Fixes recovery-code-regeneration URL

### DIFF
--- a/lib/auth0/api/v2/users.rb
+++ b/lib/auth0/api/v2/users.rb
@@ -296,7 +296,7 @@ module Auth0
         # @param user_id [string] The user_id of the recovery codes to regenerate.
         def generate_recovery_code(user_id)
           raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
-          post "#{users_path}/#{user_id}/recovery-code-generation"
+          post "#{users_path}/#{user_id}/recovery-code-regeneration"
         end
 
         # Invalidate all remembered browsers for all authentication factors for a specific user.

--- a/spec/lib/auth0/api/v2/users_spec.rb
+++ b/spec/lib/auth0/api/v2/users_spec.rb
@@ -524,7 +524,7 @@ describe Auth0::Api::V2::Users do
     end
 
     it 'is expected to get generate a recovery code' do
-      expect(@instance).to receive(:post).with('/api/v2/users/USER_ID/recovery-code-generation')
+      expect(@instance).to receive(:post).with('/api/v2/users/USER_ID/recovery-code-regeneration')
       expect do
         @instance.generate_recovery_code('USER_ID')
       end.not_to raise_error


### PR DESCRIPTION
### Changes

There seems to be a typo in the URL to regenerated the 2FA recovery codes.



Please describe both what is changing and why this is important. Include:

### References

The correct URL can be found here: https://auth0.com/docs/api/management/v2#!/Users/post_recovery_code_regeneration

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
