### PR TITLE
Change strategy when normalizing path

### DIFF
--- a/lib/auth0/mixins/httpproxy.rb
+++ b/lib/auth0/mixins/httpproxy.rb
@@ -9,8 +9,15 @@ module Auth0
 
       # proxying requests from instance methods to HTTP class methods
       %i(get post post_file put patch delete delete_with_body).each do |method|
-        define_method(method) do |path, body = {}, extra_headers = {}|
-          safe_path = Addressable::URI.escape(path)
+        define_method(method) do |uri, body = {}, extra_headers = {}|
+
+          if base_uri
+            # if a base_uri is set then the uri can be encoded as a path
+            safe_path = Addressable::URI.new(path: uri).normalized_path
+          else
+            safe_path = Addressable::URI.escape(uri)
+          end
+
           body = body.delete_if { |_, v| v.nil? }
           result = if method == :get
                      # Mutate the headers property to add parameters.

--- a/spec/lib/auth0/mixins/httpproxy_spec.rb
+++ b/spec/lib/auth0/mixins/httpproxy_spec.rb
@@ -5,6 +5,8 @@ describe Auth0::Mixins::HTTPProxy do
   before :each do
     dummy_instance = DummyClassForProxy.new
     dummy_instance.extend(Auth0::Mixins::HTTPProxy)
+    dummy_instance.base_uri = "https://auth0.com"
+
     @instance = dummy_instance
     @exception = DummyClassForRestClient.new
   end
@@ -14,7 +16,7 @@ describe Auth0::Mixins::HTTPProxy do
       it { expect(@instance).to respond_to(http_method.to_sym) }
       it "should call send http #{http_method} method to path defined through HTTP" do
         expect(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                              url: '/test',
+                                                              url: 'https://auth0.com/test',
                                                               timeout: nil,
                                                               headers: { params: {} },
                                                               payload: nil)
@@ -24,7 +26,7 @@ describe Auth0::Mixins::HTTPProxy do
 
       it 'should not raise exception if data returned not in json format (should be fixed in v2)' do
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                             url: '/test',
+                                                             url: 'https://auth0.com/test',
                                                              timeout: nil,
                                                              headers: { params: {} },
                                                              payload: nil)
@@ -36,7 +38,7 @@ describe Auth0::Mixins::HTTPProxy do
       it "should raise Auth0::Unauthorized on send http #{http_method}
         method to path defined through HTTP when 401 status received" do
         expect(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                              url: '/test',
+                                                              url: 'https://auth0.com/test',
                                                               timeout: nil,
                                                               headers: { params: {} },
                                                               payload: nil)
@@ -47,7 +49,7 @@ describe Auth0::Mixins::HTTPProxy do
       it "should raise Auth0::NotFound on send http #{http_method} method
         to path defined through HTTP when 404 status received" do
         expect(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                              url: '/test',
+                                                              url: 'https://auth0.com/test',
                                                               timeout: nil,
                                                               headers: { params: {} },
                                                               payload: nil)
@@ -58,7 +60,7 @@ describe Auth0::Mixins::HTTPProxy do
       it "should raise Auth0::Unsupported on send http #{http_method} method
         to path defined through HTTP when 418 or other unknown status received" do
         expect(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                              url: '/test',
+                                                              url: 'https://auth0.com/test',
                                                               timeout: nil,
                                                               headers: { params: {} },
                                                               payload: nil)
@@ -69,7 +71,7 @@ describe Auth0::Mixins::HTTPProxy do
       it "should raise Auth0::RequestTimeout on send http #{http_method} method
         to path defined through HTTP when RestClient::RequestTimeout received" do
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                             url: '/test',
+                                                             url: 'https://auth0.com/test',
                                                              timeout: nil,
                                                              headers: { params: {} },
                                                              payload: nil)
@@ -81,7 +83,7 @@ describe Auth0::Mixins::HTTPProxy do
         to path defined through HTTP when 400 status received" do
         @exception.response = StubResponse.new({}, false, 400)
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                             url: '/test',
+                                                             url: 'https://auth0.com/test',
                                                              timeout: nil,
                                                              headers: { params: {} },
                                                              payload: nil)
@@ -93,7 +95,7 @@ describe Auth0::Mixins::HTTPProxy do
         to path defined through HTTP when 403" do
         @exception.response = StubResponse.new({}, false, 403)
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                             url: '/test',
+                                                             url: 'https://auth0.com/test',
                                                              timeout: nil,
                                                              headers: { params: {} },
                                                              payload: nil)
@@ -110,7 +112,7 @@ describe Auth0::Mixins::HTTPProxy do
         }
         @exception.response = StubResponse.new({}, false, 429, headers)
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                             url: '/test',
+                                                             url: 'https://auth0.com/test',
                                                              timeout: nil,
                                                              headers: { params: {} },
                                                              payload: nil)
@@ -133,7 +135,7 @@ describe Auth0::Mixins::HTTPProxy do
         to path defined through HTTP when 500 received" do
         @exception.response = StubResponse.new({}, false, 500)
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                             url: '/test',
+                                                             url: 'https://auth0.com/test',
                                                              timeout: nil,
                                                              headers: { params: {} },
                                                              payload: nil)
@@ -141,14 +143,14 @@ describe Auth0::Mixins::HTTPProxy do
         expect { @instance.send(http_method, '/test') }.to raise_error(Auth0::ServerError)
       end
 
