### PR TITLE
Release 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log
 
+## [v5.1.01(https://github.com/auth0/ruby-auth0/tree/v5.1.1) (2021-04-14)
+
+[Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.1.0..v5.1.1)
+
+**Fixed**
+
+- Fixes create_organizations_enabled_connection [\#269](https://github.com/auth0/ruby-auth0/pull/269) ([davidpatrick](https://github.com/apps/davidpatrick))
+
+
 ## [v5.1.0](https://github.com/auth0/ruby-auth0/tree/v5.1.0) (2021-04-09)
 
 [Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.0.1..v5.1.0)

--- a/lib/auth0/version.rb
+++ b/lib/auth0/version.rb
@@ -1,4 +1,4 @@
 # current version of gem
 module Auth0
-  VERSION = '5.1.0'.freeze
+  VERSION = '5.1.1'.freeze
 end


### PR DESCRIPTION
## [v5.1.01(https://github.com/auth0/ruby-auth0/tree/v5.1.1) (2021-04-14)

[Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.1.0..v5.1.1)

**Fixed**

- Fixes create_organizations_enabled_connection [\#269](https://github.com/auth0/ruby-auth0/pull/269) ([davidpatrick](https://github.com/apps/davidpatrick))
