### PR TITLE
Add api_identifier as an accepted configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,12 +137,11 @@ require 'auth0'
 @auth0_client ||= Auth0Client.new(
   client_id: '{YOUR_APPLICATION_CLIENT_ID}',
   client_secret: '{YOUR_APPLICATION_CLIENT_SECRET}',
-  domain: '{YOUR_TENANT}.auth0.com'
+  domain: '{YOUR_TENANT}.auth0.com',
+  organization: "{YOUR_ORGANIZATION_ID}"
 )
 
-universal_login_url = @auth0_client.authorization_url("https://{YOUR_APPLICATION_CALLBACK_URL}", {
-  organization: "{YOUR_ORGANIZATION_ID}",
-})
+universal_login_url = @auth0_client.authorization_url("https://{YOUR_APPLICATION_CALLBACK_URL}")
 
 # redirect_to universal_login_url
 ```
@@ -157,11 +156,12 @@ require 'auth0'
 @auth0_client ||= Auth0Client.new(
   client_id: '{YOUR_APPLICATION_CLIENT_ID}',
   client_secret: '{YOUR_APPLICATION_CLIENT_ID}',
-  domain: '{YOUR_TENANT}.auth0.com'
+  domain: '{YOUR_TENANT}.auth0.com',
+  organization: "{YOUR_ORGANIZATION_ID}"
 )
 
 universal_login_url = @auth0_client.authorization_url("https://{YOUR_APPLICATION_CALLBACK_URL}", {
-  organization: "{ORGANIZATION_QUERY_PARAM}",
+  organization: "{ORGANIZATION_QUERY_PARAM}", # You can override organization if needed
   invitation: "{INVITATION_QUERY_PARAM}"
 })
 

--- a/lib/auth0/mixins/initializer.rb
+++ b/lib/auth0/mixins/initializer.rb
@@ -18,6 +18,7 @@ module Auth0
         extend Auth0::Api::AuthenticationEndpoints
         @client_id = options[:client_id]
         @client_secret = options[:client_secret]
+        @organization = options[:organization]
         initialize_api(options)
       end
 
@@ -58,7 +59,8 @@ module Auth0
       def initialize_v2(options)
         extend Auth0::Api::V2
         @token = options[:access_token] || options[:token]
-        @token = api_token.token if @token.nil? && @client_id && @client_secret
+        api_identifier = options[:api_identifier] || "https://#{@domain}/api/v2/"
+        @token = api_token(audience: api_identifier).token if @token.nil? && @client_id && @client_secret
       end
 
       def api_v2?(options)


### PR DESCRIPTION
### Changes
I'd like to fetch a api token with audience that my api identifier.
When I use auth0 with custom domain, I need to specify an audience that is different than the domain. 
But I can not unable to do this now.

The `:audience` parameter is synonymous with the OIDC ID Token and is also used to generate the login URL, so it's confusing.
Auth0's Client Credentials Flow asks the audience for[ an API identifier](https://auth0.com/docs/api/authentication#client-credentials-flow).

`:custome_domein` and `:sub` were suggested at #189 , but I thought there was a more direct way to express it.
so I think the parameter `:api_identifier` is not confusing, What are your thoughts?

### References

This issue has been discussed at #189  as well.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
