### PR TITLE
Allow client_id override for reset_password

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -173,13 +173,15 @@ module Auth0
       # @param password [string] User's new password; empty to trigger a
       #   password reset email
       # @param connection_name [string] Database connection name
-      def reset_password(email, connection_name = UP_AUTH)
+      # @param client_id [string] Client ID override (to allow forwarding
+      #   to a different application's login URI on password reset success page)
+      def reset_password(email, connection_name = UP_AUTH, client_id = @client_id)
         raise Auth0::InvalidParameter, 'Must supply a valid email' if email.to_s.empty?
 
         request_params = {
           email: email,
           connection: connection_name,
-          client_id: @client_id
+          client_id: client_id
         }
         post('/dbconnections/change_password', request_params)
       end


### PR DESCRIPTION
### Changes

`reset_password` modified to accepted an optional parameter `client_id`. This will allow the password reset success page to display a button that forwards to the application login URI of an application other than the one that made the reset password API request.

### References

See https://community.auth0.com/t/missing-back-to-app-button-on-reset-password-success-screens-universal-login/53542/4 for information advising on how `client_id` can be passed to the `/change-password` endpoint.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

`bundle exec rake test` results in:
```
Finished in 1.26 seconds (files took 0.91623 seconds to load)
164 examples, 0 failures, 1 pending
Coverage report generated for RSpec to /auth0/coverage. 668 / 715 LOC (93.43%) covered.
```

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
