### PR TITLE
add name param to connections api

### DIFF
--- a/lib/auth0/api/v2/connections.rb
+++ b/lib/auth0/api/v2/connections.rb
@@ -9,6 +9,7 @@ module Auth0
         # being specified. Accepts a list of fields to include or exclude in the resulting list of connection objects.
         # @see https://auth0.com/docs/api/management/v2#!/Connections/get_connections
         # @param strategy [string] Strategy to filter connection results.
+        # @param name [string] Name to filter connection results.
         # @param fields [string] A comma separated list of fields to include or exclude from the result.
         # @param include_fields [boolean] True if the fields specified are to be included in the result, false otherwise.
         # @param page [int] Page number to get, 0-based.
@@ -16,6 +17,7 @@ module Auth0
         # @return [json] Returns the existing connections matching the strategy.
         def connections(
           strategy: nil,
+          name: nil,
           fields: nil,
           include_fields: nil,
           page: nil,
@@ -24,6 +26,7 @@ module Auth0
           include_fields = true if !fields.nil? && include_fields.nil?
           request_params = {
             strategy: strategy,
+            name: name,
             fields: fields.is_a?(Array) ? fields.join(',') : fields,
             include_fields: include_fields,
             page: !page.nil? ? page.to_i : nil,

--- a/spec/lib/auth0/api/v2/connections_spec.rb
+++ b/spec/lib/auth0/api/v2/connections_spec.rb
@@ -14,6 +14,7 @@ describe Auth0::Api::V2::Connections do
       expect(@instance).to receive(:get).with(
         '/api/v2/connections',
         strategy: nil,
+        name: nil,
         fields: nil,
         include_fields: nil,
         page: nil,
@@ -28,6 +29,7 @@ describe Auth0::Api::V2::Connections do
         include_fields: true,
         fields: 'name',
         strategy: nil,
+        name: nil,
         page: nil,
         per_page: nil
       )
@@ -42,6 +44,7 @@ describe Auth0::Api::V2::Connections do
         include_fields: true,
         fields: 'name,strategy',
         strategy: nil,
+        name: nil,
         page: nil,
         per_page: nil
       )
@@ -56,6 +59,7 @@ describe Auth0::Api::V2::Connections do
         page: 1,
         per_page: 10,
         strategy: nil,
+        name: nil,
         fields: nil,
         include_fields: nil
       )


### PR DESCRIPTION
Hi, Thank you for Great Gem.

### Changes

I added name param to Connections api because I couldn't pass the name parameter even though it exists.

### References

https://auth0.com/docs/api/management/v2#!/Connections/get_connections


### Testing

* [x] This change adds unit test coverage

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed

Rubocop was failing before the change...