### PR TITLE
Fixes create_organizations_enabled_connection

### DIFF
--- a/lib/auth0/api/v2/organizations.rb
+++ b/lib/auth0/api/v2/organizations.rb
@@ -127,15 +127,18 @@ module Auth0
         # Add an enabled connection for an Organization
         # @see https://auth0.com/docs/api/management/v2/#!/Organizations/post_enabled_connections
         # @param organization_id [string] The Organization ID
+        # @param connection_id [string] The Organization ID
         # @param assign_membership_on_login [boolean] flag to allow assign membership on login
         #
         # @return [json] Returns the connection for the given organization
-        def create_organizations_enabled_connection(organization_id, assign_membership_on_login: false)
+        def create_organizations_enabled_connection(organization_id, connection_id, assign_membership_on_login: false)
           raise Auth0::MissingOrganizationId, 'Must supply a valid organization_id' if organization_id.to_s.empty?
+          raise Auth0::InvalidParameter, 'Must supply a valid connection id' if connection_id.to_s.empty?
           path = "#{organizations_enabled_connections_path(organization_id)}"
           
           body = {}
           body[:assign_membership_on_login] = assign_membership_on_login
+          body[:connection_id] = connection_id
 
           post(path, body)
         end

--- a/spec/lib/auth0/api/v2/organizations_spec.rb
+++ b/spec/lib/auth0/api/v2/organizations_spec.rb
@@ -247,14 +247,19 @@ describe Auth0::Api::V2::Organizations do
       expect(@instance).to receive(:post).with(
         '/api/v2/organizations/org_id/enabled_connections',
         {
+          connection_id: 'connection_id',
           assign_membership_on_login: true
         }
       )
-      @instance.create_organizations_enabled_connection('org_id', assign_membership_on_login: true)
+      @instance.create_organizations_enabled_connection('org_id', 'connection_id', assign_membership_on_login: true)
     end
 
     it 'is expected to raise an exception when the organization id is empty' do
-      expect { @instance.create_organizations_enabled_connection(nil) }.to raise_exception(Auth0::MissingOrganizationId)
+      expect { @instance.create_organizations_enabled_connection(nil, nil) }.to raise_exception(Auth0::MissingOrganizationId)
+    end
+
+    it 'is expected to raise an exception when the connection id is empty' do
+      expect { @instance.create_organizations_enabled_connection('123', nil) }.to raise_error 'Must supply a valid connection id'
     end
   end
 


### PR DESCRIPTION
This fixes the `create_organizations_enabled_connection` method, which ommitted the require `connection_id`