### PR TITLE
Relax version constraint on addressable to avoid CVE-2021-32740

### DIFF
--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rest-client', '~> 2.0.0'
   s.add_runtime_dependency 'jwt', '~> 2.2.0'
   s.add_runtime_dependency 'zache', '~> 0.12.0'
-  s.add_runtime_dependency 'addressable', '~> 2.7.0'
+  s.add_runtime_dependency 'addressable', '~> 2.7'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
Relax version constraint on addressable to avoid CVE-2021-32740

Fixes https://github.com/auth0/ruby-auth0/issues/277