### PR TITLE
bump addressable version per CVE-2021-32740

### DIFF
--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rest-client', '~> 2.0.0'
   s.add_runtime_dependency 'jwt', '~> 2.2.0'
   s.add_runtime_dependency 'zache', '~> 0.12.0'
-  s.add_runtime_dependency 'addressable', '~> 2.7.0'
+  s.add_runtime_dependency 'addressable', '~> 2.8.0'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
This bumps the dependency version on the addressable gem, as version 2.7 is covered by CVE-2021-32740

Also covered by a GHSA at https://github.com/advisories/GHSA-jxhc-q857-3j6g

Once this passes, we should probably bump the gem version and release an updated gem so that users of this gem can upgrade addressable.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
