### PR TITLE
Allow RestClient to set Content-Type Headers on bulk imports

### DIFF
--- a/lib/auth0/mixins/httpproxy.rb
+++ b/lib/auth0/mixins/httpproxy.rb
@@ -26,7 +26,10 @@ module Auth0
                      call(:delete, url(safe_path), timeout, headers, body.to_json)
                    elsif method == :post_file
                      body.merge!(multipart: true)
-                     call(:post, url(safe_path), timeout, headers, body)
+                     # Ignore the default Content-Type headers and let the HTTP client define them
+                     post_file_headers = headers.slice(*headers.keys - ['Content-Type'])
+                     # Actual call with the altered headers
+                     call(:post, url(safe_path), timeout, post_file_headers, body)
                    else
                      call(method, url(safe_path), timeout, headers, body.to_json)
                    end


### PR DESCRIPTION
When making bulk imports with `import_users`, the default `Content-Type` headers (`application/json`)
should not be used, since there is a file in the payload.

The RestClient client fixes that and replaces this header with its own (thank you RestClient), but it
emits a warning, and it's still a mistake.

Since generating headers for a multipart POST request is a bit annoying, I've chosen to simply _remove_
the `Content-Type` headers, and let RestClient do the work.

