### PR TITLE
Fix how to call delete_grant API

### DIFF
--- a/lib/auth0/api/v2/grants.rb
+++ b/lib/auth0/api/v2/grants.rb
@@ -33,8 +33,8 @@ module Auth0
         def delete_grant(id, user_id)
           raise Auth0::InvalidParameter, 'Must specify a grant id as id' if id.to_s.empty?
           raise Auth0::InvalidParameter, 'Must specify a user id' if user_id.to_s.empty?
-          path = "#{grants_path}/#{id}?user_id=#{user_id}"
-          delete(path)
+          path = "#{grants_path}/#{id}"
+          delete(path, user_id: user_id)
         end
 
         private

--- a/spec/lib/auth0/api/v2/grants_spec.rb
+++ b/spec/lib/auth0/api/v2/grants_spec.rb
@@ -81,7 +81,7 @@ describe Auth0::Api::V2::Grants do
   context '.delete_grant' do
     it { expect(@instance).to respond_to(:delete_grant) }
     it 'is expected to send delete to /api/v2/grants/1?user_id=1' do
-      expect(@instance).to receive(:delete).with('/api/v2/grants/1?user_id=1')
+      expect(@instance).to receive(:delete).with('/api/v2/grants/1', user_id: '1')
       expect { @instance.delete_grant('1', '1') }.not_to raise_error
     end
     it { expect { @instance.delete_grant('', '') }.to raise_error 'Must specify a grant id as id' }


### PR DESCRIPTION
This PR fixes https://github.com/auth0/ruby-auth0/issues/303.

### Changes
A request way for `DELETE /api/v2/grants/{id?}` was changed.

### References
https://github.com/auth0/ruby-auth0/issues/303

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
