### PR TITLE
Do not lock dependencies to minor version

### DIFF
--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'rest-client', '~> 2.0'
+  s.add_runtime_dependency 'rest-client', '~> 2.0.2' #2.1.0 has breaking changes
   s.add_runtime_dependency 'jwt', '~> 2.2'
   s.add_runtime_dependency 'zache', '~> 0.12'
   s.add_runtime_dependency 'addressable', '~> 2.8'

--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'rest-client', '~> 2.0.0'
-  s.add_runtime_dependency 'jwt', '~> 2.2.0'
-  s.add_runtime_dependency 'zache', '~> 0.12.0'
-  s.add_runtime_dependency 'addressable', '~> 2.8.0'
+  s.add_runtime_dependency 'rest-client', '~> 2.0'
+  s.add_runtime_dependency 'jwt', '~> 2.2'
+  s.add_runtime_dependency 'zache', '~> 0.12'
+  s.add_runtime_dependency 'addressable', '~> 2.8'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake', '~> 13.0'
@@ -27,10 +27,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-rspec', '~> 4.5' unless ENV['CIRCLECI']
   s.add_development_dependency 'dotenv-rails', '~> 2.0'
   s.add_development_dependency 'pry', '~> 0.10'
-  s.add_development_dependency 'pry-nav', '~> 0.2.4'
+  s.add_development_dependency 'pry-nav', '~> 0.2'
   s.add_development_dependency 'rspec', '~> 3.5'
   s.add_development_dependency 'rack-test', '~> 0.6'
-  s.add_development_dependency 'rack', '~> 2.1.2'
+  s.add_development_dependency 'rack', '~> 2.1'
   s.add_development_dependency 'simplecov', '~> 0.9'
   s.add_development_dependency 'faker', '~> 2.0'
   s.add_development_dependency 'gem-release', '~> 0.7'


### PR DESCRIPTION
Overly restrictive version locks will [cause unnecessary issues for downstream applications](https://github.com/auth0/ruby-auth0/issues/277). All gems should be following semver, such that minor version bumps are completely backwards compatible. By fuzzy locking to the minor version that you need, you both allow upgrading to compatible newer versions, while also ensuring the inclusion of functionality that may have been introduced in a minor version.