### PR TITLE
Adds Rotating Refresh Token type to Device Credentials

### DIFF
--- a/lib/auth0/api/v2/device_credentials.rb
+++ b/lib/auth0/api/v2/device_credentials.rb
@@ -12,7 +12,7 @@ module Auth0
         #   * :fields [string] A comma separated list of fields to include or exclude from the result.
         #   * :include_fields [boolean] True if the fields specified are to be included in the result, false otherwise.
         #   * :user_id [string] The user_id of the devices to retrieve.
-        #   * :type [string] The type of credentials. Possible values: 'public_key' or 'refresh_token'.
+        #   * :type [string] Type of credentials to retrieve. Must be 'public_key', 'refresh_token' or 'rotating_refresh_token'
         #
         # @return [json] Returns the list of existing devices for the specified client_id.
         # rubocop:disable Metrics/AbcSize
@@ -25,8 +25,8 @@ module Auth0
             type: options.fetch(:type, nil)
           }
           raise Auth0::InvalidParameter, 'Must supply a valid client_id' if client_id.to_s.empty?
-          if !request_params[:type].nil? && !%w(public_key refresh_token).include?(request_params[:type])
-            raise Auth0::InvalidParameter, 'Type must be one of \'public_key\', \'refresh_token\''
+          if !request_params[:type].nil? && !%w(public_key refresh_token rotating_refresh_token).include?(request_params[:type])
+            raise Auth0::InvalidParameter, 'Type must be one of \'public_key\', \'refresh_token\', \'rotating_refresh_token\''
           end
           get(device_credentials_path, request_params)
         end

--- a/spec/lib/auth0/api/v2/device_credentials_spec.rb
+++ b/spec/lib/auth0/api/v2/device_credentials_spec.rb
@@ -22,9 +22,9 @@ describe Auth0::Api::V2::DeviceCredentials do
       )
       expect { @instance.device_credentials(client_id) }.not_to raise_error
     end
-    it 'is expect to raise an error when type is not one of \'public_key\', \'refresh_token\'' do
+    it 'is expect to raise an error when type is not one of \'public_key\', \'refresh_token\', \'rotating_refresh_token\'' do
       expect { @instance.device_credentials(client_id, type: 'invalid_type') }.to raise_error(
-        'Type must be one of \'public_key\', \'refresh_token\''
+        'Type must be one of \'public_key\', \'refresh_token\', \'rotating_refresh_token\''
       )
     end
   end


### PR DESCRIPTION
### Changes

Adds `rotating_refresh_token` to the allowed device credential types. The `rotating_refresh_token` is valid in the [Auth0 Management API](https://auth0.com/docs/api/management/v2#!/Device_Credentials/get_device_credentials) but the documentation request schema is not updated.

![image](https://user-images.githubusercontent.com/1047402/124274397-7fe4f280-db41-11eb-89ca-35eed3278bb9.png)
![image](https://user-images.githubusercontent.com/1047402/124274411-85dad380-db41-11eb-88d7-db6a9a99c7c5.png)

### References

Support ticket: https://support.auth0.com/tickets/00492497

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
