### PR TITLE
Ensure email param is properly encoded in `delete_connection_user` [SDK-2660]

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ begin
 rescue Auth0::InvalidIdToken => e
   # In this case the ID Token contents should not be trusted
 end
+```
 
 For more information, please read [Work with Tokens and Organizations](https://auth0.com/docs/organizations/using-tokens) on Auth0 Docs.
 

--- a/lib/auth0/api/v2/connections.rb
+++ b/lib/auth0/api/v2/connections.rb
@@ -81,8 +81,11 @@ module Auth0
         def delete_connection_user(connection_id, user_email)
           raise Auth0::InvalidParameter, 'Must supply a valid connection id' if connection_id.to_s.empty?
           raise Auth0::InvalidParameter, 'Must supply a valid user email' if user_email.to_s.empty?
-          path = "#{connections_path}/#{connection_id}/users?email=#{user_email}"
-          delete(path)
+          path = "#{connections_path}/#{connection_id}/users"
+          request_params = {
+            email: user_email
+          }
+          delete(path, request_params)
         end
 
         # Updates a connection. Updates the fields specified in the body parameter.

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connection/_filters/should_exclude_the_fields_indicated.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connection/_filters/should_exclude_the_fields_indicated.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_LW7vB80FsVmRF4fN?fields=name,id&include_fields=false
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_n8MJ02x2Zs0JBUWN?fields=name,id&include_fields=false
     body:
       encoding: US-ASCII
       string: ''
@@ -12,52 +12,64 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.3.1
+      - rest-client/2.0.2 (darwin20.2.0 x86_64) ruby/2.7.2p137
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjEuMiIsImVudiI6eyJydWJ5IjoiMi43LjIifX0=
       Authorization:
       - Bearer API_TOKEN
-      Host:
-      - auth0-sdk-tests.auth0.com
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 05 Oct 2018 20:17:17 GMT
+      - Tue, 20 Jul 2021 02:14:49 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
-      X-Ratelimit-Limit:
-      - '10'
-      X-Ratelimit-Remaining:
-      - '7'
-      X-Ratelimit-Reset:
-      - '1538770639'
-      Vary:
-      - origin,accept-encoding
+      Cf-Ray:
+      - 6718ada05caf0d20-LAX
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
-      - max-age=15724800
-      X-Robots-Tag:
-      - noindex, nofollow, nosnippet, noarchive
+      - max-age=31536000
+      Vary:
+      - origin,accept-encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Ot-Baggage-Auth0-Request-Id:
+      - 6718ada05caf0d20
+      Ot-Tracer-Sampled:
+      - 'true'
+      Ot-Tracer-Spanid:
+      - 25f1c5cc01ec17ff
+      Ot-Tracer-Traceid:
+      - 1a4dd66f250d867d
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1626747290'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA0WOQQrCQAxF75J1BXHZrRdw4U5kSKdpHZgmJckoRXp3p4q6
-        SnifvPwnyOxJ2KB9wjTgNjB6uhO0roUaUPKiHIhVcg5G7olH+6RrAzOaPUT7
-        k+QUF2hhFOmhgU6LUxhEI4VZxSlub75Sc0WncQl3Unvzw/qn1YLFb/uqSRZ6
-        mTBxiML8lQyYrVqIscvUh5gTsddOl+vWF/O07XAm8+PvaqelW7wiuK4ve7Zv
-        I/YAAAA=
-    http_version: 
-  recorded_at: Fri, 05 Oct 2018 20:17:17 GMT
-recorded_with: VCR 4.0.0
+        H4sIAAAAAAAAAz2PwWrDQAxE/0VnF5xQCvGtFAK9BdqSQAjLei27G9aSkbQpbsi/d5M2PQk0o6eZM/BkkUmhOcPY++vwweIJoTHJWIGgZSGHJJySUzSLNOiveqlg8qpfLN2GUwwzNDAwd1CBmnjDYXYnFC0PoFlW0Eo2dD1LQDcJGwa7SX+s+02h+GyfdcFEdR2PPpILTHT39z5piYbk24SdCykiWcm0h2Wgbc7D07df7xbHesDFZrU6Pn9QvX7cveVXOFwb+TTe3O+o9vLPfZDczlZWcLj8ALzgJBkYAQAA
+  recorded_at: Tue, 20 Jul 2021 02:14:49 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connection/_filters/should_include_the_fields_indicated.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connection/_filters/should_include_the_fields_indicated.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_LW7vB80FsVmRF4fN?fields=name,id&include_fields=true
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_n8MJ02x2Zs0JBUWN?fields=name,id&include_fields=true
     body:
       encoding: US-ASCII
       string: ''
@@ -12,50 +12,64 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.3.1
+      - rest-client/2.0.2 (darwin20.2.0 x86_64) ruby/2.7.2p137
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjEuMiIsImVudiI6eyJydWJ5IjoiMi43LjIifX0=
       Authorization:
       - Bearer API_TOKEN
-      Host:
-      - auth0-sdk-tests.auth0.com
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 05 Oct 2018 20:17:17 GMT
+      - Tue, 20 Jul 2021 02:14:49 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
-      X-Ratelimit-Limit:
-      - '10'
-      X-Ratelimit-Remaining:
-      - '8'
-      X-Ratelimit-Reset:
-      - '1538770639'
-      Vary:
-      - origin,accept-encoding
+      Cf-Ray:
+      - 6718ad9ea9c23173-LAX
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
-      - max-age=15724800
-      X-Robots-Tag:
-      - noindex, nofollow, nosnippet, noarchive
+      - max-age=31536000
+      Vary:
+      - origin,accept-encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Ot-Baggage-Auth0-Request-Id:
+      - 6718ad9ea9c23173
+      Ot-Tracer-Sampled:
+      - 'true'
+      Ot-Tracer-Spanid:
+      - 1bb309994137c31b
+      Ot-Tracer-Traceid:
+      - 0747a0f428a15eca
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1626747290'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA6tWykxRslJKzs+L9wk3L3OyMHArDssNcjNJ81PSUcpLzE0F
-        yoakFpc45+flpSaXZObn6RaVJlWWAIWACjKL41PycxMz8+KT4fJKVmmJOcWp
-        tQCC/XfpWwAAAA==
-    http_version: 
-  recorded_at: Fri, 05 Oct 2018 20:17:17 GMT
-recorded_with: VCR 4.0.0
+        H4sIAAAAAAAAA6tWykxRslJKzs+Lz7Pw9TIwqjCKKjbwcgoN91PSUcpLzE0FyoakFpc45+flpSaXZObn6RaVJlWWAIWACjKL41PycxMz8+KT4fJKVmmJOcWptQAJ916aWwAAAA==
+  recorded_at: Tue, 20 Jul 2021 02:14:49 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connection/should_find_the_correct_connection.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connection/should_find_the_correct_connection.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_LW7vB80FsVmRF4fN?include_fields=true
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_n8MJ02x2Zs0JBUWN?include_fields=true
     body:
       encoding: US-ASCII
       string: ''
@@ -12,52 +12,64 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.3.1
+      - rest-client/2.0.2 (darwin20.2.0 x86_64) ruby/2.7.2p137
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjEuMiIsImVudiI6eyJydWJ5IjoiMi43LjIifX0=
       Authorization:
       - Bearer API_TOKEN
-      Host:
-      - auth0-sdk-tests.auth0.com
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 05 Oct 2018 20:17:16 GMT
+      - Tue, 20 Jul 2021 02:14:49 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
-      X-Ratelimit-Limit:
-      - '10'
-      X-Ratelimit-Remaining:
-      - '9'
-      X-Ratelimit-Reset:
-      - '1538770638'
-      Vary:
-      - origin,accept-encoding
+      Cf-Ray:
+      - 6718ad9c7dbfeadf-LAX
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
-      - max-age=15724800
-      X-Robots-Tag:
-      - noindex, nofollow, nosnippet, noarchive
+      - max-age=31536000
+      Vary:
+      - origin,accept-encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Ot-Baggage-Auth0-Request-Id:
+      - 6718ad9c7dbfeadf
+      Ot-Tracer-Sampled:
+      - 'true'
+      Ot-Tracer-Spanid:
+      - 4bb13e5568acac26
+      Ot-Tracer-Traceid:
+      - 505815493146e9d4
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1626747290'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA3WPQUvEQAyF/0vOFRYRlB4V9iQii+hhWYbpNK0DM0lJMl3K
-        0v/u1EU9eUp4L3zv5QKxhxYCk3v+uJ8fH3Z7fc+H/d3wAg3wZJFJob1AHvw2
-        fLA4I7QmBRsQtCLkkIRTcopmkUa9umsDk1c9s/SvnGJYaszI3FdsJ8XQDSwB
-        3SRsGLaYH6iaeMNxcTOKfuu3659aKb7Y565iyOfaBN5Q7YmJrpQbKd1iVaoH
-        UV3P2Udy4deHdvBJawyS7xL2LqSIZLX08bQ95FPe9n+pp/ULPGRgtDMBAAA=
-    http_version: 
-  recorded_at: Fri, 05 Oct 2018 20:17:16 GMT
-recorded_with: VCR 4.0.0
+        H4sIAAAAAAAAA3WPQUsDMRCF/8ucV9guInZvKhQsKAUtLUoJ2WR2TcnOLMmkupb+d9NWvfU0MO/N997swVmowTApun2al9VX9RbL+f1y9QwF8CCOKUK9h77Vx6GNuB1CLSFhAQElBVJIgb1XEUUcdfGsHgoYdIyfHOyCvTNjjumYbcZGCVqwG9UOQ8wBUFcFNCEJqpaDQTUEFjRykn5ZfzeZopN8lBlDus9N4BWjPDDR+eAqpGaUvMoGF5XlXjtS5l+HutU+5u5IuvFolfEOSXLpd6gMrVLqbr71bD3Zlh1OFtPp9m5J5ex6/ZIeYXN8Wfv+5L6Uuzn8AGJlr3xVAQAA
+  recorded_at: Tue, 20 Jul 2021 02:14:49 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/_filters/should_include_previously-created_connection_when_filtered.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/_filters/should_include_previously-created_connection_when_filtered.yml
@@ -12,48 +12,68 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.5.1
+      - rest-client/2.0.2 (darwin20.2.0 x86_64) ruby/2.7.2p137
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjEuMiIsImVudiI6eyJydWJ5IjoiMi43LjIifX0=
       Authorization:
       - Bearer API_TOKEN
-      Host:
-      - auth0-sdk-tests.auth0.com
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 04 Oct 2018 15:41:06 GMT
+      - Tue, 20 Jul 2021 02:14:50 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
-      X-Ratelimit-Limit:
-      - '10'
-      X-Ratelimit-Remaining:
-      - '5'
-      X-Ratelimit-Reset:
-      - '1538667669'
-      Vary:
-      - origin,accept-encoding
+      Cf-Ray:
+      - 6718ada5cb713673-LAX
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
+      Link:
+      - <http://auth0-sdk-tests.auth0.com/api/v2/connections?strategy=auth0&page=0&per_page=50>;
+        rel="first", <http://auth0-sdk-tests.auth0.com/api/v2/connections?strategy=auth0&page=0&per_page=50>;
+        rel="last"
       Strict-Transport-Security:
-      - max-age=15724800
-      X-Robots-Tag:
-      - noindex, nofollow, nosnippet, noarchive
+      - max-age=31536000
+      Vary:
+      - origin,accept-encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Ot-Baggage-Auth0-Request-Id:
+      - 6718ada5cb713673
+      Ot-Tracer-Sampled:
+      - 'true'
+      Ot-Tracer-Spanid:
+      - 15d3346a2a6da9b3
+      Ot-Tracer-Traceid:
+      - 3876ed7d19efac4a
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1626747291'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA62SXZOaMBSG/0uu3Znw0VX3DlBRUYsfKLjjMIEEzS4SSQIu7vjfG2237UU77Ux7lcw5b97zJnme3wHF4AmkrIjDN9PjFUMJNM91HoWgBdhJUlYI8PQOjhm6LSiVtCbgSfKKtAAnsuJFTArO8jwWREpa7MXX7rUFEl5JEmeMpyQ+cSZJerP7OCwkR5Lsm7gmXNzr+vVHVYVClTxAlaJARzURBILw2/bBR0KcGccPlhKQQtIU3X1bgIoYsyOiRawuVHyMy1Au7mFRflThnv/stGsBUqAkJzhOc6oa92OGc5539Oac4XIzo5qvocx6RC94OIjcgzkSKoBRWqMg77hT7IZanSZ8u33VR1i/TIIB2rS7SmKbzB/mELbXSHNtvA3pcoj6TlCuN6+4G74qiSMCUzMmHZkF1Cv36LPt0L7FIgTlfOFAQ0nc6SxcQkdmx0dzfFrPN9740tad2SEYUteaJ0qyxmP4aQ9rrbFhgEva8+yJlQVvs1Kz9XRoKknaG5fpfuj4nRMrt00vi7QD9ILB6LG++Ktudnv8E+wvqrY7HLAZ3NDNxEoGo2z2srxE3kDARknKS9IzxLipVpGjh8bIKvU6jYx27qe4u4I3kC4L305RVgWD2RSZpRhH85cMe9sAdrd5e1mC3bX1E4oenLp9g4YrTNDUO5n/juLp20/7LKfpDa49Yxj8b0RXREjnO3kPvEoaqUp/T+bvDH4J5O66+wKG5I4YwAMAAA==
-    http_version: 
-  recorded_at: Thu, 04 Oct 2018 15:41:06 GMT
-recorded_with: VCR 3.0.3
+        H4sIAAAAAAAAA62X167sxpWG32VfHwHMQXdkN3MzZxrCBnPOmYbffcgj2RgDNjyG5qrR4Fe1qv4V6y9//SqTr1+/4r77lpsWlg/VQNfFA11z+/rx1Q9L2Xfz169//Wqz8PkJ46Xc0q9fl2lNf3xN6bJO3XfaTX3TfM/pspRdPv/+9W8/vpJyDqMm/Z7LvFuHr1+zsJnvVUM4z3s/JVrflPF5W8/7PrmtzcsULml+fm/pNN92v36FHhPjWk7p/L3O6dSFbfqPbaJpXdLvrJ/i9HuY+iWNl5+L/jD+993u/cN1KYDbwO/Lv6x0Xu5/5fyd9G1Ydt/37bu/r/5j8ykNm/a+yV9+p3/78ZV2z12S77gp0255Pv32tx//S76OkEUAOqBgBkTadpU/L99/pdOfUuP1DwF+mdboXP5rgf7VBv9Ssy8o7tx1zbErZD2wAvIU1EiyouwOYBHPXIWvf1bVOxBpWvswApB9a3zvz6v6/6ue/UdU/qL94axfqBu4L1vG4c8t/s8y/sed/o2eGt9bYY4pUecvMDXTs3KwZR3YiSCzNTrdB5AGjGJ8fVt3tqYhUaaaILK2OXtreZxh63PG+aBPm0OwZh4+O7yjFc5Uga2WB168MIDhbsSTFMBinBzigvAc52HNJKs610gnN9yS78P8+HIlNLZfCBfvJSNvPa29AZWJuFxs0qZOD+lGHBLqdw8ZODXlXiDCWrhiDzVvHHfSBD6z34gadYDdC+p6Fgt4SvHEanqTu2cusk0xcvyNXLxnlXbXtrBi6AbK36fegCowmZQGlpcD3cge8FmRcFopWK2llh+wL+qehi+zXWPvdNJHF5Rc+QHFw97MWudFIwWFwwAee6+OFPssuhE5xJZB0b12SgMkJ+DOIufPEKpvunw5wCu7EQqaFuBKE5MvCLQ4AeLjtnVD+bQjoAj8Im9kHFhOodhM9RFE2rqCjQCIWdctpJgEkSj5RpjPVvqIefmah7YYK9CmzC4uR2bk0c989LhxRPBg1OIeB+ZBB8fukie6nGowcXshjcQHiUEEpNbIGT3lpRcwUriYhaPSmCgTjNPmgzjdfkiFCBrvmBy0mTcLYmYQBrlIKdjDRb2RVzi/OSF+mbOixvkLJpvtZL0SdJpAMyzhuZEd6/HssrxavD5NJJJ80Wx6BLa2MigSDlOPA1roleNdt3Fayg4uHLe1VQkj5Hvqbh/Y9YRUsqmoQxBSZJQGOQlWDq55ZHhyPJkAtjyGwka4Dv4aNPrd5tsiTmHdupOEygqUNbpt3ggUspiCOS04M00UU1VcMIXBlV6WbekKseCNiNM+jy93x94ITAxlmezSQqqX3EhzpjiddSM6vEx+ltcEU6dx9qmCbKsdhQQ7wUd6I3u64bhmLwizogTV6x2zYM2R47WUBpuZOlnzxicDnHZqYXzWfRDS2shrlBSr0vRKELy19/q8EbBX7U7rRLiTKsUcDK3tQYFbN71pJNZmnti1tyyyI4GJZ6MdDaJBQAg4EMtnMlXjNFe/EfTgDR2RzQXAaM3PzGCnLg5ppFFiZnvdyp9RV11JOquxe9i03vNgiGyYwSFwg4Hkhj4+UuaqJ/sMZvE6qaGtpqnJnFsbUT8stif7Uxl8UV0U/hV6tnwch9YgQxsjFm6coMnuQfoY2kg/EzEJcokClVxSmaw3n6j8xm761IqE8QSDGeX4BrOu3eafz5nkx2VI68FGM/xZpwu9Ed7DEsbPFX7UPDqFDuzApJFciRZX21EJ7OcsUE0Rtd678Duutbd5K1wcewAsnG0uGls8ZRlZMireghITi/ZtAINYrvkOXMTKbaxui0/UARMkKDqR5RVSiVTpq35ZVAsdVSB7yd3rRs7du4IGX0NZ3OK4KSg2hYoW1OQRrdMReI4LrLCCrzH9XhznVK5dSSnZWsULBCXeNTr6cWP9zkcjByG71ePG44Q7xgajNmi2tl9gKdwI1r19yQuSbp4kASl8Kj5aHQiSbXSjK7HqG4HHyy3azMJ9TR4YSOXGUHgXygJuhRQN3lNU1SIKwvQOxroQOfRNdAgpU/p2tJIuJP3Q38hb9BstTEgUFJhIQI+orKuBPlxTP2mCMZ9pxT1IM5qPYTU4FGVW/ZKxGIQqaDAGoMDCn9m4+8gJqcCsZEB50BMRHzLzDjhP1g0QYJ+++DbYhKXQYk3l15jrVpzzAJ+NL3hjLZ2smhupYmJNQu3skE46UuTNgi1CBmdUR3FmTubjI+myUFSV2Tl0qJ20Lse3Z9FAT5xV9mBFnzFAk4sNn6VFVUQPoTMdH8oPXAdBVShsIupPNsZqKyGEBN61r1orpwRYljAaYm87yp/27slppx3cqIDRTZTE0l9XZsic0sCQCH1FsoM9SUJDftjDnb4KydteiZ4LOj0OT7LODVr0qMdH00A7EuOQliV4zFigfrLEqwOz09JLQ44jN5JYa8hDWGWCZRWekzKp0ClV/BpyOp+Z4uNGeDmRNnccClcD7fW+6IXU3uBkGTiV297uPo1PhqpPSFRdjbAKnvFhDgWRqo4ZAMwt5P2sL1kPxIAKVR65pRKnjGrCujyKzr1ziQX1GMrgw4GwuZ6WKhOvfCSFFms968APEkc25WnCJRzWMZhWgehCMwbjXpoKeMt8CrSpHLTEbgRx2a1t9SuY54PkkLXZz+k4XcEfhSlAiGdmMK1CsFZUkszrc9dREVfnxGWLhh3Kt+z9HE7mOBdaJ3WMbtNpe14+oylJ6/DiD+PAYedxYy9MjSHkYvsZgUNAIjP0pbrQqmr0cqmMnhKUiREs89gwJyDuBgpgdmmb1fiBxmylKuNTgkCJwWNXBE4AGCpguHvEm0uGQF0NmI3uLH4cwC4L7EAiCVCckhxRUFZVuYlEzhTaRWj502ws8ABRHai34WKg9/lSqVZNV87CSqwl0fWpdZ6WqfpMOc3nTF0iRlgDlO1qnSDfJXPz8RGsTeMJoapE2rtClOQaErHX5DzPLfpldY8uHTWa7LjBuuYAJiB9zATaTkGV77mKMK7libqDghX94FOvoAMwH/i6kyJFAhis3I87rR9DK50XMSlo+psI8c7CHPiNoRtPhUKO+lT2DG32TH+2gtJSS09CXEWOhjp6o4T4DWsIeHn6tDPgr08BRg3eUPeIBKe7XLzD8RONzE7XyfNWCFK4hQx5DAFuxjagnDI68dgkwxwAt09Ie0LqbsfrYSchxtXrvr9opyfRhnqpWT4KNfqoq5QAT0xt+ErLIybml0bA2zFXdc6nWURmx43U5zVhOC40rSmir2CMHWngegIfeTFoPvtTpUBrXkTVO/xBdZkDhtixcr2zUQjwBRo2/kj3H18h90RWohsqEziGMj7mKrfmJ3Xi+AKm0IJS2zMzEMCQ+ldKBSHWGMvBmL0GMKzt2bU1MjX5hNRrthEQ/hBLZpfSmIcq/SoZqvdDYNGNFwA/nh4Axlhxjmd7BXBL90NFrJAp1T0MSuwMPG50EhFAc2ADTxqwk7F8S/SHyuxDGUEainnkZ5ugBLshODnhPHCLoykIakhIoOtjs6GL/xxDr+gNz+K5Wv4L8mCBGqEt9mG80eKEtICnqF6GRsdhttqsIofIOIu+XmWJFNgAefdD88lGTlY8E3gtWYsh4uDoriReOPRSCpsvOUp/pub4LY533b/dN/RjcL4zHywAyWYFbLs0i3ymZvi16wR07lkyukoJamCYUVhYJTzrcwUizPcz8Lf/AcL3JQGdEAAA
+  recorded_at: Tue, 20 Jul 2021 02:14:50 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/_filters/should_should_exclude_the_fields_indicated_from_filtered_results.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/_filters/should_should_exclude_the_fields_indicated_from_filtered_results.yml
@@ -12,48 +12,68 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.5.1
+      - rest-client/2.0.2 (darwin20.2.0 x86_64) ruby/2.7.2p137
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjEuMiIsImVudiI6eyJydWJ5IjoiMi43LjIifX0=
       Authorization:
       - Bearer API_TOKEN
-      Host:
-      - auth0-sdk-tests.auth0.com
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 04 Oct 2018 15:41:06 GMT
+      - Tue, 20 Jul 2021 02:14:51 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
-      X-Ratelimit-Limit:
-      - '10'
-      X-Ratelimit-Remaining:
-      - '3'
-      X-Ratelimit-Reset:
-      - '1538667671'
-      Vary:
-      - origin,accept-encoding
+      Cf-Ray:
+      - 6718ada988f531f7-LAX
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
+      Link:
+      - <http://auth0-sdk-tests.auth0.com/api/v2/connections?strategy=auth0&fields=name&include_fields=false&page=0&per_page=50>;
+        rel="first", <http://auth0-sdk-tests.auth0.com/api/v2/connections?strategy=auth0&fields=name&include_fields=false&page=0&per_page=50>;
+        rel="last"
       Strict-Transport-Security:
-      - max-age=15724800
-      X-Robots-Tag:
-      - noindex, nofollow, nosnippet, noarchive
+      - max-age=31536000
+      Vary:
+      - origin,accept-encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Ot-Baggage-Auth0-Request-Id:
+      - 6718ada988f531f7
+      Ot-Tracer-Sampled:
+      - 'true'
+      Ot-Tracer-Spanid:
+      - 43a569100a7a6d38
+      Ot-Tracer-Traceid:
+      - 1968a4b72d72e843
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1626747292'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA72SX4+iMBTFvwvPTlL+7KjzBiigKIujKDgxpNCinUEqbcHBid99qruzuw/7tsk+NTn3d25Pcs/Lh0KQ8qTktErjd8NnDYUZMM5tmcRKT6EnQWjFlacP5VjA2wNzQVqsPAnW4J7CsGhYleKK0bJMORaCVHv+Y3rtKRlrBE4LynKcnhgVOL+t+zJzwaDA+y5tMeN3Xbv+VmUo2IgDkCkITxE9QlKlMmb1taSAJb9HgOVRfvmiRByzCh7xQwg5P1OGHky5AFeC5PBu2fUUXMGsxCjNSyIHd5tunxcDrTsXqN4ERA1VWJiP8BV5TuIejAmXAfTanETlwJ0jN1bbPGPb7Zs2QdplFjlw0x9KxDJo6JUA9NdQdS20jcnSg2M7qtebNzSM3yRi88hQ9dlAFBHx6z38btlkbNIEArF4toEuEXcexEtgi+L4aExP68XGn176mh0cIo+45iKTyBpNwbc9aNXOAhGqyci3ZmYRvQe1amm5Z0gkH03rfO/Z4eBE6203KhL1APzImTy2l3A1LCRSncD4uem7nkMDsCGbmZk5kyJ4XV4S3+Ggk0h9yUY6n3bNKrG1WJ+Ytdbmid4vwxwNV+BWj8tzaOWwaCInmEOj5tNk8VogfxuB4bbsL2tld+39UTAfzN2xTuIVwnDun4x/L9jp56VDWpL8Vpk9pUj538VbYS7sX8ADa7JOSOnvfdtdd58RXtJxdQMAAA==
-    http_version: 
-  recorded_at: Thu, 04 Oct 2018 15:41:06 GMT
-recorded_with: VCR 3.0.3
+        H4sIAAAAAAAAA72Xx67k2JVF/+WNswB6kzMygj7oPYXCA733ngX9u8hUSZAGQqMhdI9iEIv3XO59HP/yx1eZfP38ivvuW25aWD5UA10XD3TN7evHVz8sZd/NXz//+Gqz8PkJ46Xc0q+fy7SmP76mdFmn7jvtpr5pvud0Wcoun//+719/fCXlHEZN+j2XebcOXz+zsJnvp4Zwnvd+SrS+KePzjp73fXJHm5cpXNL8/N7Sab7jfv2EnhDjWk7p/L3O6dSFbfrPY6JpXdLvrJ/i9HuY+iWNl18P/Rn8H6fd54frUgB3gHL+Tvo2LLvv+327f/B/HjelYdPed//Ll5XOy9fvP77S7rl98h03Zdotz1+///XHvwjWEbIIQAcUzIBI267y3wv2v1Lm//T9X/8EfpvW6Fz+oyRfUNy565pjV8h6YAXkKaiRZEXZHcAinrkKX/8umncg0rT2YQQg+9b43n8v2v+vOPafafib9qdXv1H3AbcYZRz+euQ/qKTxvRXmmBJ1/gJTMz0rB1vWgZ0IMluj030BacAoxte3dWdrGhJlqgkia5uzt5bHGbZ2Tx4c9GlzCNbMw2eHd7TCmSqw1fLAixcGMNyNeJICWIyTQ1wQnuM8rJlkVeca6eSGW/J9mR9froTG9gvh4r1k5K2ntTegMhGXi03a1Okh3YhDQv3uIQOnptwLRFgLV+yh5o3jzvTAZ/YbUaMOsHtBXc9iAU8pnlhNb3L3zEW2KUaOv5GL96zS7toWVgzdQPn71htQBSaT0sDycqAb2QM+KxJOKwWrtdTyA/ZF3dPwZbZr7J1O+uiCkis/oHjYm1nrvGikoHAYwGPv1ZFin0U3IofYMii6105pgOQE3Fnk/BlC9U2XLwd4ZTdCQdMCXGli8gWBFidAfNy2biifdgQUgV/kjYwDyykUm6k+gkhbV7ARADHruoUUkyASJd8I89lKHzEvX/PQFmMF2pTZxeXIjDz6mY8eG0cED0Yt7nFgHnRw7C55osupBhO3F9JIfJAYREBqjZzRU156ASOFi1k4Ko2JMsE4bT6I0+2HVIig8Y7JQZt5syBmBmGQi5SCPVzUG3mF85sT4pc5K2qcv2Cy2U7WK0GnCTTDEp43smM9nl2WV4vXp4lEki+aTY/A1lYGRcJh6jGghV453nUbp6Xs4MJxW1uVMEK+p+72gV1PSiWbijoEIUVGaZCTYOXgmkeGJ8eTCWDLEyhshOvgr0Gj322+LeIU1q07SaisQFmj2+aNQCGLKZjTgjPTRDFVxQVTGFzpZdmWrhAL3og47fP4cnfsjcDEUJbJLi2kesmNNGeK01k3osPL5Gd5TTB1GmefKsi22lFIsBN8pDeyZ2iNa/aCMCtKUL3eMQvWHDleS2mwmamTNW98KsBppxbGZ90HIa2NvEZJsSpNrwTBW3uvzxsBe9XutE6EO6lSzMHQ2h4UuHXTm0ZibebJXXvLIjsSmHg22tEgGgSEgAOxfCZTNU5z9RtBD97QEdlcAIzW/MwMdurikEYaJWa21638lXXVlaSzGruHTes9D4bIhhkcAjcYSG7o45EyVz3ZZzCL10kNbTVNTebc2oj6YbE92Z/O4IvqovCv0LPl4zi0BhnaGLFw4wRNdg/SJ9BG+pmISZBLFKjkkspkvflE5Td206dWJIwnGcwoxzeYde02/3zOJD8uQ1oPNprhzzpd6I3wHpYwfq7wo+bRKXRgByaN5Eq0uNqOSmA/d4Fqiqj13oXfca29zVvh4tgDYOFsc9HY4kY6ZMmoeAtKTCzatwEMYrnmO3ARK7exui0+WQdMkKDoRJZXSCVSpa/6ZVEtdFSB7CV3rxs5d+8KGnwNZXGL46ag2BQqWlCTR7ROR+C5LrDCCr7G9HtxnFO5diWlZGsVLxCUeNfo6MfG+p2PRg5CdqvHjccJd44NRm3QbG2/wFK4Eax7+5IXJN08SQJS+FR8tDoQJNvoRldi1TcCj5dbtJmF+5o8MJDKjaHwLpQF3AopGrynqapFFITpnYx1IXLom+gQUqb07WglXUj6ob+Rt+g3WpiQKCgwkYAeUVlXA324pn7SBGM+K4Z7kGY0H8NqcCjKrPolYzEIVdBgDECBhb+qcfeRE1KBWcmA8qAnIj5k5h1wnqwbIMA+0+5tsAlLocWayq8x16045wE+G1/wxlo6WTU3UsXEmoTa2SGddKTImwVbhAzOqI7izJzMxyPpslBUldk5dKidtC7Ht2fRQE+cVfZgRZ/hrsnFhs/Soiqih9CZjg/lB66DoCoUNhH1pxpjtZUQQgLv3letlVMCLEsYDbG3HeVPe/fUtNMOblTA6CZKYumvKzNkTmlgSIS+ItnBniKhIT/s4U5fheRtr0TPBZ0ehydZ5wYtetTj0TTQjsQ4pGUJHjMWqJ8s8erA7LT00pDjyI0k1hryEFaZYFmF56RMKnRKFb+GnM5npvjYCC8n0uaOQ+FqoL3eF72Q2hucLAOnctvb3WfwyVD1CYmqqxFWwTM+zKEgUtUxA4C5hbxf/SXrgRhQocojt1TilFFNWJdH0bl3LrGgnkAZfDgQNtfTUmXilY+k0GKtZx34QeLIpjxDuITDOgbTKhBdaMZg3EtTAW+ZT4E2lYOW2I0gLru1rX4F83yQHLI2+zkdpyv4ozAFCPHsDKZVCNaKSpJ5fe4+KuLqnLhs0bBD+Za9X8vJHOdC66SO0W06bc/LZzQlaR1e/GEcOOw8NvbC1BhCLrafETgEJDJDX6oLrapGL5fK6GlBmRjBMo8NcwLibqAAZpe2WY0faMxWqjI+LQiUGDx2ReAEgKEChntGvLlkCNTVgNnoruLHAHZZYAcSSYDilOSIgrKqyk0kcqbQLkLLn2FjgQeI6kC9DRcDvc+XSrVqunIWVmItia5Pr/O0TNVnymk+Z+oSMcIaoGxX6wT5Lpmbj0ewNo0nhKoSae8KUZJrSMRek/M8t+iX1T26dNRosuMG65oDmID0MRNoOwVVvvcqwriWJ+sOClb0g0+9gg7AfODrTooUCWCwcj/usn4CrXRexKSg6W8ixDsLc+A3hm48FQo56lPZs7TZM/3ZCkpLLT0JcRU5GurojRLiN6wh4OWZ086Avz4FGDV4Q90rEpzucvEOx080MjtdJ8uNBCncQoY8hgA3YxtQThmdeGySYQ6A2yekPSl1j+P1sJMQ4+p131+005NoQ73ULB+FGn3UVUqAJ6Y2fKXlERPzSyPg7ZirOufTLCKz40bq85owHBea1hTRVzDGjjRwPYGPvBg0n/3pUqA1L6LqHf6guswBQ+xYud7ZKAT4Ag0bf6T7H78t7o2sRDdUJnAMZXzMVW7NT+rE8QVMoQWltmdnIIAh9a+UCkKsMZaDMXsNYFjbs2trZGrySanXbCMg/CGWzC6lMQ9V+lUyVO+HwKIbLwB+nB4Axlhxjmd7BXBL90NFrJAp1b0MSuwMPDY6iQigObCBJw3YyVi+JfpDZfahjCANxTzya0xQgt0QnJxwHrjF0RQENSQk0PWx2dDFf62hV/SGZ/FcLf8FebBAjdAW+zDeaHFCWsDTVC9Do+MwW21WkUNknEVfr7JECmyAvOeh+VQjJyueCbyWrMUQcXB0VxIvHHophc2XHKU/W3P8Fse779/2Df0YnO/MBwtAslkB2y7NIp+tGX7tOgGde5aMrlKCGhhmFBZWCc/6XIEI8/1x9/vfAFfMG5REEAAA
+  recorded_at: Tue, 20 Jul 2021 02:14:51 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/_filters/should_should_include_the_fields_indicated_from_filtered_results.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/_filters/should_should_include_the_fields_indicated_from_filtered_results.yml
@@ -12,48 +12,68 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.5.1
+      - rest-client/2.0.2 (darwin20.2.0 x86_64) ruby/2.7.2p137
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjEuMiIsImVudiI6eyJydWJ5IjoiMi43LjIifX0=
       Authorization:
       - Bearer API_TOKEN
-      Host:
-      - auth0-sdk-tests.auth0.com
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 04 Oct 2018 15:41:06 GMT
+      - Tue, 20 Jul 2021 02:14:50 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
-      X-Ratelimit-Limit:
-      - '10'
-      X-Ratelimit-Remaining:
-      - '4'
-      X-Ratelimit-Reset:
-      - '1538667670'
-      Vary:
-      - origin,accept-encoding
+      Cf-Ray:
+      - 6718ada76f58323e-LAX
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
+      Link:
+      - <http://auth0-sdk-tests.auth0.com/api/v2/connections?strategy=auth0&fields=name&include_fields=true&page=0&per_page=50>;
+        rel="first", <http://auth0-sdk-tests.auth0.com/api/v2/connections?strategy=auth0&fields=name&include_fields=true&page=0&per_page=50>;
+        rel="last"
       Strict-Transport-Security:
-      - max-age=15724800
-      X-Robots-Tag:
-      - noindex, nofollow, nosnippet, noarchive
+      - max-age=31536000
+      Vary:
+      - origin,accept-encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Ot-Baggage-Auth0-Request-Id:
+      - 6718ada76f58323e
+      Ot-Tracer-Sampled:
+      - 'true'
+      Ot-Tracer-Spanid:
+      - 62e7cb956fc072cc
+      Ot-Tracer-Traceid:
+      - 3f541eaa685fcec5
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1626747291'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA4uuVspMUbJSSs7Pi4+oMPEuKs1PTDIwKS/LiYxQ0lHKS8xNBcqGFqcWgZi6AYnFxeX5RSm6jqUlGal5JZnJiSWZ+XlAlZnF8Sn5uYmZefFAo/JSk8HCVmmJOcWptTpIlngb+Lq7GmdGhKSkJvp6F5ggLAlJLS5xhuvVLSpNqiwBChEwOxYAA7Uw2cIAAAA=
-    http_version: 
-  recorded_at: Thu, 04 Oct 2018 15:41:06 GMT
-recorded_with: VCR 3.0.3
+        H4sIAAAAAAAAA4uuVspMUbJSSs7Pi/fNyTX2rfAPMi0tiTAMDy5T0lHKS8xNBcqGpBaXAHmZxfEp+bmJmXnxQOV5qcklmfl5SlZpiTnFqbU6SAblWfh6GRhVGEUVG3g5hYb7oRrkDNerW1SaVFlCmtkRFSbeRaX5iUkGJuVlOZERCLNDi1OLQEzdgMTi4vL8ohRdx9KSjNS8kszkRLBp+C2JBQAk8HzQCwEAAA==
+  recorded_at: Tue, 20 Jul 2021 02:14:50 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/should_include_the_previously_created_connection.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/should_include_the_previously_created_connection.yml
@@ -12,48 +12,68 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.5.1
+      - rest-client/2.0.2 (darwin20.2.0 x86_64) ruby/2.7.2p137
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjEuMiIsImVudiI6eyJydWJ5IjoiMi43LjIifX0=
       Authorization:
       - Bearer API_TOKEN
-      Host:
-      - auth0-sdk-tests.auth0.com
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 04 Oct 2018 15:41:06 GMT
+      - Tue, 20 Jul 2021 02:14:50 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
-      X-Ratelimit-Limit:
-      - '10'
-      X-Ratelimit-Remaining:
-      - '5'
-      X-Ratelimit-Reset:
-      - '1538667669'
-      Vary:
-      - origin,accept-encoding
+      Cf-Ray:
+      - 6718ada36ae53101-LAX
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
+      Link:
+      - <http://auth0-sdk-tests.auth0.com/api/v2/connections?page=0&per_page=50>;
+        rel="first", <http://auth0-sdk-tests.auth0.com/api/v2/connections?page=0&per_page=50>;
+        rel="last"
       Strict-Transport-Security:
-      - max-age=15724800
-      X-Robots-Tag:
-      - noindex, nofollow, nosnippet, noarchive
+      - max-age=31536000
+      Vary:
+      - origin,accept-encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Ot-Baggage-Auth0-Request-Id:
+      - 6718ada36ae53101
+      Ot-Tracer-Sampled:
+      - 'true'
+      Ot-Tracer-Spanid:
+      - 28c647886d286e44
+      Ot-Tracer-Traceid:
+      - 70573da1644fb6a1
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1626747291'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA+2TXXOaQBSG/wvXZmb5qF93iIqKWoyiYMZhlmXBTZAFdsFgJv+9S9IktdNOO9NOr3oFc87Lu4f3PHv3JJFQ6kuIpr4FFuZIJe4mxHBhZZrUkmjGCU2Z1H+SThFsHhBxUmGpz4sSt6QC87JIfZwWNEl8hjknacxeu88tKYOMnWkR2jQhqBbHxJSGwjYoSo79iBYI+1lBOUbNMW+mjBeQ47j2K1ywl7ry/FEVLrDkRyBsUngSk0gbzLhB0/TV5aYog5qLkhAQ5of0BEnqo/e+1I9gwl5mh8lJzHr3U4NDS8IpDBIc+ighOOWN+vDc+iYz91GzipLCAGjnKvHcP8/s72bjMFw0rzf211Xc6EIgfoUg+OL72yH90umHaUmqcV51lfochfluSWRbhpHehvfhZOyZR23KxABqrk+dpGsuQtOVKxQU+/2DMg2Vy9wZw12nJyQDjdqTBIDOFsrmINy7ZD2BI8PJt7uHsOc+CInBHE1W510eOcTKY/h5YJCRTj0I+OrWAKqQmIuluwYGj05tbZZtVztrdukoxvLoTIiprwIh2YYz8CkGlVwPgBPmZGgN5nrkPC5zeaCgSXMn0HCWo3hi2N2M5vt6GHnyEVjOeNquLvamFzXhZ2B0W3bMyZguwY7s5nownkbL+/XFs8YM1EKSX4KhymZ1ufEMxVWneq5UyFM7iY3C3gY0IF1u7QGCUemMlwuo5Wzmre6j0No7oLdPOutcukbR7sENaI/iagM6eIp21yhiseHkjSLBVUSSdyIZohlulvUq+ugfrtkStzdO8A1tGFM+GPu+/JtAXX/2n55/T8/hC1zkMgH+BQAA
-    http_version: 
-  recorded_at: Thu, 04 Oct 2018 15:41:06 GMT
-recorded_with: VCR 3.0.3
+        H4sIAAAAAAAAA+1Y2W7jSLL9lYGfy13cl36jFkoiJW4iKYqNhsCdFHcm98H8+2XKdlfZ3YXuQc3ThWFAliJPZkSciIzMjN/+/ZT4T78+eWVxa479udcIwoxBI5fo5unLU1m1SVmAp1///RTkTpI9/do2XfDlCXhlFSzTHsIvHQiam5s0bew708uvIXBB0gYvP+IyD9pyKF5+ZaXnwFVfgWWT3uIEtGXzOjXwuxfAe7Hjll17y1+XdJ1i+VssdHxwawJn8SF0MrCY5mVJULS3h1coQ2AUixA4RqA0gxILvgF9dQv6BfLHjBerkjQA70VVCdpvIqjkBtrlX/4e9mrKKzMvLsD1P6wWNWVXfdQQl235QQZap+0+yPrED77D5Yu+KLhVy8cH+2A43HJ8PztsFkb8D0u+BujN7FfWQOA1wcLME8lirEeHFBYGXoDRGOn7LOaEBOl7oUv71MJk1blZAuIPZrxJHya/Ny4pQBLFH3l5i+s7At+S6Z3wLY3eCd+y6U0I8+GFn/z7GD/M8m5VU4ZJFnwTQ9sX5QA4UVJEH+QgLoclMUD7Ef/Cv9c6H1zxHrvluQiGj2x/l+XvzH+b4pZl+pGY16G8A4n310PvSX4MNUH24APEycdsa50oCvxblTnex7yBfr0lz8dtEDkLPw+VfdJO78demPA/JvcrQUXZJmHyEp8fOBcmbbGw/37wTxXgHWWLh0kEB6syS9rE++CK1y1T8tekh8EDPybo5gft4jT4UT7ADVosfnS5GzQ/BIHOBV6TVO/dfBjjdP5ihrcsEbSPHPiwB/6zlNK2cdogWnx8CpfAwERYNlfhwB3xvSQBN79cQlTcllpdBN5L0n9TluXLor99m/H7l6egcNxsic7L5obDv//ny3cFX2EdHaG2Ua8jdHDwLn9f8H97lS4kvO6k3799fUDfexSVZZQFz6XTtTH2za2P4n/o2/tpf+ngE6bsS92JKMktri3OgRWQRj5JbcM/nPiUbBZtYkVx26vadwOfrjDhxGW2q/cg3CiRF1JdsUDAuJqMHUFloDoO+EDe6e3dNuRkpOM1hWx3C8QSJUTfmhG2s52pBlUXivp96lyV7Wn9tBjz5ekikp6xJnbekGxPfblSNoi8dXeRkAVZGoziAjFZrBwsotrJwW6NErxOS0aV7rUREVb2dTssENktEKM8yN0Ut+gkeg2vqFl0mSKBz+J6t18g897SE6PIc1zSVI3cL1b3yN0+b4MV0q5NSPFg78PY3ynJQc91OTmiZZyWK3w+551nTWYAeSHZbl+RtFOew9xcr4iYo3GE9qx1wQpl6C6Qk0O1laRaeRPYRMTghc6CY+XIm1WyNpF1uEA4rGmROfDP+5gh4wlhjpc8zbjryjyQBL5mF0hd8TuJ40P5ShBiX8S8i2DbrusdbusTIndaINtjn1yJ83xVLDKn+MPqfOLby44N2bEEexeGsSZou1a8kkZApaJ1MZ+aVdKkqH8pD4ErQIiHEijXuWZtSWs1xon4Quk0Kda+1OD06gwhZjGMYiyg2sZjKwXszzEDtsSWmFnRHpxWXiBrB2x2B299BpLsRWuczfqJtxLUzGxF0w/QI8NTPXDh93K8PmauwO7jrFddNDekShJpnIMByLF1RBdFv1MCvrrgXp7q90ONXS15MEZqhinl9zJpMozoaonGNgc9QrvI1ayT15wRqoWKnOwwj/u5UlabPOpboXHS/NKI5EnCwkw1zgsEc3hKoswcBdvM9bi7F29jbZdYYdgHHcajC0RoBlCvLwO1IXCmShJ/EFtWnk+ZCELJLPQFouJtcw2jlNmmgRce73bYp6bEosXhSpRa2MMAdOEao3TXJ9V0oHRcMU9el4iVsW2Kk2LVcAeYeZPjNFCvKKbkrpVJAXUPgtkn6NwY0mmBoKVsFEoh4IV4l86VpuQleth1vZplIm9sYe4afega7mHrAS2vNSYjUAwZCf26DWVlp1zUBUKOe00lTucWoVbKNTzbAzfviEysxS0wuj55ZN199gMge5fRWKnlHnWIntJ2BJ5RKNuTMEYSuJdsGeI8nfop1qcrrjmD3CDkI08N/gArw1WQW2m/dizjNI6jkhFV7hE6rU3omR/sACrq2WsoUCJ2YWJSvLBSo2/2vrzv+V5tcoHRYDKc3Yjucf5i5NHxOPnROGtiN/IuwI9dM5MLZG9R/vYaSftasVYBNlIjJdZsx+S0nNeSbUBbsJRjUrW84BsvVTbnheF4HGyk3RnnVuFjWHCJNuS83k4oIc43GlIJSRcNyMx0u55XDQFmHdJgB0llwuhO3AUuucrXJL63K/eO8vOpWC+QabBmO6M75yT0npfFHB9gcY4qp5pMgxqB5iIdLtGdt9q0pjlJ8yAF3EnvhBlFxf1FK1YwjOkmqrUIxYxc9TJrd1hyrNJSbcWnxhpNDguEKjZX0bL9AjTigYivnDfmKmL7fX1xZ1+H5yBez5c4D3X6qpyqLSbvauewiaUW7WPRrSxYVOXYtZ1gScY0FnbkhikI9sSp/ZiL6sEvq3KBbIRrpjg+S6KHrXsgRzdJ79VqvJzVacVszxLM3ZE9u2CsOm1HkttOnU+Uh2J3rNIqJKacx24crsSEyQiQQiQZVw3jjaftxt5ZJ1VDER6BijTe5zky7oLTuo5U3Yv2yD6s13jP6yp7h0fp3WM631GmgijEMSA2PJoTrD25qeuF5+YMYyTOOknKJx44Jjew+mxeDSBo5ETz0mB3pLVAlFPc00BsZUmwiFWo0lVyxFPbvscS7wsq3I2enIsEI6JL7bt3dzNBeJ7RMmbIC+7aDAXc02ZeXdwYJ3tBFJJr122r0Ew0inDJtXsyKbhJVtjVKfFC7Q7+xuiYcmcXqudMbBppK8HiYIyaamWKW5PV9YO1rWPy6rdeZ+J805ZiFdHwHebrnbPHqPsZTe7O1EiNjE3ifd85O3UfngUYRrydiDwyTY6WbWW9mVctq2zQRtdoLjKsAV5X5hN2PzrMvUgJXqLDvRNhtivLdYggIMesR30JS8RDZOxusX0g7qRa9vnLniRBac5CzEFFIT6aGAXSpr2HwhzV7CGncksf6ZGliV6Ch3CCO6mHBndbuGCAwmkrCA50vj3GZHY3yQS+h4gL3+e5OtsAjOyO6LJhasbpcrjWh8YmGHhnOOvxQe9IUTzPx6WOCrQM/AsfZ3yVbE7W43ICvOiQm4GpFb26MkB7rM+i2FXr/aiNNG7CMJaHJtMOkZAfa2Q8EO7ZuYpprNzvtRWJiQtLUCi4+GlPVcBH6YstIeciyMOUHkmPv8tSDUsQKm5p7yIgE4JUd6RazojNzq9sudNw3l12MQwA37a4iQkswu0kf3Tt5H5PeoGJtrEyM0oEDxsdHVFSRdK+mrfYZlrLXC4H3U6nEipnyQ7WOksJZRVwZnacggvjEbyGnox712DXCxudYYxwpaknjJRF1hgkJmE7h/GsLNrvd6066wXkpeDqM1/3uKqYyBkRj2cf66eDfFruVYw2tzDrRg6X1HEfWPHKRqNqnxaiK4nIlkqGcdnWUFG3imKPPSjqhnHoQqdMfEOR/Z5zDhF55UJ4aTPA6tjHnBLoqu/QMjFm3FhqCbbvqYzBW3hOmxW9Psaom9EZt1yR8GA4xRunPrr1dlilfrtA7ADPMe1UO8gOUD2SNOHKt3g/pEyENiZMgSm1HMfdaPgOtUu7YVivzJIlM24th1F9SEnIrpQge6bJnXWQjB4D1gqD9yO4p9E+CF02HBdIOs0NRdOHLD8L5NquPVOsdiVD13vBzo4DrFKoDlpBtsZrJV+2I47x9f1iTZnEoGtUM2hIHeYVl66LqNnhLfSORAGqsOydMwqEJ6xzB0vzNiF78sTQFLm9Uhdp4XziJppu0QBrSa6HdwYGqYLrHHC2Q2VaO27PpYJsecMyUr3epixMqTUwCBQ/Mm1oJGIdOfJqnWy58uograqtERxGukK2Wkfv9nwpIZfkcuRc/hBK9+UyKPIAgWE0fQEhI6RHpxVi+HWyEVdHLjRGqUZXmLcnHscEdzAyZnfydxbae25j2yl28LH5aPDOhX5cQ2d3gwNh6vTrGrPwA1djvXfF6UzxfFZHYFGdNWXlOWFn8NLJIWogXNV76Iu2gbDLeXiGu3F3kqwzsm7DnCKEylQvojDT2FqKjX2y41R4a/Y2Qr3U/SV8VVnb0ya8ojEiGvyB6mdFZ+GtGV8PKoNNQ+jXFylBFdQJOcq5+3v+uouJA3h6/3JbX4UNck0ie/Rp4PTz+5dbOz2ac2FTFu3Ni53lSZU9fWvaLZ9F4v/r9dn2r7cXXQJAB1+5T3HbVuDXr18Hp3pOM/DsB3mJoPArfHg9ww/kGUF/ceauCV77SOCX5YULz7IhBbeuSX5mma+/DEGWPadFORRfX4x9XpwOk6hrHk/3r1DL0/tWHweXg+dKsrjZB820WJH9lBXLYm2ZBsUtKPyqTGAzqeiy7KWNkBRh+d3AT6h5ffF+fVsVXisWdNkk80sP5H+q5W3p4On9Q71MfO/b+zwNpgx2Zf7mZf7ojzng5nZt+514CUGVOdPtT4t9e8m/yf5Bk+KU5fhplDWyay30cu7fp3oeOvDfozv1RwuxCdqugcQ1ZZbdQNC2SRGBP/oTi31Q5Q0kUdFV37V1ABjKxlfKLPFemxf+0zeWbktWgYf7GFRRd0kTLLm+hO3F0ddl3KZrg1tYNl4A243tG2d/bo44ryn7ypMegPaf90Ie6H9AX8GcBAQbMRsgwsq4SD9P33/F00+xsf6DgOemc6f2vyborxb4Qdvo7w7A96xaIyE2Xem4CDH02dX6eVb/t+wZr1n5rLwG6xnWx8XZ127sP6fxb1f6bMN9tuE+23CfbbjPNtxnG+6zDffZhvtsw3224T7bcJ9tuP+vbbjf/w+oh9snMycAAA==
+  recorded_at: Tue, 20 Jul 2021 02:14:50 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/should_not_be_empty.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_connections/should_not_be_empty.yml
@@ -12,48 +12,68 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.5.1
+      - rest-client/2.0.2 (darwin20.2.0 x86_64) ruby/2.7.2p137
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjEuMiIsImVudiI6eyJydWJ5IjoiMi43LjIifX0=
       Authorization:
       - Bearer API_TOKEN
-      Host:
-      - auth0-sdk-tests.auth0.com
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 04 Oct 2018 15:41:05 GMT
+      - Tue, 20 Jul 2021 02:14:50 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
-      X-Ratelimit-Limit:
-      - '10'
-      X-Ratelimit-Remaining:
-      - '6'
-      X-Ratelimit-Reset:
-      - '1538667668'
-      Vary:
-      - origin,accept-encoding
+      Cf-Ray:
+      - 6718ada1de0c051b-LAX
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
+      Link:
+      - <http://auth0-sdk-tests.auth0.com/api/v2/connections?page=0&per_page=50>;
+        rel="first", <http://auth0-sdk-tests.auth0.com/api/v2/connections?page=0&per_page=50>;
+        rel="last"
       Strict-Transport-Security:
-      - max-age=15724800
-      X-Robots-Tag:
-      - noindex, nofollow, nosnippet, noarchive
+      - max-age=31536000
+      Vary:
+      - origin,accept-encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Ot-Baggage-Auth0-Request-Id:
+      - 6718ada1de0c051b
+      Ot-Tracer-Sampled:
+      - 'true'
+      Ot-Tracer-Spanid:
+      - 72570d713bb68b34
+      Ot-Tracer-Traceid:
+      - 1a2a73cc2f516c87
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1626747291'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA+2TXXOaQBSG/wvXZmb5qF93iIqKWoyiYMZhlmXBTZAFdsFgJv+9S9IktdNOO9NOr3oFc87Lu4f3PHv3JJFQ6kuIpr4FFuZIJe4mxHBhZZrUkmjGCU2Z1H+SThFsHhBxUmGpz4sSt6QC87JIfZwWNEl8hjknacxeu88tKYOMnWkR2jQhqBbHxJSGwjYoSo79iBYI+1lBOUbNMW+mjBeQ47j2K1ywl7ry/FEVLrDkRyBsUngSk0gbzLhB0/TV5aYog5qLkhAQ5of0BEnqo/e+1I9gwl5mh8lJzHr3U4NDS8IpDBIc+ighOOWN+vDc+iYz91GzipLCAGjnKvHcP8/s72bjMFw0rzf211Xc6EIgfoUg+OL72yH90umHaUmqcV51lfochfluSWRbhpHehvfhZOyZR23KxABqrk+dpGsuQtOVKxQU+/2DMg2Vy9wZw12nJyQDjdqTBIDOFsrmINy7ZD2BI8PJt7uHsOc+CInBHE1W510eOcTKY/h5YJCRTj0I+OrWAKqQmIuluwYGj05tbZZtVztrdukoxvLoTIiprwIh2YYz8CkGlVwPgBPmZGgN5nrkPC5zeaCgSXMn0HCWo3hi2N2M5vt6GHnyEVjOeNquLvamFzXhZ2B0W3bMyZguwY7s5nownkbL+/XFs8YM1EKSX4KhymZ1ufEMxVWneq5UyFM7iY3C3gY0IF1u7QGCUemMlwuo5Wzmre6j0No7oLdPOutcukbR7sENaI/iagM6eIp21yhiseHkjSLBVUSSdyIZohlulvUq+ugfrtkStzdO8A1tGFM+GPu+/JtAXX/2n55/T8/hC1zkMgH+BQAA
-    http_version: 
-  recorded_at: Thu, 04 Oct 2018 15:41:05 GMT
-recorded_with: VCR 3.0.3
+        H4sIAAAAAAAAA+1Y2W7jSLL9lYGfy13cl36jFkoiJW4iKYqNhsCdFHcm98H8+2XKdlfZ3YXuQc3ThWFAliJPZkSciIzMjN/+/ZT4T78+eWVxa479udcIwoxBI5fo5unLU1m1SVmAp1///RTkTpI9/do2XfDlCXhlFSzTHsIvHQiam5s0bew708uvIXBB0gYvP+IyD9pyKF5+ZaXnwFVfgWWT3uIEtGXzOjXwuxfAe7Hjll17y1+XdJ1i+VssdHxwawJn8SF0MrCY5mVJULS3h1coQ2AUixA4RqA0gxILvgF9dQv6BfLHjBerkjQA70VVCdpvIqjkBtrlX/4e9mrKKzMvLsD1P6wWNWVXfdQQl235QQZap+0+yPrED77D5Yu+KLhVy8cH+2A43HJ8PztsFkb8D0u+BujN7FfWQOA1wcLME8lirEeHFBYGXoDRGOn7LOaEBOl7oUv71MJk1blZAuIPZrxJHya/Ny4pQBLFH3l5i+s7At+S6Z3wLY3eCd+y6U0I8+GFn/z7GD/M8m5VU4ZJFnwTQ9sX5QA4UVJEH+QgLoclMUD7Ef/Cv9c6H1zxHrvluQiGj2x/l+XvzH+b4pZl+pGY16G8A4n310PvSX4MNUH24APEycdsa50oCvxblTnex7yBfr0lz8dtEDkLPw+VfdJO78demPA/JvcrQUXZJmHyEp8fOBcmbbGw/37wTxXgHWWLh0kEB6syS9rE++CK1y1T8tekh8EDPybo5gft4jT4UT7ADVosfnS5GzQ/BIHOBV6TVO/dfBjjdP5ihrcsEbSPHPiwB/6zlNK2cdogWnx8CpfAwERYNlfhwB3xvSQBN79cQlTcllpdBN5L0n9TluXLor99m/H7l6egcNxsic7L5obDv//ny3cFX2EdHaG2Ua8jdHDwLn9f8H97lS4kvO6k3799fUDfexSVZZQFz6XTtTH2za2P4n/o2/tpf+ngE6bsS92JKMktri3OgRWQRj5JbcM/nPiUbBZtYkVx26vadwOfrjDhxGW2q/cg3CiRF1JdsUDAuJqMHUFloDoO+EDe6e3dNuRkpOM1hWx3C8QSJUTfmhG2s52pBlUXivp96lyV7Wn9tBjz5ekikp6xJnbekGxPfblSNoi8dXeRkAVZGoziAjFZrBwsotrJwW6NErxOS0aV7rUREVb2dTssENktEKM8yN0Ut+gkeg2vqFl0mSKBz+J6t18g897SE6PIc1zSVI3cL1b3yN0+b4MV0q5NSPFg78PY3ynJQc91OTmiZZyWK3w+551nTWYAeSHZbl+RtFOew9xcr4iYo3GE9qx1wQpl6C6Qk0O1laRaeRPYRMTghc6CY+XIm1WyNpF1uEA4rGmROfDP+5gh4wlhjpc8zbjryjyQBL5mF0hd8TuJ40P5ShBiX8S8i2DbrusdbusTIndaINtjn1yJ83xVLDKn+MPqfOLby44N2bEEexeGsSZou1a8kkZApaJ1MZ+aVdKkqH8pD4ErQIiHEijXuWZtSWs1xon4Quk0Kda+1OD06gwhZjGMYiyg2sZjKwXszzEDtsSWmFnRHpxWXiBrB2x2B299BpLsRWuczfqJtxLUzGxF0w/QI8NTPXDh93K8PmauwO7jrFddNDekShJpnIMByLF1RBdFv1MCvrrgXp7q90ONXS15MEZqhinl9zJpMozoaonGNgc9QrvI1ayT15wRqoWKnOwwj/u5UlabPOpboXHS/NKI5EnCwkw1zgsEc3hKoswcBdvM9bi7F29jbZdYYdgHHcajC0RoBlCvLwO1IXCmShJ/EFtWnk+ZCELJLPQFouJtcw2jlNmmgRce73bYp6bEosXhSpRa2MMAdOEao3TXJ9V0oHRcMU9el4iVsW2Kk2LVcAeYeZPjNFCvKKbkrpVJAXUPgtkn6NwY0mmBoKVsFEoh4IV4l86VpuQleth1vZplIm9sYe4afega7mHrAS2vNSYjUAwZCf26DWVlp1zUBUKOe00lTucWoVbKNTzbAzfviEysxS0wuj55ZN199gMge5fRWKnlHnWIntJ2BJ5RKNuTMEYSuJdsGeI8nfop1qcrrjmD3CDkI08N/gArw1WQW2m/dizjNI6jkhFV7hE6rU3omR/sACrq2WsoUCJ2YWJSvLBSo2/2vrzv+V5tcoHRYDKc3Yjucf5i5NHxOPnROGtiN/IuwI9dM5MLZG9R/vYaSftasVYBNlIjJdZsx+S0nNeSbUBbsJRjUrW84BsvVTbnheF4HGyk3RnnVuFjWHCJNuS83k4oIc43GlIJSRcNyMx0u55XDQFmHdJgB0llwuhO3AUuucrXJL63K/eO8vOpWC+QabBmO6M75yT0npfFHB9gcY4qp5pMgxqB5iIdLtGdt9q0pjlJ8yAF3EnvhBlFxf1FK1YwjOkmqrUIxYxc9TJrd1hyrNJSbcWnxhpNDguEKjZX0bL9AjTigYivnDfmKmL7fX1xZ1+H5yBez5c4D3X6qpyqLSbvauewiaUW7WPRrSxYVOXYtZ1gScY0FnbkhikI9sSp/ZiL6sEvq3KBbIRrpjg+S6KHrXsgRzdJ79VqvJzVacVszxLM3ZE9u2CsOm1HkttOnU+Uh2J3rNIqJKacx24crsSEyQiQQiQZVw3jjaftxt5ZJ1VDER6BijTe5zky7oLTuo5U3Yv2yD6s13jP6yp7h0fp3WM631GmgijEMSA2PJoTrD25qeuF5+YMYyTOOknKJx44Jjew+mxeDSBo5ETz0mB3pLVAlFPc00BsZUmwiFWo0lVyxFPbvscS7wsq3I2enIsEI6JL7bt3dzNBeJ7RMmbIC+7aDAXc02ZeXdwYJ3tBFJJr122r0Ew0inDJtXsyKbhJVtjVKfFC7Q7+xuiYcmcXqudMbBppK8HiYIyaamWKW5PV9YO1rWPy6rdeZ+J805ZiFdHwHebrnbPHqPsZTe7O1EiNjE3ifd85O3UfngUYRrydiDwyTY6WbWW9mVctq2zQRtdoLjKsAV5X5hN2PzrMvUgJXqLDvRNhtivLdYggIMesR30JS8RDZOxusX0g7qRa9vnLniRBac5CzEFFIT6aGAXSpr2HwhzV7CGncksf6ZGliV6Ch3CCO6mHBndbuGCAwmkrCA50vj3GZHY3yQS+h4gL3+e5OtsAjOyO6LJhasbpcrjWh8YmGHhnOOvxQe9IUTzPx6WOCrQM/AsfZ3yVbE7W43ICvOiQm4GpFb26MkB7rM+i2FXr/aiNNG7CMJaHJtMOkZAfa2Q8EO7ZuYpprNzvtRWJiQtLUCi4+GlPVcBH6YstIeciyMOUHkmPv8tSDUsQKm5p7yIgE4JUd6RazojNzq9sudNw3l12MQwA37a4iQkswu0kf3Tt5H5PeoGJtrEyM0oEDxsdHVFSRdK+mrfYZlrLXC4H3U6nEipnyQ7WOksJZRVwZnacggvjEbyGnox712DXCxudYYxwpaknjJRF1hgkJmE7h/GsLNrvd6066wXkpeDqM1/3uKqYyBkRj2cf66eDfFruVYw2tzDrRg6X1HEfWPHKRqNqnxaiK4nIlkqGcdnWUFG3imKPPSjqhnHoQqdMfEOR/Z5zDhF55UJ4aTPA6tjHnBLoqu/QMjFm3FhqCbbvqYzBW3hOmxW9Psaom9EZt1yR8GA4xRunPrr1dlilfrtA7ADPMe1UO8gOUD2SNOHKt3g/pEyENiZMgSm1HMfdaPgOtUu7YVivzJIlM24th1F9SEnIrpQge6bJnXWQjB4D1gqD9yO4p9E+CF02HBdIOs0NRdOHLD8L5NquPVOsdiVD13vBzo4DrFKoDlpBtsZrJV+2I47x9f1iTZnEoGtUM2hIHeYVl66LqNnhLfSORAGqsOydMwqEJ6xzB0vzNiF78sTQFLm9Uhdp4XziJppu0QBrSa6HdwYGqYLrHHC2Q2VaO27PpYJsecMyUr3epixMqTUwCBQ/Mm1oJGIdOfJqnWy58uograqtERxGukK2Wkfv9nwpIZfkcuRc/hBK9+UyKPIAgWE0fQEhI6RHpxVi+HWyEVdHLjRGqUZXmLcnHscEdzAyZnfydxbae25j2yl28LH5aPDOhX5cQ2d3gwNh6vTrGrPwA1djvXfF6UzxfFZHYFGdNWXlOWFn8NLJIWogXNV76Iu2gbDLeXiGu3F3kqwzsm7DnCKEylQvojDT2FqKjX2y41R4a/Y2Qr3U/SV8VVnb0ya8ojEiGvyB6mdFZ+GtGV8PKoNNQ+jXFylBFdQJOcq5+3v+uouJA3h6/3JbX4UNck0ie/Rp4PTz+5dbOz2ac2FTFu3Ni53lSZU9fWvaLZ9F4v/r9dn2r7cXXQJAB1+5T3HbVuDXr18Hp3pOM/DsB3mJoPArfHg9ww/kGUF/ceauCV77SOCX5YULz7IhBbeuSX5mma+/DEGWPadFORRfX4x9XpwOk6hrHk/3r1DL0/tWHweXg+dKsrjZB820WJH9lBXLYm2ZBsUtKPyqTGAzqeiy7KWNkBRh+d3AT6h5ffF+fVsVXisWdNkk80sP5H+q5W3p4On9Q71MfO/b+zwNpgx2Zf7mZf7ojzng5nZt+514CUGVOdPtT4t9e8m/yf5Bk+KU5fhplDWyay30cu7fp3oeOvDfozv1RwuxCdqugcQ1ZZbdQNC2SRGBP/oTi31Q5Q0kUdFV37V1ABjKxlfKLPFemxf+0zeWbktWgYf7GFRRd0kTLLm+hO3F0ddl3KZrg1tYNl4A243tG2d/bo44ryn7ypMegPaf90Ie6H9AX8GcBAQbMRsgwsq4SD9P33/F00+xsf6DgOemc6f2vyborxb4Qdvo7w7A96xaIyE2Xem4CDH02dX6eVb/t+wZr1n5rLwG6xnWx8XZ127sP6fxb1f6bMN9tuE+23CfbbjPNtxnG+6zDffZhvtsw3224T7bcJ9tuP+vbbjf/w+oh9snMycAAA==
+  recorded_at: Tue, 20 Jul 2021 02:14:49 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_delete_connection/should_delete_the_connection.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_delete_connection/should_delete_the_connection.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_LW7vB80FsVmRF4fN
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_n8MJ02x2Zs0JBUWN
     body:
       encoding: US-ASCII
       string: ''
@@ -12,43 +12,64 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.3.1
+      - rest-client/2.0.2 (darwin20.2.0 x86_64) ruby/2.7.2p137
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjEuMiIsImVudiI6eyJydWJ5IjoiMi43LjIifX0=
       Authorization:
       - Bearer API_TOKEN
-      Host:
-      - auth0-sdk-tests.auth0.com
   response:
     status:
-      code: 204
-      message: No Content
+      code: 202
+      message: Accepted
     headers:
       Date:
-      - Fri, 05 Oct 2018 20:17:17 GMT
+      - Tue, 20 Jul 2021 02:14:52 GMT
       Content-Type:
       - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
-      X-Ratelimit-Limit:
-      - '10'
-      X-Ratelimit-Remaining:
-      - '6'
-      X-Ratelimit-Reset:
-      - '1538770640'
+      Cf-Ray:
+      - 6718adb058ffeb65-LAX
+      Cache-Control:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Strict-Transport-Security:
+      - max-age=31536000
       Vary:
       - origin,accept-encoding
-      Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
-      Strict-Transport-Security:
-      - max-age=15724800
-      X-Robots-Tag:
-      - noindex, nofollow, nosnippet, noarchive
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Ot-Baggage-Auth0-Request-Id:
+      - 6718adb058ffeb65
+      Ot-Tracer-Sampled:
+      - 'true'
+      Ot-Tracer-Spanid:
+      - 61710b70011a7381
+      Ot-Tracer-Traceid:
+      - 76fb49cf5f307bba
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1626747293'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
     body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 05 Oct 2018 20:17:17 GMT
-recorded_with: VCR 4.0.0
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAA6tWSknNSS1JTYlPLFGyUjIyMDLUNTDXNTIIMTCyMjSxMjXSMzY1iVKqBQBOPmWhKQAAAA==
+  recorded_at: Tue, 20 Jul 2021 02:14:52 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_delete_connection_user/should_delete_the_user_created.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_delete_connection_user/should_delete_the_user_created.yml
@@ -12,50 +12,70 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.5.1
+      - rest-client/2.0.2 (darwin20.2.0 x86_64) ruby/2.7.2p137
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjEuMiIsImVudiI6eyJydWJ5IjoiMi43LjIifX0=
       Authorization:
       - Bearer API_TOKEN
-      Host:
-      - auth0-sdk-tests.auth0.com
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Thu, 04 Oct 2018 15:41:06 GMT
+      - Tue, 20 Jul 2021 02:14:51 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
-      X-Ratelimit-Limit:
-      - '10'
-      X-Ratelimit-Remaining:
-      - '3'
-      X-Ratelimit-Reset:
-      - '1538667671'
-      Vary:
-      - origin,accept-encoding
+      Cf-Ray:
+      - 6718adab19a642b6-LAX
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
+      Link:
+      - <http://auth0-sdk-tests.auth0.com/api/v2/connections?page=0&per_page=50>;
+        rel="first", <http://auth0-sdk-tests.auth0.com/api/v2/connections?page=0&per_page=50>;
+        rel="last"
       Strict-Transport-Security:
-      - max-age=15724800
-      X-Robots-Tag:
-      - noindex, nofollow, nosnippet, noarchive
+      - max-age=31536000
+      Vary:
+      - origin,accept-encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Ot-Baggage-Auth0-Request-Id:
+      - 6718adab19a642b6
+      Ot-Tracer-Sampled:
+      - 'true'
+      Ot-Tracer-Spanid:
+      - 5ad493b861f7eff2
+      Ot-Tracer-Traceid:
+      - 452b6f063c800f3d
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1626747292'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA+2TXXOaQBSG/wvXZmb5qF93iIqKWoyiYMZhlmXBTZAFdsFgJv+9S9IktdNOO9NOr3oFc87Lu4f3PHv3JJFQ6kuIpr4FFuZIJe4mxHBhZZrUkmjGCU2Z1H+SThFsHhBxUmGpz4sSt6QC87JIfZwWNEl8hjknacxeu88tKYOMnWkR2jQhqBbHxJSGwjYoSo79iBYI+1lBOUbNMW+mjBeQ47j2K1ywl7ry/FEVLrDkRyBsUngSk0gbzLhB0/TV5aYog5qLkhAQ5of0BEnqo/e+1I9gwl5mh8lJzHr3U4NDS8IpDBIc+ighOOWN+vDc+iYz91GzipLCAGjnKvHcP8/s72bjMFw0rzf211Xc6EIgfoUg+OL72yH90umHaUmqcV51lfochfluSWRbhpHehvfhZOyZR23KxABqrk+dpGsuQtOVKxQU+/2DMg2Vy9wZw12nJyQDjdqTBIDOFsrmINy7ZD2BI8PJt7uHsOc+CInBHE1W510eOcTKY/h5YJCRTj0I+OrWAKqQmIuluwYGj05tbZZtVztrdukoxvLoTIiprwIh2YYz8CkGlVwPgBPmZGgN5nrkPC5zeaCgSXMn0HCWo3hi2N2M5vt6GHnyEVjOeNquLvamFzXhZ2B0W3bMyZguwY7s5nownkbL+/XFs8YM1EKSX4KhymZ1ufEMxVWneq5UyFM7iY3C3gY0IF1u7QGCUemMlwuo5Wzmre6j0No7oLdPOutcukbR7sENaI/iagM6eIp21yhiseHkjSLBVUSSdyIZohlulvUq+ugfrtkStzdO8A1tGFM+GPu+/JtAXX/2n55/T8/hC1zkMgH+BQAA
-    http_version: 
-  recorded_at: Thu, 04 Oct 2018 15:41:06 GMT
+        H4sIAAAAAAAAA+1Y2W7jSLL9lYGfy13cl36jFkoiJW4iKYqNhsCdFHcm98H8+2XKdlfZ3YXuQc3ThWFAliJPZkSciIzMjN/+/ZT4T78+eWVxa479udcIwoxBI5fo5unLU1m1SVmAp1///RTkTpI9/do2XfDlCXhlFSzTHsIvHQiam5s0bew708uvIXBB0gYvP+IyD9pyKF5+ZaXnwFVfgWWT3uIEtGXzOjXwuxfAe7Hjll17y1+XdJ1i+VssdHxwawJn8SF0MrCY5mVJULS3h1coQ2AUixA4RqA0gxILvgF9dQv6BfLHjBerkjQA70VVCdpvIqjkBtrlX/4e9mrKKzMvLsD1P6wWNWVXfdQQl235QQZap+0+yPrED77D5Yu+KLhVy8cH+2A43HJ8PztsFkb8D0u+BujN7FfWQOA1wcLME8lirEeHFBYGXoDRGOn7LOaEBOl7oUv71MJk1blZAuIPZrxJHya/Ny4pQBLFH3l5i+s7At+S6Z3wLY3eCd+y6U0I8+GFn/z7GD/M8m5VU4ZJFnwTQ9sX5QA4UVJEH+QgLoclMUD7Ef/Cv9c6H1zxHrvluQiGj2x/l+XvzH+b4pZl+pGY16G8A4n310PvSX4MNUH24APEycdsa50oCvxblTnex7yBfr0lz8dtEDkLPw+VfdJO78demPA/JvcrQUXZJmHyEp8fOBcmbbGw/37wTxXgHWWLh0kEB6syS9rE++CK1y1T8tekh8EDPybo5gft4jT4UT7ADVosfnS5GzQ/BIHOBV6TVO/dfBjjdP5ihrcsEbSPHPiwB/6zlNK2cdogWnx8CpfAwERYNlfhwB3xvSQBN79cQlTcllpdBN5L0n9TluXLor99m/H7l6egcNxsic7L5obDv//ny3cFX2EdHaG2Ua8jdHDwLn9f8H97lS4kvO6k3799fUDfexSVZZQFz6XTtTH2za2P4n/o2/tpf+ngE6bsS92JKMktri3OgRWQRj5JbcM/nPiUbBZtYkVx26vadwOfrjDhxGW2q/cg3CiRF1JdsUDAuJqMHUFloDoO+EDe6e3dNuRkpOM1hWx3C8QSJUTfmhG2s52pBlUXivp96lyV7Wn9tBjz5ekikp6xJnbekGxPfblSNoi8dXeRkAVZGoziAjFZrBwsotrJwW6NErxOS0aV7rUREVb2dTssENktEKM8yN0Ut+gkeg2vqFl0mSKBz+J6t18g897SE6PIc1zSVI3cL1b3yN0+b4MV0q5NSPFg78PY3ynJQc91OTmiZZyWK3w+551nTWYAeSHZbl+RtFOew9xcr4iYo3GE9qx1wQpl6C6Qk0O1laRaeRPYRMTghc6CY+XIm1WyNpF1uEA4rGmROfDP+5gh4wlhjpc8zbjryjyQBL5mF0hd8TuJ40P5ShBiX8S8i2DbrusdbusTIndaINtjn1yJ83xVLDKn+MPqfOLby44N2bEEexeGsSZou1a8kkZApaJ1MZ+aVdKkqH8pD4ErQIiHEijXuWZtSWs1xon4Quk0Kda+1OD06gwhZjGMYiyg2sZjKwXszzEDtsSWmFnRHpxWXiBrB2x2B299BpLsRWuczfqJtxLUzGxF0w/QI8NTPXDh93K8PmauwO7jrFddNDekShJpnIMByLF1RBdFv1MCvrrgXp7q90ONXS15MEZqhinl9zJpMozoaonGNgc9QrvI1ayT15wRqoWKnOwwj/u5UlabPOpboXHS/NKI5EnCwkw1zgsEc3hKoswcBdvM9bi7F29jbZdYYdgHHcajC0RoBlCvLwO1IXCmShJ/EFtWnk+ZCELJLPQFouJtcw2jlNmmgRce73bYp6bEosXhSpRa2MMAdOEao3TXJ9V0oHRcMU9el4iVsW2Kk2LVcAeYeZPjNFCvKKbkrpVJAXUPgtkn6NwY0mmBoKVsFEoh4IV4l86VpuQleth1vZplIm9sYe4afega7mHrAS2vNSYjUAwZCf26DWVlp1zUBUKOe00lTucWoVbKNTzbAzfviEysxS0wuj55ZN199gMge5fRWKnlHnWIntJ2BJ5RKNuTMEYSuJdsGeI8nfop1qcrrjmD3CDkI08N/gArw1WQW2m/dizjNI6jkhFV7hE6rU3omR/sACrq2WsoUCJ2YWJSvLBSo2/2vrzv+V5tcoHRYDKc3Yjucf5i5NHxOPnROGtiN/IuwI9dM5MLZG9R/vYaSftasVYBNlIjJdZsx+S0nNeSbUBbsJRjUrW84BsvVTbnheF4HGyk3RnnVuFjWHCJNuS83k4oIc43GlIJSRcNyMx0u55XDQFmHdJgB0llwuhO3AUuucrXJL63K/eO8vOpWC+QabBmO6M75yT0npfFHB9gcY4qp5pMgxqB5iIdLtGdt9q0pjlJ8yAF3EnvhBlFxf1FK1YwjOkmqrUIxYxc9TJrd1hyrNJSbcWnxhpNDguEKjZX0bL9AjTigYivnDfmKmL7fX1xZ1+H5yBez5c4D3X6qpyqLSbvauewiaUW7WPRrSxYVOXYtZ1gScY0FnbkhikI9sSp/ZiL6sEvq3KBbIRrpjg+S6KHrXsgRzdJ79VqvJzVacVszxLM3ZE9u2CsOm1HkttOnU+Uh2J3rNIqJKacx24crsSEyQiQQiQZVw3jjaftxt5ZJ1VDER6BijTe5zky7oLTuo5U3Yv2yD6s13jP6yp7h0fp3WM631GmgijEMSA2PJoTrD25qeuF5+YMYyTOOknKJx44Jjew+mxeDSBo5ETz0mB3pLVAlFPc00BsZUmwiFWo0lVyxFPbvscS7wsq3I2enIsEI6JL7bt3dzNBeJ7RMmbIC+7aDAXc02ZeXdwYJ3tBFJJr122r0Ew0inDJtXsyKbhJVtjVKfFC7Q7+xuiYcmcXqudMbBppK8HiYIyaamWKW5PV9YO1rWPy6rdeZ+J805ZiFdHwHebrnbPHqPsZTe7O1EiNjE3ifd85O3UfngUYRrydiDwyTY6WbWW9mVctq2zQRtdoLjKsAV5X5hN2PzrMvUgJXqLDvRNhtivLdYggIMesR30JS8RDZOxusX0g7qRa9vnLniRBac5CzEFFIT6aGAXSpr2HwhzV7CGncksf6ZGliV6Ch3CCO6mHBndbuGCAwmkrCA50vj3GZHY3yQS+h4gL3+e5OtsAjOyO6LJhasbpcrjWh8YmGHhnOOvxQe9IUTzPx6WOCrQM/AsfZ3yVbE7W43ICvOiQm4GpFb26MkB7rM+i2FXr/aiNNG7CMJaHJtMOkZAfa2Q8EO7ZuYpprNzvtRWJiQtLUCi4+GlPVcBH6YstIeciyMOUHkmPv8tSDUsQKm5p7yIgE4JUd6RazojNzq9sudNw3l12MQwA37a4iQkswu0kf3Tt5H5PeoGJtrEyM0oEDxsdHVFSRdK+mrfYZlrLXC4H3U6nEipnyQ7WOksJZRVwZnacggvjEbyGnox712DXCxudYYxwpaknjJRF1hgkJmE7h/GsLNrvd6066wXkpeDqM1/3uKqYyBkRj2cf66eDfFruVYw2tzDrRg6X1HEfWPHKRqNqnxaiK4nIlkqGcdnWUFG3imKPPSjqhnHoQqdMfEOR/Z5zDhF55UJ4aTPA6tjHnBLoqu/QMjFm3FhqCbbvqYzBW3hOmxW9Psaom9EZt1yR8GA4xRunPrr1dlilfrtA7ADPMe1UO8gOUD2SNOHKt3g/pEyENiZMgSm1HMfdaPgOtUu7YVivzJIlM24th1F9SEnIrpQge6bJnXWQjB4D1gqD9yO4p9E+CF02HBdIOs0NRdOHLD8L5NquPVOsdiVD13vBzo4DrFKoDlpBtsZrJV+2I47x9f1iTZnEoGtUM2hIHeYVl66LqNnhLfSORAGqsOydMwqEJ6xzB0vzNiF78sTQFLm9Uhdp4XziJppu0QBrSa6HdwYGqYLrHHC2Q2VaO27PpYJsecMyUr3epixMqTUwCBQ/Mm1oJGIdOfJqnWy58uograqtERxGukK2Wkfv9nwpIZfkcuRc/hBK9+UyKPIAgWE0fQEhI6RHpxVi+HWyEVdHLjRGqUZXmLcnHscEdzAyZnfydxbae25j2yl28LH5aPDOhX5cQ2d3gwNh6vTrGrPwA1djvXfF6UzxfFZHYFGdNWXlOWFn8NLJIWogXNV76Iu2gbDLeXiGu3F3kqwzsm7DnCKEylQvojDT2FqKjX2y41R4a/Y2Qr3U/SV8VVnb0ya8ojEiGvyB6mdFZ+GtGV8PKoNNQ+jXFylBFdQJOcq5+3v+uouJA3h6/3JbX4UNck0ie/Rp4PTz+5dbOz2ac2FTFu3Ni53lSZU9fWvaLZ9F4v/r9dn2r7cXXQJAB1+5T3HbVuDXr18Hp3pOM/DsB3mJoPArfHg9ww/kGUF/ceauCV77SOCX5YULz7IhBbeuSX5mma+/DEGWPadFORRfX4x9XpwOk6hrHk/3r1DL0/tWHweXg+dKsrjZB820WJH9lBXLYm2ZBsUtKPyqTGAzqeiy7KWNkBRh+d3AT6h5ffF+fVsVXisWdNkk80sP5H+q5W3p4On9Q71MfO/b+zwNpgx2Zf7mZf7ojzng5nZt+514CUGVOdPtT4t9e8m/yf5Bk+KU5fhplDWyay30cu7fp3oeOvDfozv1RwuxCdqugcQ1ZZbdQNC2SRGBP/oTi31Q5Q0kUdFV37V1ABjKxlfKLPFemxf+0zeWbktWgYf7GFRRd0kTLLm+hO3F0ddl3KZrg1tYNl4A243tG2d/bo44ryn7ypMegPaf90Ie6H9AX8GcBAQbMRsgwsq4SD9P33/F00+xsf6DgOemc6f2vyborxb4Qdvo7w7A96xaIyE2Xem4CDH02dX6eVb/t+wZr1n5rLwG6xnWx8XZ127sP6fxb1f6bMN9tuE+23CfbbjPNtxnG+6zDffZhvtsw3224T7bcJ9tuP+vbbjf/w+oh9snMycAAA==
+  recorded_at: Tue, 20 Jul 2021 02:14:51 GMT
 - request:
     method: delete
     uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_Xx4Kruoab04wvlYX/users?email=rubytest-rubytest-username@auth0.com
@@ -68,43 +88,59 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.5.1
+      - rest-client/2.0.2 (darwin20.2.0 x86_64) ruby/2.7.2p137
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjEuMiIsImVudiI6eyJydWJ5IjoiMi43LjIifX0=
       Authorization:
       - Bearer API_TOKEN
-      Host:
-      - auth0-sdk-tests.auth0.com
   response:
     status:
       code: 204
       message: No Content
     headers:
       Date:
-      - Thu, 04 Oct 2018 15:41:07 GMT
+      - Tue, 20 Jul 2021 02:14:51 GMT
       Content-Type:
       - application/json; charset=utf-8
       Connection:
       - keep-alive
-      X-Ratelimit-Limit:
-      - '10'
-      X-Ratelimit-Remaining:
-      - '2'
-      X-Ratelimit-Reset:
-      - '1538667672'
+      Cf-Ray:
+      - 6718adacca2242b7-LAX
+      Cache-Control:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000
       Vary:
       - origin,accept-encoding
-      Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
-      Strict-Transport-Security:
-      - max-age=15724800
-      X-Robots-Tag:
-      - noindex, nofollow, nosnippet, noarchive
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Ot-Baggage-Auth0-Request-Id:
+      - 6718adacca2242b7
+      Ot-Tracer-Sampled:
+      - 'true'
+      Ot-Tracer-Spanid:
+      - 6000ff4e6cf602a8
+      Ot-Tracer-Traceid:
+      - 6130cf9358b2cbdd
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1626747292'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
     body:
       encoding: UTF-8
       string: ''
-    http_version: 
-  recorded_at: Thu, 04 Oct 2018 15:41:07 GMT
-recorded_with: VCR 3.0.3
+  recorded_at: Tue, 20 Jul 2021 02:14:51 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_update_connection/should_update_the_connection.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_update_connection/should_update_the_connection.yml
@@ -2,65 +2,76 @@
 http_interactions:
 - request:
     method: patch
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_LW7vB80FsVmRF4fN
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_n8MJ02x2Zs0JBUWN?email=rubytest-rubytest-username@auth0.com
     body:
       encoding: UTF-8
-      string: '{"options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"excellent","brute_force_protection":true,"strategy_version":2}}'
+      string: '{"options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"excellent","strategy_version":2,"brute_force_protection":true}}'
     headers:
       Accept:
       - "*/*"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.3.1
+      - rest-client/2.0.2 (darwin20.2.0 x86_64) ruby/2.7.2p137
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjEuMiIsImVudiI6eyJydWJ5IjoiMi43LjIifX0=
       Authorization:
       - Bearer API_TOKEN
       Content-Length:
       - '145'
-      Host:
-      - auth0-sdk-tests.auth0.com
   response:
     status:
       code: 200
       message: OK
     headers:
       Date:
-      - Fri, 05 Oct 2018 20:17:17 GMT
+      - Tue, 20 Jul 2021 02:14:52 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
-      X-Ratelimit-Limit:
-      - '10'
-      X-Ratelimit-Remaining:
-      - '7'
-      X-Ratelimit-Reset:
-      - '1538770640'
-      Vary:
-      - origin,accept-encoding
+      Cf-Ray:
+      - 6718adae6d5fd392-LAX
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
-      - max-age=15724800
-      X-Robots-Tag:
-      - noindex, nofollow, nosnippet, noarchive
+      - max-age=31536000
+      Vary:
+      - origin,accept-encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Ot-Baggage-Auth0-Request-Id:
+      - 6718adae6d5fd392
+      Ot-Tracer-Sampled:
+      - 'true'
+      Ot-Tracer-Spanid:
+      - '01528db6466cb119'
+      Ot-Tracer-Traceid:
+      - 16b32c893374bd64
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1626747293'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA3WPQUvEQAyF/0vOFRYRlB4V9iQiInqQZUin6Towk5QkrZal
-        /92pi3rylPBe+N7LCVIPLUThcP96Pd/e7Pb2Up72V8MDNCCjJ2GD9gRlwG1g
-        9DQTtK4TNaDkk3IgVsk5GLknPtrZXRsY0exDtH+UnOJSY+gzUs7EXtmdTk5h
-        EI0URhWnuGX9kM0VnY5LmEntW79c/9SKwsnfdxXDWGodeCbzO2E+Uy506hav
-        Uj1IFnopmDjEXx/aAbPVGGLsMvUh5lRb1eZvh+0rzGXb/6Ue1i8UuRaiOAEA
-        AA==
-    http_version: 
-  recorded_at: Fri, 05 Oct 2018 20:17:17 GMT
-recorded_with: VCR 4.0.0
+        H4sIAAAAAAAAA3VPX0vDMBD/LvdcISsirm8qDBwoAx0byghpeq0Z6aVcLnN17LubbeqbTwf3+38A10AFNpCm26e5KvflW1Tz++XqGQoIg7hAEaoD9K05HWPF7RAq4YQFMEpi0kgcvNcRRRx18YIeCxhMjJ+Bm0Xwzo45BvcWvUeS7B2FjWA36h1yzClQlQXUnAR1G9iiHjgIWjlDP4a/mmxlknyobEOmz3XgFaM8BKKL4IpTPUp+ZYKLugm9caTtHw5Va3zMA5BM7bHR1rvcKjd/h9LSKqXu5svM1pOt6nCymE63d0tSs+v1S3qEzWm38f2Z/V/u5vgN+ngBeVoBAAA=
+  recorded_at: Tue, 20 Jul 2021 02:14:52 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/create_test_connection.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/create_test_connection.yml
@@ -12,54 +12,66 @@ http_interactions:
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
-      - Ruby/2.3.1
+      - rest-client/2.0.2 (darwin20.2.0 x86_64) ruby/2.7.2p137
       Content-Type:
       - application/json
       Auth0-Client:
-      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI0LjUuMCJ9
+      - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjEuMiIsImVudiI6eyJydWJ5IjoiMi43LjIifX0=
       Authorization:
       - Bearer API_TOKEN
       Content-Length:
       - '53'
-      Host:
-      - auth0-sdk-tests.auth0.com
   response:
     status:
       code: 201
       message: Created
     headers:
       Date:
-      - Fri, 05 Oct 2018 20:16:25 GMT
+      - Tue, 20 Jul 2021 02:06:03 GMT
       Content-Type:
       - application/json; charset=utf-8
       Transfer-Encoding:
       - chunked
       Connection:
       - keep-alive
-      X-Ratelimit-Limit:
-      - '10'
-      X-Ratelimit-Remaining:
-      - '9'
-      X-Ratelimit-Reset:
-      - '1538770587'
-      Vary:
-      - origin,accept-encoding
+      Cf-Ray:
+      - 6718a0c42c0a323a-LAX
       Cache-Control:
-      - private, no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      - no-cache
       Content-Encoding:
       - gzip
       Strict-Transport-Security:
-      - max-age=15724800
-      X-Robots-Tag:
-      - noindex, nofollow, nosnippet, noarchive
+      - max-age=31536000
+      Vary:
+      - origin,accept-encoding
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Ot-Baggage-Auth0-Request-Id:
+      - 6718a0c42c0a323a
+      Ot-Tracer-Sampled:
+      - 'true'
+      Ot-Tracer-Spanid:
+      - 672b1d28532dec55
+      Ot-Tracer-Traceid:
+      - 1552b04c1ec626a6
+      X-Content-Type-Options:
+      - nosniff
+      X-Ratelimit-Limit:
+      - '50'
+      X-Ratelimit-Remaining:
+      - '49'
+      X-Ratelimit-Reset:
+      - '1626746764'
+      Server:
+      - cloudflare
+      Alt-Svc:
+      - h3-27=":443"; ma=86400, h3-28=":443"; ma=86400, h3-29=":443"; ma=86400, h3=":443";
+        ma=86400
     body:
       encoding: ASCII-8BIT
       string: !binary |-
-        H4sIAAAAAAAAA3WPQUvEQAyF/0vOFRYRlB4V9iQii+hhWYbpNK0DM0lJMl3K
-        0v/u1EU9eUp4L3zv5QKxhxYCk3v+uJ8fH3Z7fc+H/d3wAg3wZJFJob1AHvw2
-        fLA4I7QmBRsQtCLkkIRTcopmkUa9umsDk1c9s/SvnGJYaszI3FdsJ8XQDSwB
-        3SRsGLaYH6iaeMNxcTOKfuu3659aKb7Y565iyOfaBN5Q7YmJrpQbKd1iVaoH
-        UV3P2Udy4deHdvBJawyS7xL2LqSIZLX08bQ95FPe9n+pp/ULPGRgtDMBAAA=
-    http_version: 
-  recorded_at: Fri, 05 Oct 2018 20:16:25 GMT
-recorded_with: VCR 4.0.0
+        H4sIAAAAAAAAA3WPQUvEQAyF/0vOFUpPMke9LSgelAVlGaYzaR2YJiVJd7cs+9+duurNU0Je8r2XC+QEDiKTp/unXdudu3dtdw9v+2dogGfLTAruAtMQthKi5SOCM1mwAUFbhDyScCle0SzTqDf12sAcVE8s6YVLjmu1GZlTxapJMBxXf0TRagCua6CXxdAPLBH9LGwY7Vv6Yf3eVEpY7LOtGApTTQKvqPbIRLeDO1n61eqoLmT1iaeQycc/HdwQitbsSKEvmHwsGclq6I/D9lAo09b/Sz1cvwBFiD9BMwEAAA==
+  recorded_at: Tue, 20 Jul 2021 02:06:02 GMT
+recorded_with: VCR 6.0.0

--- a/spec/lib/auth0/api/v2/connections_spec.rb
+++ b/spec/lib/auth0/api/v2/connections_spec.rb
@@ -113,7 +113,7 @@ describe Auth0::Api::V2::Connections do
   context '.delete_connection_user' do
     it { expect(@instance).to respond_to(:delete_connection_user) }
     it 'is expected to call delete to /api/v2/connections/connectionId/users' do
-      expect(@instance).to receive(:delete).with('/api/v2/connections/connectionId/users?email=email@test.com')
+      expect(@instance).to receive(:delete).with('/api/v2/connections/connectionId/users', email: 'email@test.com')
       @instance.delete_connection_user('connectionId', 'email@test.com')
     end
 


### PR DESCRIPTION
### Changes

This PR modifies the `delete_connection_user` method, putting the `email` query param inside the `body` hash parameter of the `delete` method, so it gets properly encoded and added as a query param to the URL by the [rest-client](https://github.com/rest-client/rest-client) gem.

Previously, this query param was added directly to the endpoint path, which resulted in it not being properly percent-encoded (the reserved characters [as per RFC 3986](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) were not encoded). This resulted in the [endpoint](https://auth0.com/docs/api/management/v2#!/Connections/delete_users_by_email) returning an error due to the input validation failed with emails like `foo+tag@example.com`, because `+` was not percent-encoded.

See similar instance: https://github.com/auth0/ruby-auth0/blob/master/lib/auth0/api/v2/user_blocks.rb#L30

#### Why the query param needs to be added to `body`

See https://github.com/auth0/ruby-auth0/blob/master/lib/auth0/mixins/httpproxy.rb.

This is the `body` parameter of the `delete` method:
<img width="503" alt="Screen Shot 2021-07-13 at 21 49 51" src="https://user-images.githubusercontent.com/5055789/125543527-54117f9c-942c-45f0-90c4-06b3904fcf04.png">

When the HTTP method is `:delete`, that method [calls](https://github.com/auth0/ruby-auth0/blob/master/lib/auth0/mixins/httpproxy.rb#L24) the `call` method to make the HTTP request with rest-client.

<img width="473" alt="Screen Shot 2021-07-13 at 21 56 13" src="https://user-images.githubusercontent.com/5055789/125544025-edd3aa10-949b-4050-8e68-1a1bf947e9d8.png">

Due to the [peculiar API](https://github.com/rest-client/rest-client#passing-advanced-options) rest-client offers to pass parameters  when using arbitrary HTTP methods, the parameters (the `body` hash in the case of `:delete`) must to be added to the `headers` hash:
<img width="793" alt="Screen Shot 2021-07-13 at 21 06 08" src="https://user-images.githubusercontent.com/5055789/125542639-f19e6390-a7f8-44be-ab26-2f56b5651043.png">

The `call` method then invokes rest-client with that `headers` hash containing the query params, that are then properly encoded and added to the URL:

<img width="358" alt="Screen Shot 2021-07-13 at 22 04 48" src="https://user-images.githubusercontent.com/5055789/125544574-3c6cf362-dcd9-432a-8247-1deb31be8fa4.png">

### Testing

This change has been tested on `ruby 2.7.1p83`.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed