### PR TITLE
[SDK-2689] Automatically retry requests when API returns a 429 rate-limit status header. 

### DIFF
--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'jwt', '~> 2.2'
   s.add_runtime_dependency 'zache', '~> 0.12'
   s.add_runtime_dependency 'addressable', '~> 2.8'
+  s.add_runtime_dependency 'retryable', '~> 3.0'
 
   s.add_development_dependency 'bundler'
   s.add_development_dependency 'rake', '~> 13.0'

--- a/lib/auth0/mixins/initializer.rb
+++ b/lib/auth0/mixins/initializer.rb
@@ -15,6 +15,7 @@ module Auth0
         @base_uri = base_url(options)
         @headers = client_headers
         @timeout = options[:timeout] || 10
+        @retry_count = options[:retry_count]
         extend Auth0::Api::AuthenticationEndpoints
         @client_id = options[:client_id]
         @client_secret = options[:client_secret]

--- a/spec/lib/auth0/mixins/initializer_spec.rb
+++ b/spec/lib/auth0/mixins/initializer_spec.rb
@@ -26,5 +26,12 @@ describe Auth0::Mixins::Initializer do
 
       expect(instance.instance_variable_get('@token')).to eq('123')
     end
+
+    it 'sets retry_count when passed' do
+      params[:token] = '123'
+      params[:retry_count] = 10
+
+      expect(instance.instance_variable_get('@retry_count')).to eq(10)
+    end
   end
 end


### PR DESCRIPTION
### Changes

This PR enables support for automatic retry of API requests that encounter a 429 rate-limit status response from the Auth0 API. It will retry, by default, up to 3 times, with a hard-coded cap of 10. It exponentially increases the delay between each request ("exponential backoff"), and uses a jitter technique to slightly randomize the variance of this delay.

### References

Please see the internal SDK-2653 epic on this topic.

### Testing

Coverage added ✅ 
existing tests also ✅ 
