### PR TITLE
Properly handle headers when parsing x_ratelimit_reset in exception

### DIFF
--- a/lib/auth0/exception.rb
+++ b/lib/auth0/exception.rb
@@ -53,7 +53,7 @@ module Auth0
   # Auth0 API rate-limiting encountered
   class RateLimitEncountered < Auth0::HTTPError
     def reset
-      Time.at(headers['X-RateLimit-Reset']).utc
+      Time.at(Integer(headers[:x_ratelimit_reset])).utc
     end
   end
 

--- a/spec/lib/auth0/mixins/httpproxy_spec.rb
+++ b/spec/lib/auth0/mixins/httpproxy_spec.rb
@@ -104,9 +104,9 @@ describe Auth0::Mixins::HTTPProxy do
       it "should raise Auth0::RateLimitEncountered on send http #{http_method} method
         to path defined through HTTP when 429 recieved" do
         headers = {
-          'X-RateLimit-Limit'     => 10,
-          'X-RateLimit-Remaining' => 0,
-          'X-RateLimit-Reset'     => 1560564149
+          :x_ratelimit_limit     => 10,
+          :x_ratelimit_remaining => 0,
+          :x_ratelimit_reset     => 1560564149
         }
         @exception.response = StubResponse.new({}, false, 429, headers)
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
@@ -127,7 +127,7 @@ describe Auth0::Mixins::HTTPProxy do
             reset: Time.at(1560564149)
           )
         }
-      end      
+      end
 
       it "should raise Auth0::ServerError on send http #{http_method} method
         to path defined through HTTP when 500 received" do
@@ -188,13 +188,13 @@ describe Auth0::Mixins::HTTPProxy do
           .and_raise(@exception)
         expect { @instance.send(http_method, '/test') }.to raise_error(Auth0::Unauthorized)
       end
-      
+
       it "should raise Auth0::RateLimitEncountered on send http #{http_method} method
         to path defined through HTTP when 429 status received" do
         headers = {
-          'X-RateLimit-Limit'     => 10,
-          'X-RateLimit-Remaining' => 0,
-          'X-RateLimit-Reset'     => 1560564149
+          :x_ratelimit_limit     => 10,
+          :x_ratelimit_remaining => 0,
+          :x_ratelimit_reset     => 1560564149
         }
         @exception.response = StubResponse.new({}, false, 429,headers)
         allow(RestClient::Request).to receive(:execute).with(method: http_method,


### PR DESCRIPTION
I noticed that we had type error when we were trying to get the `.reset`
time in an RateLimitEncountered. Headers are symbolized and are not
strings.

To reproduce de behavior I did
```ruby
t = []
  85.times do
    t << Thread.new do
      auth0_client.clients
    rescue Auth0::RateLimitEncountered => e
      puts <<~DOC

        exception: #{e.inspect}

        reset: #{e.reset}

      DOC
    end
  end
end; nil
p t.map(&:join); nil
p 1
```

Without the fix
```
.../gems/activesupport-6.0.3.6/lib/active_support/core_ext/time/calculations.rb:53:in `at': can't convert nil into an exact number (TypeError)
```

Inspecting headers:
```
headers['X-RateLimit-Reset']: nil, headers[:x_ratelimit_reset]: 1619192310
```

With the fix:
```
exception: #<Auth0::RateLimitEncountered: {"statusCode":429,"error":"Too Many Requests","message":"Global limit has been reached","errorCode":"too_many_requests"}>

reset: 2021-04-23 15:49:17 UTC
```

Related:
  - https://github.com/auth0/ruby-auth0/pull/170

---

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
