### PR TITLE
Document checkpoint pagination params [SDK-2667]

### DIFF
--- a/lib/auth0/api/v2/logs.rb
+++ b/lib/auth0/api/v2/logs.rb
@@ -17,7 +17,7 @@ module Auth0
         #   * :include_fields [boolean] True if the fields specified are to be included in the result, false otherwise.
         #   * :include_totals [string] True if a query summary must be included in the result, false otherwise.
         #   * :from [string] For checkpoint pagination, the Id from which to start selection from.
-        #   * :take [integer] or checkpoint pagination, the number of entries to retrieve. Default 50.
+        #   * :take [integer] For checkpoint pagination, the number of entries to retrieve. Default is 50.
         # Default: 50. Max value: 100.
         #
         # @return [json] Returns the list of existing log entries.

--- a/lib/auth0/api/v2/logs.rb
+++ b/lib/auth0/api/v2/logs.rb
@@ -16,7 +16,7 @@ module Auth0
         #   * :fields [string] A comma separated list of fields to include or exclude from the result.
         #   * :include_fields [boolean] True if the fields specified are to be included in the result, false otherwise.
         #   * :include_totals [string] True if a query summary must be included in the result, false otherwise.
-        #   * :from [string] For checkpoint pagination, the Id from which to start selection from.
+        #   * :from [string] For checkpoint pagination, the ID from which to start selection from.
         #   * :take [integer] For checkpoint pagination, the number of entries to retrieve. Default is 50.
         # Default: 50. Max value: 100.
         #

--- a/lib/auth0/api/v2/logs.rb
+++ b/lib/auth0/api/v2/logs.rb
@@ -16,8 +16,8 @@ module Auth0
         #   * :fields [string] A comma separated list of fields to include or exclude from the result.
         #   * :include_fields [boolean] True if the fields specified are to be included in the result, false otherwise.
         #   * :include_totals [string] True if a query summary must be included in the result, false otherwise.
-        #   * :from [string] Log Event Id to start retrieving logs. You can limit the amount of logs using the take parameter.
-        #   * :take [integer] The total amount of entries to retrieve when using the from parameter.
+        #   * :from [string] For checkpoint pagination, the Id from which to start selection from.
+        #   * :take [integer] or checkpoint pagination, the number of entries to retrieve. Default 50.
         # Default: 50. Max value: 100.
         #
         # @return [json] Returns the list of existing log entries.

--- a/lib/auth0/api/v2/organizations.rb
+++ b/lib/auth0/api/v2/organizations.rb
@@ -219,7 +219,7 @@ module Auth0
         # @param options [hash] The Hash options used to define the paging of rersults
         #   * :per_page [integer] The amount of entries per page. Default: 50. Max value: 100.
         #   * :page [integer] The page number. Zero based.
-        #   * :from [string] For checkpoint pagination, the Id from which to start selection from.
+        #   * :from [string] For checkpoint pagination, the ID from which to start selection from.
         #   * :take [integer] For checkpoint pagination, the number of entries to retrieve. Default is 50.
         #   * :include_totals [boolean] True to include query summary in the result, false or nil otherwise.
         #

--- a/lib/auth0/api/v2/organizations.rb
+++ b/lib/auth0/api/v2/organizations.rb
@@ -224,7 +224,7 @@ module Auth0
         #   * :include_totals [boolean] True to include query summary in the result, false or nil otherwise.
         #
         # @return [json] Returns the members for the given organization