-      it 'should escape path with Addressable::URI.escape' do
+      it 'should normalize path with Addressable::URI' do
         expect(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                              url: '/te%20st',
+                                                              url: 'https://auth0.com/te%20st%23test',
                                                               timeout: nil,
                                                               headers: { params: {} },
                                                               payload: nil)
           .and_return(StubResponse.new({}, true, 200))
-        expect { @instance.send(http_method, '/te st') }.not_to raise_error
+        expect { @instance.send(http_method, '/te st#test') }.not_to raise_error
       end
     end
   end
@@ -158,7 +160,7 @@ describe Auth0::Mixins::HTTPProxy do
       it { expect(@instance).to respond_to(http_method.to_sym) }
       it "should call send http #{http_method} method to path defined through HTTP" do
         expect(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                              url: '/test',
+                                                              url: 'https://auth0.com/test',
                                                               timeout: nil,
                                                               headers: nil,
                                                               payload: '{}')
@@ -168,7 +170,7 @@ describe Auth0::Mixins::HTTPProxy do
 
       it 'should not raise exception if data returned not in json format (should be fixed in v2)' do
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                             url: '/test',
+                                                             url: 'https://auth0.com/test',
                                                              timeout: nil,
                                                              headers: nil,
                                                              payload: '{}')
@@ -181,7 +183,7 @@ describe Auth0::Mixins::HTTPProxy do
         to path defined through HTTP when 401 status received" do
         @exception.response = StubResponse.new({}, false, 401)
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                             url: '/test',
+                                                             url: 'https://auth0.com/test',
                                                              timeout: nil,
                                                              headers: nil,
                                                              payload: '{}')
@@ -198,7 +200,7 @@ describe Auth0::Mixins::HTTPProxy do
         }
         @exception.response = StubResponse.new({}, false, 429,headers)
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                             url: '/test',
+                                                             url: 'https://auth0.com/test',
                                                              timeout: nil,
                                                              headers: nil,
                                                              payload: '{}')
@@ -221,7 +223,7 @@ describe Auth0::Mixins::HTTPProxy do
         to path defined through HTTP when 404 status received" do
         @exception.response = StubResponse.new({}, false, 404)
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                             url: '/test',
+                                                             url: 'https://auth0.com/test',
                                                              timeout: nil,
                                                              headers: nil,
                                                              payload: '{}')
@@ -233,7 +235,7 @@ describe Auth0::Mixins::HTTPProxy do
         to path defined through HTTP when 418 or other unknown status received" do
         @exception.response = StubResponse.new({}, false, 418)
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                             url: '/test',
+                                                             url: 'https://auth0.com/test',
                                                              timeout: nil,
                                                              headers: nil,
                                                              payload: '{}')
@@ -244,7 +246,7 @@ describe Auth0::Mixins::HTTPProxy do
       it "should raise Auth0::RequestTimeout on send http #{http_method} method
         to path defined through HTTP when RestClient::RequestTimeout received" do
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                             url: '/test',
+                                                             url: 'https://auth0.com/test',
                                                              timeout: nil,
                                                              headers: nil,
                                                              payload: '{}')
@@ -256,7 +258,7 @@ describe Auth0::Mixins::HTTPProxy do
         to path defined through HTTP when 400 status received" do
         @exception.response = StubResponse.new({}, false, 400)
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                             url: '/test',
+                                                             url: 'https://auth0.com/test',
                                                              timeout: nil,
                                                              headers: nil,
                                                              payload: '{}')
@@ -267,7 +269,7 @@ describe Auth0::Mixins::HTTPProxy do
       it "should raise Auth0::ServerError on send http #{http_method} method
         to path defined through HTTP when 500 received" do
         @exception.response = StubResponse.new({}, false, 500)
-        allow(RestClient::Request).to receive(:execute).with(method: http_method, url: '/test',
+        allow(RestClient::Request).to receive(:execute).with(method: http_method, url: 'https://auth0.com/test',
                                                              timeout: nil,
                                                              headers: nil,
                                                              payload: '{}')
@@ -275,9 +277,9 @@ describe Auth0::Mixins::HTTPProxy do
         expect { @instance.send(http_method, '/test') }.to raise_error(Auth0::ServerError)
       end
 
-      it 'should escape path with Addressable::URI.escape' do
+      it 'should normalize path with Addressable::URI' do
         expect(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                              url: '/te%20st',
+                                                              url: 'https://auth0.com/te%20st',
                                                               timeout: nil,
                                                               headers: nil,
                                                               payload: '{}')
@@ -292,7 +294,7 @@ describe Auth0::Mixins::HTTPProxy do
                                             3241312' on property id (The user_id of the user to retrieve).",
                             'errorCode' => 'invalid_uri')
         expect(RestClient::Request).to receive(:execute).with(method: http_method,
-                                                              url: '/test',
+                                                              url: 'https://auth0.com/test',
                                                               timeout: nil,
                                                               headers: nil,
                                                               payload: '{}')

--- a/spec/support/dummy_class_for_proxy.rb
+++ b/spec/support/dummy_class_for_proxy.rb
@@ -1,5 +1,4 @@
 class DummyClassForProxy
   include Auth0::Mixins::HTTPProxy
   include Auth0::Mixins::Headers
-  @base_uri = 'http://auth0.com'
 end


### PR DESCRIPTION
When encoding the uri, we currently have two different strategies, either the full URL or the path.  When passing in just the path, the Addressable aggresively parses the path assuming its a full url.  This causes some charachters to not be encoded and instead be parsing points of the url.

This PR changes the strategy to check for when the base_uri is set, and if is is we dont need to parse the url, just encode the path.