### PR TITLE
Deprecate change_password in favor of reset_password

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -151,7 +151,7 @@ module Auth0
       # @see https://auth0.com/docs/connections/database/password-change
       # @param email [string] User's current email
       # @param password [string] User's new password. This is only available
-      #   on legacy tenants with the change_pwd_flow_v1 flag enabled
+      #   on legacy tenants with change password v1 flow enabled
       # @param connection_name [string] Database connection name
       # @deprecated Use {#password_reset} instead.
       def change_password(email, password, connection_name = UP_AUTH)

--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -150,15 +150,34 @@ module Auth0
       # @see https://auth0.com/docs/api/authentication#change-password
       # @see https://auth0.com/docs/connections/database/password-change
       # @param email [string] User's current email
-      # @param password [string] User's new password; empty to trigger a
-      #   password reset email
+      # @param password [string] User's new password. This is only available
+      #   on legacy tenants with the change_pwd_flow_v1 flag enabled
       # @param connection_name [string] Database connection name
+      # @deprecated Use {#password_reset} instead.
       def change_password(email, password, connection_name = UP_AUTH)
         raise Auth0::InvalidParameter, 'Must supply a valid email' if email.to_s.empty?
 
         request_params = {
           email: email,
           password: password,
+          connection: connection_name,
+          client_id: @client_id
+        }
+        post('/dbconnections/change_password', request_params)
+      end
+
+      # Trigger a password reset email.
+      # @see https://auth0.com/docs/api/authentication#change-password
+      # @see https://auth0.com/docs/connections/database/password-change
+      # @param email [string] User's current email
+      # @param password [string] User's new password; empty to trigger a
+      #   password reset email
+      # @param connection_name [string] Database connection name
+      def reset_password(email, connection_name = UP_AUTH)
+        raise Auth0::InvalidParameter, 'Must supply a valid email' if email.to_s.empty?
+
+        request_params = {
+          email: email,
           connection: connection_name,
           client_id: @client_id
         }


### PR DESCRIPTION
The method `change_password` took a password argument that was only supported on legacy tenants with the flag `change_pwd_flow_v1` enabled.  In order to resolve confusion, we're introducing a new method `reset_password` to fire off a password reset email, and deprecating the old method.

Fixes #292 