-        def get_organizations_members(organization_id, params = {})
+        def get_organizations_members(organization_id, options = {})
           raise Auth0::MissingOrganizationId, 'Must supply a valid organization_id' if organization_id.to_s.empty?
           request_params = {
             per_page:       options.fetch(:per_page, nil),

--- a/lib/auth0/api/v2/organizations.rb
+++ b/lib/auth0/api/v2/organizations.rb
@@ -12,7 +12,7 @@ module Auth0
         # @param options [hash] The Hash options used to define the paging of rersults
         #   * :per_page [integer] The amount of entries per page. Default: 50. Max value: 100.
         #   * :page [integer] The page number. Zero based.
-        #   * :from [string] For checkpoint pagination, the Id from which to start selection from.
+        #   * :from [string] For checkpoint pagination, the ID from which to start selection from.
         #   * :take [integer] or checkpoint pagination, the number of entries to retrieve. Default 50.
         #   * :include_totals [boolean] True to include query summary in the result, false or nil otherwise.
         # @return [json] All Organizations

--- a/lib/auth0/api/v2/organizations.rb
+++ b/lib/auth0/api/v2/organizations.rb
@@ -13,7 +13,7 @@ module Auth0
         #   * :per_page [integer] The amount of entries per page. Default: 50. Max value: 100.
         #   * :page [integer] The page number. Zero based.
         #   * :from [string] For checkpoint pagination, the ID from which to start selection from.
-        #   * :take [integer] or checkpoint pagination, the number of entries to retrieve. Default 50.
+        #   * :take [integer] For checkpoint pagination, the number of entries to retrieve. Default is 50.
         #   * :include_totals [boolean] True to include query summary in the result, false or nil otherwise.
         # @return [json] All Organizations
         def organizations(options = {})

--- a/lib/auth0/api/v2/organizations.rb
+++ b/lib/auth0/api/v2/organizations.rb
@@ -220,7 +220,7 @@ module Auth0
         #   * :per_page [integer] The amount of entries per page. Default: 50. Max value: 100.
         #   * :page [integer] The page number. Zero based.
         #   * :from [string] For checkpoint pagination, the Id from which to start selection from.
-        #   * :take [integer] or checkpoint pagination, the number of entries to retrieve. Default 50.
+        #   * :take [integer] For checkpoint pagination, the number of entries to retrieve. Default is 50.
         #   * :include_totals [boolean] True to include query summary in the result, false or nil otherwise.
         #
         # @return [json] Returns the members for the given organization

--- a/lib/auth0/api/v2/organizations.rb
+++ b/lib/auth0/api/v2/organizations.rb
@@ -12,12 +12,16 @@ module Auth0
         # @param options [hash] The Hash options used to define the paging of rersults
         #   * :per_page [integer] The amount of entries per page. Default: 50. Max value: 100.
         #   * :page [integer] The page number. Zero based.
+        #   * :from [string] For checkpoint pagination, the Id from which to start selection from.
+        #   * :take [integer] or checkpoint pagination, the number of entries to retrieve. Default 50.
         #   * :include_totals [boolean] True to include query summary in the result, false or nil otherwise.
         # @return [json] All Organizations
         def organizations(options = {})
           request_params = {
             per_page:       options.fetch(:per_page, nil),
             page:           options.fetch(:page, nil),
+            from:           options.fetch(:from, nil),
+            take:           options.fetch(:take, nil),
             include_totals: options.fetch(:include_totals, nil)
           }
           get(organizations_path, request_params)
@@ -212,13 +216,25 @@ module Auth0
         # Get Members in a Organization
         # @see https://auth0.com/docs/api/management/v2/#!/Organizations/get_members
         # @param organization_id [string] The Organization ID
-        # @param user_id [string] The User ID
+        # @param options [hash] The Hash options used to define the paging of rersults
+        #   * :per_page [integer] The amount of entries per page. Default: 50. Max value: 100.
+        #   * :page [integer] The page number. Zero based.
+        #   * :from [string] For checkpoint pagination, the Id from which to start selection from.
+        #   * :take [integer] or checkpoint pagination, the number of entries to retrieve. Default 50.
+        #   * :include_totals [boolean] True to include query summary in the result, false or nil otherwise.
         #
         # @return [json] Returns the members for the given organization
-        def get_organizations_members(organization_id)
+        def get_organizations_members(organization_id, params = {})
           raise Auth0::MissingOrganizationId, 'Must supply a valid organization_id' if organization_id.to_s.empty?
+          request_params = {
+            per_page:       options.fetch(:per_page, nil),
+            page:           options.fetch(:page, nil),
+            from:           options.fetch(:from, nil),
+            take:           options.fetch(:take, nil),
+            include_totals: options.fetch(:include_totals, nil)
+          }
           path = "#{organizations_members_path(organization_id)}"
-          get(path)
+          get(path, request_params)
         end
 
         # Add members in an organization

--- a/lib/auth0/api/v2/roles.rb
+++ b/lib/auth0/api/v2/roles.rb
@@ -87,7 +87,7 @@ module Auth0
         # @param options [hash] A hash of options for getting Roles
         #   - per_page: Number of Roles to return.
         #   - page: Page number to return, zero-based.
-        #   * :from [string] For checkpoint pagination, the Id from which to start selection from.
+        #   * :from [string] For checkpoint pagination, the ID from which to start selection from.
         #   * :take [integer] For checkpoint pagination, the number of entries to retrieve. Default is 50.
         #   * :include_totals [boolean] True to include query summary in the result, false or nil otherwise.
         def get_role_users(role_id, options = {})

--- a/lib/auth0/api/v2/roles.rb
+++ b/lib/auth0/api/v2/roles.rb
@@ -88,7 +88,7 @@ module Auth0
         #   - per_page: Number of Roles to return.
         #   - page: Page number to return, zero-based.
         #   * :from [string] For checkpoint pagination, the Id from which to start selection from.
-        #   * :take [integer] or checkpoint pagination, the number of entries to retrieve. Default 50.
+        #   * :take [integer] For checkpoint pagination, the number of entries to retrieve. Default is 50.
         #   * :include_totals [boolean] True to include query summary in the result, false or nil otherwise.
         def get_role_users(role_id, options = {})
           raise Auth0::MissingParameter, 'Must supply a valid role_id' if role_id.to_s.empty?

--- a/lib/auth0/api/v2/roles.rb
+++ b/lib/auth0/api/v2/roles.rb
@@ -87,13 +87,17 @@ module Auth0
         # @param options [hash] A hash of options for getting Roles
         #   - per_page: Number of Roles to return.
         #   - page: Page number to return, zero-based.
-        #   - include_totals: True to include query summary in the result, false or nil otherwise.
+        #   * :from [string] For checkpoint pagination, the Id from which to start selection from.
+        #   * :take [integer] or checkpoint pagination, the number of entries to retrieve. Default 50.
+        #   * :include_totals [boolean] True to include query summary in the result, false or nil otherwise.
         def get_role_users(role_id, options = {})
           raise Auth0::MissingParameter, 'Must supply a valid role_id' if role_id.to_s.empty?
 
           request_params = {
-            per_page: options.fetch(:per_page, nil),
-            page: options.fetch(:page, nil),
+            per_page:       options.fetch(:per_page, nil),
+            page:           options.fetch(:page, nil),
+            from:           options.fetch(:from, nil),
+            take:           options.fetch(:take, nil),
             include_totals: options.fetch(:include_totals, nil)
           }
           get "#{roles_path}/#{role_id}/users", request_params

--- a/spec/lib/auth0/api/v2/organizations_spec.rb
+++ b/spec/lib/auth0/api/v2/organizations_spec.rb
@@ -20,6 +20,8 @@ describe Auth0::Api::V2::Organizations do
         '/api/v2/organizations',
         per_page: nil,
         page: nil,
+        from: nil,
+        take: nil,
         include_totals: nil
       )
       expect { @instance.organizations }.not_to raise_error
@@ -30,12 +32,16 @@ describe Auth0::Api::V2::Organizations do
         '/api/v2/organizations',
         per_page: 10,
         page: 1,
+        from: 'org_id',
+        take: 50,
         include_totals: true
       )
       expect do
         @instance.organizations(
           per_page: 10,
           page: 1,
+          from: 'org_id',
+          take: 50,
           include_totals: true
         )
       end.not_to raise_error
@@ -438,19 +444,38 @@ describe Auth0::Api::V2::Organizations do
       expect { @instance.get_organizations_members(nil) }.to raise_exception(Auth0::MissingOrganizationId)
     end
 
-    it 'is expected to get invitations for an org' do
-      expect(@instance).to receive(:get).with(
-        '/api/v2/organizations/org_id/members'
-      )
-      expect { @instance.get_organizations_members('org_id') }.not_to raise_error
-    end
-
     it 'is expected to get members for an org' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/organizations/org_id/members'
+        '/api/v2/organizations/org_id/members',
+        per_page: nil,
+        page: nil,
+        from: nil,
+        take: nil,
+        include_totals: nil
       )
       expect do
         @instance.get_organizations_members('org_id')
+      end.not_to raise_error
+    end
+
+    it 'is expected to get /api/v2/organizations with custom parameters' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/organizations/org_id/members',
+        per_page: 10,
+        page: 1,
+        from: 'org_id',
+        take: 50,
+        include_totals: true
+      )
+      expect do
+        @instance.get_organizations_members(
+          'org_id',
+          per_page: 10,
+          page: 1,
+          from: 'org_id',
+          take: 50,
+          include_totals: true
+        )
       end.not_to raise_error
     end
   end

--- a/spec/lib/auth0/api/v2/roles_spec.rb
+++ b/spec/lib/auth0/api/v2/roles_spec.rb
@@ -152,6 +152,8 @@ describe Auth0::Api::V2::Roles do
         '/api/v2/roles/ROLE_ID/users',
         per_page: nil,
         page: nil,
+        from: nil,
+        take: nil,
         include_totals: nil
       )
       expect { @instance.get_role_users('ROLE_ID') }.not_to raise_error
@@ -162,10 +164,12 @@ describe Auth0::Api::V2::Roles do
         '/api/v2/roles/ROLE_ID/users',
         per_page: 30,
         page: 4,
+        from: 'org_id',
+        take: 50,
         include_totals: true
       )
       expect do
-        @instance.get_role_users('ROLE_ID', per_page: 30, page: 4, include_totals: true)
+        @instance.get_role_users('ROLE_ID', per_page: 30, page: 4, from: 'org_id', take: 50, include_totals: true)
       end.not_to raise_error
     end
   end


### PR DESCRIPTION
## Changes
This PR includes method documentation (docblock) updates to reflect the availability of checkpoint pagination parameters on supported endpoints. It does not add any new functionality or require new tests.

## References
Please see the internal Jira tickets SDK-2667 and related epic SDK-2653 for details on this initiative.
