### PR TITLE
[SDK-3106] Fix up tests for Ruby 3 and rspec-mocks update

### DIFF
--- a/spec/lib/auth0/api/v2/actions_spec.rb
+++ b/spec/lib/auth0/api/v2/actions_spec.rb
@@ -17,14 +17,14 @@ describe Auth0::Api::V2::Actions do
 
     it 'is expected to get /api/v2/actions with custom parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/actions/actions',
+        '/api/v2/actions/actions', {
         trigger_id: 'post-login',
         action_name: 'loginHandler',
         deployed: true,
         per_page: 10,
         page: 1,
         installed: true
-      )
+      })
       expect do
         @instance.actions(
           'post-login',
@@ -71,9 +71,9 @@ describe Auth0::Api::V2::Actions do
 
     it 'is expected to post to /api/v2/actions' do
       expect(@instance).to receive(:post).with(
-        '/api/v2/actions',
+        '/api/v2/actions', {
           name: 'test_org'
-        )
+        })
       expect do
         @instance.create_action(
           name: 'test_org'
@@ -141,10 +141,10 @@ describe Auth0::Api::V2::Actions do
 
     it 'is expected to call get request to /api/v2/actions/actions/{id}/versions' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/actions/actions/123/versions',
+        '/api/v2/actions/actions/123/versions', {
         per_page: nil,
         page: nil
-      )
+      })
       expect { @instance.actions_versions('123') }.not_to raise_error
     end
 
@@ -154,10 +154,10 @@ describe Auth0::Api::V2::Actions do
 
     it 'is expected to get /api/v2/actions/actions/{id}/versions with custom parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/actions/actions/123/versions',
+        '/api/v2/actions/actions/123/versions', {
         per_page: 10,
         page: 1
-      )
+      })
       expect do
         @instance.actions_versions(
           '123',
@@ -176,10 +176,10 @@ describe Auth0::Api::V2::Actions do
 
     it 'is expected to call get request to /api/v2/actions/triggers/{id}/bindings' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/actions/triggers/123/bindings',
+        '/api/v2/actions/triggers/123/bindings', {
         per_page: nil,
         page: nil
-      )
+      })
       expect { @instance.trigger_bindings('123') }.not_to raise_error
     end
 
@@ -189,10 +189,10 @@ describe Auth0::Api::V2::Actions do
 
     it 'is expected to get /api/v2/actions/triggers/{id}/bindings with custom parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/actions/triggers/123/bindings',
+        '/api/v2/actions/triggers/123/bindings', {
         per_page: 10,
         page: 1
-      )
+      })
       expect do
         @instance.trigger_bindings(
           '123',
@@ -278,7 +278,7 @@ describe Auth0::Api::V2::Actions do
     it 'is expected to post to /api/v2/actions/{id}/test' do
       expect(@instance).to receive(:post).with(
         '/api/v2/actions/actions/123/test',
-          name: 'test_org'
+          { name: 'test_org' }
         )
       expect do
         @instance.test_action(

--- a/spec/lib/auth0/api/v2/blacklists_spec.rb
+++ b/spec/lib/auth0/api/v2/blacklists_spec.rb
@@ -9,7 +9,7 @@ describe Auth0::Api::V2::Blacklists do
   context '.blacklisted_tokens' do
     it { expect(@instance).to respond_to(:blacklisted_tokens) }
     it 'is expected to call /api/v2/blacklists/tokens' do
-      expect(@instance).to receive(:get).with('/api/v2/blacklists/tokens', aud: nil)
+      expect(@instance).to receive(:get).with('/api/v2/blacklists/tokens', { aud: nil })
       expect { @instance.blacklisted_tokens }.not_to raise_error
     end
   end
@@ -17,7 +17,7 @@ describe Auth0::Api::V2::Blacklists do
   context '.add_token.to_blacklist' do
     it { expect(@instance).to respond_to(:add_token_to_blacklist) }
     it 'is expected to call post to /api/v2/blacklists/tokens' do
-      expect(@instance).to receive(:post).with('/api/v2/blacklists/tokens', aud: 'aud', jti: 'jti')
+      expect(@instance).to receive(:post).with('/api/v2/blacklists/tokens', { aud: 'aud', jti: 'jti' })
       @instance.add_token_to_blacklist('jti', 'aud')
     end
     it { expect { @instance.add_token_to_blacklist('', '') }.to raise_error 'Must specify a valid JTI' }

--- a/spec/lib/auth0/api/v2/branding_spec.rb
+++ b/spec/lib/auth0/api/v2/branding_spec.rb
@@ -24,8 +24,9 @@ describe Auth0::Api::V2::Branding do
     it { expect(@instance).to respond_to(:patch_branding) }
     it 'is expected to call post /api/v2/branding' do
       expect(@instance).to receive(:patch).with(
-        '/api/v2/branding',
-        template: 'Test'
+        '/api/v2/branding', {
+          template: 'Test'
+        }
       )
       expect { @instance.patch_branding({ template: 'Test' }) }.not_to raise_error
     end
@@ -52,7 +53,7 @@ describe Auth0::Api::V2::Branding do
     it { expect(@instance).to respond_to(:put_branding_templates_for_universal_login) }
     it 'is expected to call put /api/v2/branding/templates/universal-login' do
       expect(@instance).to receive(:put).with(
-        '/api/v2/branding/templates/universal-login', template: 'Template'
+        '/api/v2/branding/templates/universal-login', { template: 'Template' }
       )
       expect do
         @instance.put_branding_templates_for_universal_login(template: 'Template')

--- a/spec/lib/auth0/api/v2/client_grants_spec.rb
+++ b/spec/lib/auth0/api/v2/client_grants_spec.rb
@@ -12,12 +12,12 @@ describe Auth0::Api::V2::ClientGrants do
 
     it 'is expected to get /api/v2/client-grants/' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/client-grants',
+        '/api/v2/client-grants', {
         client_id: nil,
         audience: nil,
         page: nil,
         per_page: nil
-      )
+      })
       expect { @instance.client_grants }.not_to raise_error
     end
 
@@ -25,23 +25,23 @@ describe Auth0::Api::V2::ClientGrants do
       audience = "https://samples.auth0.com/api/v2/"
 
       expect(@instance).to receive(:get).with(
-        '/api/v2/client-grants',
+        '/api/v2/client-grants', {
         client_id: '1',
         audience: audience,
         page: nil,
         per_page: nil
-      )
-      expect { @instance.client_grants(client_id: '1', audience: audience) }.not_to raise_error
+      })
+      expect { @instance.client_grants(client_id: '1', audience: audience ) }.not_to raise_error
     end
 
     it 'is expected to send get /api/v2/client-grants/ with pagination' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/client-grants',
+        '/api/v2/client-grants', {
         client_id: nil,
         audience: nil,
         page: 1,
         per_page: 2
-      )
+      })
       expect { @instance.client_grants(page: 1, per_page: 2) }.not_to raise_error
     end
   end
@@ -49,7 +49,7 @@ describe Auth0::Api::V2::ClientGrants do
   context '.create_client_grant' do
     it { expect(@instance).to respond_to(:create_client_grant) }
     it 'is expected to send post to /api/v2/client-grants' do
-      expect(@instance).to receive(:post).with('/api/v2/client-grants', opt: 'test body')
+      expect(@instance).to receive(:post).with('/api/v2/client-grants', { opt: 'test body' })
       expect { @instance.create_client_grant(opt: 'test body') }.not_to raise_error
     end
   end

--- a/spec/lib/auth0/api/v2/clients_spec.rb
+++ b/spec/lib/auth0/api/v2/clients_spec.rb
@@ -12,23 +12,23 @@ describe Auth0::Api::V2::Clients do
 
     it 'is expected to send get request to the Clients endpoint' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/clients',
+        '/api/v2/clients', {
         fields: nil,
         include_fields: nil,
         page: nil,
         per_page: nil
-      )
+      })
       expect { @instance.clients }.not_to raise_error
     end
 
     it 'is expected to send get request to the Clients endpoint with a name parameter' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/clients',
+        '/api/v2/clients', {
         include_fields: true,
         fields: 'name',
         page: nil,
         per_page: nil
-      )
+      })
       expect {
         @instance.clients(fields: 'name', include_fields: true)
       }.not_to raise_error
@@ -36,12 +36,12 @@ describe Auth0::Api::V2::Clients do
 
     it 'is expected to send get request to Clients endpoint using an array of fields' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/clients',
+        '/api/v2/clients', {
         include_fields: true,
         fields: 'name,app_type',
         page: nil,
         per_page: nil
-      )
+      })
       expect {
         @instance.clients(fields: ['name','app_type'], include_fields: true)
       }.not_to raise_error
@@ -49,12 +49,12 @@ describe Auth0::Api::V2::Clients do
 
     it 'is expected to send get request to Clients endpoint with pagination' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/clients',
+        '/api/v2/clients', {
         page: 1,
         per_page: 10,
         fields: nil,
         include_fields: nil
-      )
+      })
       expect {
         @instance.clients(page: 1, per_page: 10)
       }.not_to raise_error
@@ -64,11 +64,11 @@ describe Auth0::Api::V2::Clients do
   context '.client' do
     it { expect(@instance).to respond_to(:client) }
     it 'is expected to send get request to /api/v2/clients/1' do
-      expect(@instance).to receive(:get).with('/api/v2/clients/1', fields: nil, include_fields: nil)
+      expect(@instance).to receive(:get).with('/api/v2/clients/1', { fields: nil, include_fields: nil })
       expect { @instance.client(1) }.not_to raise_error
     end
     it 'is expected to send get request to /api/v2/clients?fields=name&include_fields=true' do
-      expect(@instance).to receive(:get).with('/api/v2/clients/1', include_fields: true, fields: [:name])
+      expect(@instance).to receive(:get).with('/api/v2/clients/1', { include_fields: true, fields: [:name] })
       expect { @instance.client(1, include_fields: true, fields: [:name]) }.not_to raise_error
     end
     it { expect { @instance.client('') }.to raise_error 'Must specify a client id' }
@@ -77,7 +77,7 @@ describe Auth0::Api::V2::Clients do
   context '.create_client' do
     it { expect(@instance).to respond_to(:create_client) }
     it 'is expected to send post to /api/v2/clients' do
-      expect(@instance).to receive(:post).with('/api/v2/clients', name: 'name', opt: 'opt')
+      expect(@instance).to receive(:post).with('/api/v2/clients', { name: 'name', opt: 'opt' })
       expect { @instance.create_client('name', name: '/name1', opt: 'opt') }.not_to raise_error
     end
     it { expect { @instance.create_client('') }.to raise_error 'Must specify a valid client name' }
@@ -95,7 +95,7 @@ describe Auth0::Api::V2::Clients do
   context '.patch_client' do
     it { expect(@instance).to respond_to(:patch_client) }
     it 'is expected to send patch to /api/v2/clients/1' do
-      expect(@instance).to receive(:patch).with('/api/v2/clients/1', fields: 'fields')
+      expect(@instance).to receive(:patch).with('/api/v2/clients/1', { fields: 'fields' })
       expect { @instance.patch_client('1', fields: 'fields') }.not_to raise_error
     end
     it { expect { @instance.patch_client('', nil) }.to raise_error 'Must specify a client id' }

--- a/spec/lib/auth0/api/v2/connections_spec.rb
+++ b/spec/lib/auth0/api/v2/connections_spec.rb
@@ -12,27 +12,27 @@ describe Auth0::Api::V2::Connections do
 
     it 'is expected to call /api/v2/connections' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/connections',
+        '/api/v2/connections', {
         strategy: nil,
         name: nil,
         fields: nil,
         include_fields: nil,
         page: nil,
         per_page: nil
-      )
+      })
       expect { @instance.connections }.not_to raise_error
     end
 
     it 'is expected to send get request to /api/v2/connections?fields=name' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/connections',
+        '/api/v2/connections', {
         include_fields: true,
         fields: 'name',
         strategy: nil,
         name: nil,
         page: nil,
         per_page: nil
-      )
+      })
       expect {
         @instance.connections(fields: 'name', include_fields: true)
       }.not_to raise_error
@@ -40,14 +40,14 @@ describe Auth0::Api::V2::Connections do
 
     it 'is expected to convert fields param from Array to string' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/connections',
+        '/api/v2/connections', {
         include_fields: true,
         fields: 'name,strategy',
         strategy: nil,
         name: nil,
         page: nil,
         per_page: nil
-      )
+      })
       expect {
         @instance.connections(fields: ['name','strategy'], include_fields: true)
       }.not_to raise_error
@@ -55,14 +55,14 @@ describe Auth0::Api::V2::Connections do
 
     it 'is expected to add pagination' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/connections',
+        '/api/v2/connections', {
         page: 1,
         per_page: 10,
         strategy: nil,
         name: nil,
         fields: nil,
         include_fields: nil
-      )
+      })
       expect {
         @instance.connections(page: 1, per_page: 10)
       }.not_to raise_error
@@ -88,7 +88,7 @@ describe Auth0::Api::V2::Connections do
   context '.connection' do
     it { expect(@instance).to respond_to(:connection) }
     it 'is expected to call get request to /api/v2/connection/connectionId' do
-      expect(@instance).to receive(:get).with('/api/v2/connections/connectionId', fields: nil, include_fields: true)
+      expect(@instance).to receive(:get).with('/api/v2/connections/connectionId', { fields: nil, include_fields: true })
       expect { @instance.connection('connectionId') }.not_to raise_error
     end
     it 'is expected raise an error when calling with empty id' do
@@ -113,7 +113,7 @@ describe Auth0::Api::V2::Connections do
   context '.delete_connection_user' do
     it { expect(@instance).to respond_to(:delete_connection_user) }
     it 'is expected to call delete to /api/v2/connections/connectionId/users' do
-      expect(@instance).to receive(:delete).with('/api/v2/connections/connectionId/users', email: 'email@test.com')
+      expect(@instance).to receive(:delete).with('/api/v2/connections/connectionId/users', { email: 'email@test.com' })
       @instance.delete_connection_user('connectionId', 'email@test.com')
     end
 

--- a/spec/lib/auth0/api/v2/device_credentials_spec.rb
+++ b/spec/lib/auth0/api/v2/device_credentials_spec.rb
@@ -13,13 +13,13 @@ describe Auth0::Api::V2::DeviceCredentials do
     it { expect(@instance).to respond_to(:list_device_credentials) }
     it 'is expected to send get request to /api/v2/device-credentials' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/device-credentials',
+        '/api/v2/device-credentials', {
         fields: nil,
         include_fields: nil,
         user_id: nil,
         client_id: client_id,
         type: nil
-      )
+      })
       expect { @instance.device_credentials(client_id) }.not_to raise_error
     end
     it 'is expect to raise an error when type is not one of \'public_key\', \'refresh_token\', \'rotating_refresh_token\'' do
@@ -34,13 +34,13 @@ describe Auth0::Api::V2::DeviceCredentials do
     it { expect(@instance).to respond_to(:create_device_public_key) }
     it 'is expected to send post to /api/v2/device-credentials' do
       expect(@instance).to receive(:post).with(
-        '/api/v2/device-credentials',
+        '/api/v2/device-credentials', {
         device_name: 'device_name',
         value: 'value',
         device_id: 'device_id',
         client_id: 'client_id',
         type: 'public_key'
-      )
+      })
       expect { @instance.create_device_credential('device_name', 'value', 'device_id', 'client_id') }
         .not_to raise_error
     end

--- a/spec/lib/auth0/api/v2/emails_spec.rb
+++ b/spec/lib/auth0/api/v2/emails_spec.rb
@@ -9,11 +9,11 @@ describe Auth0::Api::V2::Emails do
   context '.get_email' do
     it { expect(@instance).to respond_to(:get_provider) }
     it 'expect client to send get to /api/v2/emails/provider with fields' do
-      expect(@instance).to receive(:get).with('/api/v2/emails/provider', fields: 'some', include_fields: true)
+      expect(@instance).to receive(:get).with('/api/v2/emails/provider', { fields: 'some', include_fields: true })
       expect { @instance.get_provider(fields: 'some', include_fields: true) }.not_to raise_error
     end
     it 'expect client to send get to /api/v2/emails/provider with empty fields' do
-      expect(@instance).to receive(:get).with('/api/v2/emails/provider', fields: nil, include_fields: nil)
+      expect(@instance).to receive(:get).with('/api/v2/emails/provider', { fields: nil, include_fields: nil })
       expect { @instance.get_provider }.not_to raise_error
     end
   end

--- a/spec/lib/auth0/api/v2/grants_spec.rb
+++ b/spec/lib/auth0/api/v2/grants_spec.rb
@@ -12,14 +12,14 @@ describe Auth0::Api::V2::Grants do
 
     it 'is expected to get /api/v2/grants/' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/grants',
+        '/api/v2/grants', {
         client_id: nil,
         user_id: nil,
         audience: nil,
         page: nil,
         per_page: nil,
         include_totals: nil
-      )
+      })
       expect { @instance.grants }.not_to raise_error
     end
 
@@ -27,53 +27,53 @@ describe Auth0::Api::V2::Grants do
       audience = "https://samples.auth0.com/api/v2/"
 
       expect(@instance).to receive(:get).with(
-        '/api/v2/grants',
+        '/api/v2/grants', {
         client_id: '1',
         user_id: nil,
         audience: audience,
         page: nil,
         per_page: nil,
         include_totals: nil
-      )
+      })
       expect { @instance.grants(client_id: '1', audience: audience) }.not_to raise_error
     end
 
     it 'is expected to send get /api/v2/grants/ with client_id and user_id' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/grants',
+        '/api/v2/grants', {
         client_id: '1',
         user_id: '1',
         audience: nil,
         page: nil,
         per_page: nil,
         include_totals: nil
-      )
+      })
       expect { @instance.grants(client_id: '1', user_id: '1') }.not_to raise_error
     end
 
     it 'is expected to send get /api/v2/grants/ with pagination' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/grants',
+        '/api/v2/grants', {
         client_id: nil,
         user_id: nil,
         audience: nil,
         page: 1,
         per_page: 2,
         include_totals: nil
-      )
+      })
       expect { @instance.grants(page: 1, per_page: 2) }.not_to raise_error
     end
 
     it 'is expected to send get /api/v2/grants/ with include_totals' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/grants',
+        '/api/v2/grants', {
         client_id: nil,
         user_id: nil,
         audience: nil,
         page: 1,
         per_page: 2,
         include_totals: true
-      )
+      })
       expect { @instance.grants(page: 1, per_page: 2, include_totals: true) }.not_to raise_error
     end
   end

--- a/spec/lib/auth0/api/v2/jobs_spec.rb
+++ b/spec/lib/auth0/api/v2/jobs_spec.rb
@@ -25,24 +25,24 @@ describe Auth0::Api::V2::Jobs do
     it { expect(@instance).to respond_to(:import_users) }
     it 'expect client to send post to /api/v2/jobs/users-imports' do
       expect(@instance).to receive(:post_file).with(
-        '/api/v2/jobs/users-imports',
+        '/api/v2/jobs/users-imports', {
         users: 'file',
         connection_id: 'connnection_id',
         upsert: false,
         external_id: nil,
         send_completion_email: true
-      )
+      })
       expect { @instance.import_users('file', 'connnection_id') }.not_to raise_error
     end
     it 'expect client to send post to /api/v2/jobs/users-imports with options' do
       expect(@instance).to receive(:post_file).with(
-        '/api/v2/jobs/users-imports',
+        '/api/v2/jobs/users-imports', {
         users: 'file',
         connection_id: 'connnection_id',
         upsert: true,
         external_id: 'external_1',
         send_completion_email: false
-      )
+      })
       expect do
         @instance.import_users(
           'file',
@@ -61,12 +61,12 @@ describe Auth0::Api::V2::Jobs do
     it { expect { @instance.export_users }.not_to raise_error }
     it 'sends post to /api/v2/jobs/users-exports with correct params' do
       expect(@instance).to receive(:post).with(
-        '/api/v2/jobs/users-exports',
+        '/api/v2/jobs/users-exports', {
         fields: [{ name: 'author' }],
         connection_id: 'test-connection',
         format: 'csv',
         limit: 10
-      )
+      })
       @instance.export_users(
         fields: ['author'],
         connection_id: 'test-connection',
@@ -83,9 +83,9 @@ describe Auth0::Api::V2::Jobs do
 
     it 'should post to the jobs email verification endpoint' do
       expect(@instance).to receive(:post).with(
-        '/api/v2/jobs/verification-email',
+        '/api/v2/jobs/verification-email', {
         user_id: 'test_user_id'
-      )
+      })
       expect do
         @instance.send_verification_email('test_user_id')
       end.not_to raise_error
@@ -93,21 +93,22 @@ describe Auth0::Api::V2::Jobs do
 
     it 'should post to the jobs email verification endpoint with a client_id' do
       expect(@instance).to receive(:post).with(
-        '/api/v2/jobs/verification-email',
+        '/api/v2/jobs/verification-email', {
         user_id: 'test_user_id',
         client_id: 'test_client_id'
-      )
+      })
       expect do
         @instance.send_verification_email('test_user_id', 'test_client_id')
       end.not_to raise_error
     end
 
     it 'expect client to accept hash identity' do
-      expect(@instance).to receive(:post).with('/api/v2/jobs/verification-email', user_id: 'user_id',
-                                                                                  identity: {
-                                                                                    provider: "auth0",
-                                                                                    user_id: "user_id"
-                                                                                  })
+      expect(@instance).to receive(:post).with('/api/v2/jobs/verification-email', {
+        user_id: 'user_id',
+        identity: {
+        provider: "auth0",
+        user_id: "user_id"
+      }})
       expect {
         @instance.send_verification_email('user_id', identity: { provider: "auth0", user_id: "user_id"}) 
       }.not_to raise_error
@@ -120,10 +121,10 @@ describe Auth0::Api::V2::Jobs do
     end
 
     it 'expect client to accept organization_id' do
-      expect(@instance).to receive(:post).with('/api/v2/jobs/verification-email',
+      expect(@instance).to receive(:post).with('/api/v2/jobs/verification-email', {
         user_id: 'user_id',
         organization_id: 'org_id'
-      )
+      })
 
       expect {
         @instance.send_verification_email('user_id', organization_id: 'org_id')

--- a/spec/lib/auth0/api/v2/log_streams_spec.rb
+++ b/spec/lib/auth0/api/v2/log_streams_spec.rb
@@ -33,7 +33,7 @@ describe Auth0::Api::V2::LogStreams do
     it { expect(@instance).to respond_to(:create_log_stream) }
     it 'is expected to call post /api/v2/log-streams' do
       expect(@instance).to receive(:post).with(
-        '/api/v2/log-streams',
+        '/api/v2/log-streams', {
         name: 'test',
         type: 'https',
         sink: {
@@ -42,7 +42,7 @@ describe Auth0::Api::V2::LogStreams do
           httpContentFormat: "JSONLINES",
           httpAuthorization: "string"
         }
-      )
+      })
 
       @instance.create_log_stream('test', 'https',
         httpEndpoint: "https://mycompany.com",
@@ -75,7 +75,7 @@ describe Auth0::Api::V2::LogStreams do
   context '.patch_log_stream' do
     it { expect(@instance).to respond_to(:patch_log_stream) }
     it 'is expected to send patch to /api/v2/log_streams/test' do
-      expect(@instance).to receive(:patch).with('/api/v2/log-streams/test', status: 'paused')
+      expect(@instance).to receive(:patch).with('/api/v2/log-streams/test', { status: 'paused' })
       expect { @instance.patch_log_stream('test', 'paused') }.not_to raise_error
     end
     it { expect { @instance.patch_log_stream('', nil) }.to raise_error 'Must specify a log stream id' }

--- a/spec/lib/auth0/api/v2/logs_spec.rb
+++ b/spec/lib/auth0/api/v2/logs_spec.rb
@@ -11,7 +11,7 @@ describe Auth0::Api::V2::Logs do
     it { expect(@instance).to respond_to(:get_logs) }
     it 'is expected to call /api/v2/logs' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/logs',
+        '/api/v2/logs', {
         q: nil,
         page: nil,
         per_page: nil,
@@ -21,7 +21,7 @@ describe Auth0::Api::V2::Logs do
         include_totals: nil,
         from: nil,
         take: nil
-      )
+      })
       expect { @instance.logs }.not_to raise_error
     end
     it 'is expect to rise an error when take is higher than 100' do

--- a/spec/lib/auth0/api/v2/organizations_spec.rb
+++ b/spec/lib/auth0/api/v2/organizations_spec.rb
@@ -17,25 +17,25 @@ describe Auth0::Api::V2::Organizations do
 
     it 'is expected to get /api/v2/organizations' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/organizations',
+        '/api/v2/organizations', {
         per_page: nil,
         page: nil,
         from: nil,
         take: nil,
         include_totals: nil
-      )
+      })
       expect { @instance.organizations }.not_to raise_error
     end
 
     it 'is expected to get /api/v2/organizations with custom parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/organizations',
+        '/api/v2/organizations', {
         per_page: 10,
         page: 1,
         from: 'org_id',
         take: 50,
         include_totals: true
-      )
+      })
       expect do
         @instance.organizations(
           per_page: 10,
@@ -72,9 +72,9 @@ describe Auth0::Api::V2::Organizations do
 
     it 'is expected to post to /api/v2/organizations' do
       expect(@instance).to receive(:post).with(
-        '/api/v2/organizations',
+        '/api/v2/organizations', {
           name: 'test_org'
-        )
+        })
       expect do
         @instance.create_organization(
           name: 'test_org'
@@ -130,9 +130,9 @@ describe Auth0::Api::V2::Organizations do
 
     it 'is expected to patch /api/v2/organizations/org_id' do
       expect(@instance).to receive(:patch).with(
-        '/api/v2/organizations/org_id',
+        '/api/v2/organizations/org_id', {
         name: 'name'
-      )
+      })
       @instance.patch_organization(
         'org_id',
         name: 'name'
@@ -446,13 +446,13 @@ describe Auth0::Api::V2::Organizations do
 
     it 'is expected to get members for an org' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/organizations/org_id/members',
+        '/api/v2/organizations/org_id/members', {
         per_page: nil,
         page: nil,
         from: nil,
         take: nil,
         include_totals: nil
-      )
+      })
       expect do
         @instance.get_organizations_members('org_id')
       end.not_to raise_error
@@ -460,13 +460,13 @@ describe Auth0::Api::V2::Organizations do
 
     it 'is expected to get /api/v2/organizations with custom parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/organizations/org_id/members',
+        '/api/v2/organizations/org_id/members', {
         per_page: 10,
         page: 1,
         from: 'org_id',
         take: 50,
         include_totals: true
-      )
+      })
       expect do
         @instance.get_organizations_members(
           'org_id',

--- a/spec/lib/auth0/api/v2/resource_servers_spec.rb
+++ b/spec/lib/auth0/api/v2/resource_servers_spec.rb
@@ -12,10 +12,10 @@ describe Auth0::Api::V2::ResourceServers do
     it { expect(@instance).to respond_to(:get_resource_servers) }
     it 'is expected to call get /api/v2/resource-servers' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/resource-servers',
+        '/api/v2/resource-servers', {
         page: nil,
         per_page: nil,
-      )
+      })
       expect { @instance.resource_servers }.not_to raise_error
     end
   end
@@ -35,14 +35,14 @@ describe Auth0::Api::V2::ResourceServers do
     it { expect(@instance).to respond_to(:create_resource_server) }
     it 'is expected to call post /api/v2/resource-servers' do
       expect(@instance).to receive(:post).with(
-        '/api/v2/resource-servers',
+        '/api/v2/resource-servers', {
         identifier: 'test',
         name: 'name',
         signing_alg: 'signing_alg',
         signing_secret: 'signing_secret',
         token_lifetime: 'token_lifetime',
         scopes: 'scopes'
-      )
+      })
 
       @instance.create_resource_server('test', name: 'name',
                                                signing_alg: 'signing_alg',
@@ -77,7 +77,7 @@ describe Auth0::Api::V2::ResourceServers do
   context '.patch_resource_server' do
     it { expect(@instance).to respond_to(:patch_resource_server) }
     it 'is expected to send patch to /api/v2/resource_servers/1' do
-      expect(@instance).to receive(:patch).with('/api/v2/resource-servers/1', fields: 'fields')
+      expect(@instance).to receive(:patch).with('/api/v2/resource-servers/1', { fields: 'fields' })
       expect { @instance.patch_resource_server('1', fields: 'fields') }.not_to raise_error
     end
     it { expect { @instance.patch_resource_server('', nil) }.to raise_error Auth0::InvalidParameter }

--- a/spec/lib/auth0/api/v2/roles_spec.rb
+++ b/spec/lib/auth0/api/v2/roles_spec.rb
@@ -17,23 +17,23 @@ describe Auth0::Api::V2::Roles do
 
     it 'is expected to get Roles with default parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/roles',
+        '/api/v2/roles', {
         per_page: nil,
         page: nil,
         include_totals: nil,
         name_filter: nil
-      )
+      })
       expect { @instance.get_roles }.not_to raise_error
     end
 
     it 'is expected to get Roles with custom parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/roles',
+        '/api/v2/roles', {
         per_page: 10,
         page: 3,
         include_totals: true,
         name_filter: 'test'
-      )
+      })
       expect do
         @instance.get_roles(per_page: 10, page: 3, include_totals: true, name_filter: 'test')
       end.not_to raise_error
@@ -76,10 +76,10 @@ describe Auth0::Api::V2::Roles do
 
     it 'is expected to post a new Role' do
       expect(@instance).to receive(:post).with(
-        '/api/v2/roles',
+        '/api/v2/roles', {
         name: 'ROLE_NAME',
         description: 'ROLE_DESCRIPTION'
-      )
+      })
       expect do
         @instance.create_role(
           'ROLE_NAME',
@@ -103,10 +103,10 @@ describe Auth0::Api::V2::Roles do
 
     it 'is expected to post an updated Role' do
       expect(@instance).to receive(:patch).with(
-        '/api/v2/roles/ROLE_ID',
+        '/api/v2/roles/ROLE_ID', {
         name: 'ROLE_NAME',
         description: 'ROLE_DESCRIPTION'
-      )
+      })
       expect do
         @instance.update_role(
           'ROLE_ID',
@@ -149,25 +149,25 @@ describe Auth0::Api::V2::Roles do
 
     it 'is expected to get Users for a Role with default parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/roles/ROLE_ID/users',
+        '/api/v2/roles/ROLE_ID/users', {
         per_page: nil,
         page: nil,
         from: nil,
         take: nil,
         include_totals: nil
-      )
+      })
       expect { @instance.get_role_users('ROLE_ID') }.not_to raise_error
     end
 
     it 'is expected to get Users for a Role with custom parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/roles/ROLE_ID/users',
+        '/api/v2/roles/ROLE_ID/users', {
         per_page: 30,
         page: 4,
         from: 'org_id',
         take: 50,
         include_totals: true
-      )
+      })
       expect do
         @instance.get_role_users('ROLE_ID', per_page: 30, page: 4, from: 'org_id', take: 50, include_totals: true)
       end.not_to raise_error
@@ -202,9 +202,9 @@ describe Auth0::Api::V2::Roles do
 
     it 'is expected to add Users to a Role' do
       expect(@instance).to receive(:post).with(
-        '/api/v2/roles/ROLE_ID/users',
+        '/api/v2/roles/ROLE_ID/users', {
         users: %w[test|user-01 test|user-02]
-      )
+      })
       expect do
         @instance.add_role_users('ROLE_ID', %w[test|user-01 test|user-02])
       end.not_to raise_error
@@ -225,21 +225,21 @@ describe Auth0::Api::V2::Roles do
 
     it 'is expected to get Roles with default parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/roles/ROLE_ID/permissions',
+        '/api/v2/roles/ROLE_ID/permissions', {
         per_page: nil,
         page: nil,
         include_totals: nil
-      )
+      })
       expect { @instance.get_role_permissions('ROLE_ID') }.not_to raise_error
     end
 
     it 'is expected to get Roles with custom parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/roles/ROLE_ID/permissions',
+        '/api/v2/roles/ROLE_ID/permissions', {
         per_page: 15,
         page: 5,
         include_totals: true
-      )
+      })
       expect do
         @instance.get_role_permissions('ROLE_ID', per_page: 15, page: 5, include_totals: true)
       end.not_to raise_error
@@ -281,7 +281,7 @@ describe Auth0::Api::V2::Roles do
 
     it 'is expected to add permissions to a Role' do
       expect(@instance).to receive(:post).with(
-        '/api/v2/roles/ROLE_ID/permissions',
+        '/api/v2/roles/ROLE_ID/permissions', {
         permissions: [
           {
             permission_name: 'permission-name-1',
@@ -292,7 +292,7 @@ describe Auth0::Api::V2::Roles do
             resource_server_identifier: 'server-id-2'
           }
         ]
-      )
+      })
       expect do
         @instance.add_role_permissions(
           'ROLE_ID',
@@ -340,7 +340,7 @@ describe Auth0::Api::V2::Roles do
 
     it 'is expected to remove permissions from a Role' do
       expect(@instance).to receive(:delete_with_body).with(
-        '/api/v2/roles/ROLE_ID/permissions',
+        '/api/v2/roles/ROLE_ID/permissions', {
         permissions: [
           {
             permission_name: 'permission-name-3',
@@ -351,7 +351,7 @@ describe Auth0::Api::V2::Roles do
             resource_server_identifier: 'server-id-4'
           }
         ]
-      )
+      })
       expect do
         @instance.remove_role_permissions(
           'ROLE_ID',

--- a/spec/lib/auth0/api/v2/rules_spec.rb
+++ b/spec/lib/auth0/api/v2/rules_spec.rb
@@ -12,27 +12,27 @@ describe Auth0::Api::V2::Rules do
 
     it 'is expected to call get /api/v2/rules' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/rules',
+        '/api/v2/rules', {
         enabled: nil,
         fields: nil,
         include_fields: nil,
         stage: nil,
         page: nil,
         per_page: nil
-      )
+      })
       expect { @instance.rules }.not_to raise_error
     end
 
     it 'is expected to call get /api/v2/rules with pagination' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/rules',
+        '/api/v2/rules', {
         enabled: nil,
         fields: nil,
         include_fields: nil,
         stage: nil,
         page: 1,
         per_page: 2
-      )
+      })
       expect {
         @instance.rules(page: 1, per_page: 2)
       }.not_to raise_error
@@ -43,7 +43,7 @@ describe Auth0::Api::V2::Rules do
     it { expect(@instance).to respond_to(:rule) }
     it 'is expected to call get /api/v2/rules/test' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/rules/test', fields: nil, include_fields: nil
+        '/api/v2/rules/test', { fields: nil, include_fields: nil }
       )
       expect { @instance.rule('test') }.not_to raise_error
     end
@@ -57,7 +57,7 @@ describe Auth0::Api::V2::Rules do
     it 'is expected to call post /api/v2/rules' do
       expect(@instance).to receive(:post).with(
         '/api/v2/rules',
-        name: 'test', script: 'script', order: 'order', enabled: false, stage: 'login_success'
+        { name: 'test', script: 'script', order: 'order', enabled: false, stage: 'login_success' }
       )
       expect { @instance.create_rule('test', 'script', 'order', false) }.not_to raise_error
     end
@@ -72,7 +72,7 @@ describe Auth0::Api::V2::Rules do
     it { expect(@instance).to respond_to(:update_rule) }
     it 'is expected to call put /api/v2/rules/test' do
       expect(@instance).to receive(:patch).with(
-        '/api/v2/rules/test', script: 'script', order: 'order', enabled: true, stage: 'some_stage'
+        '/api/v2/rules/test', { script: 'script', order: 'order', enabled: true, stage: 'some_stage' }
       )
       expect do
         @instance.update_rule('test', script: 'script', order: 'order', enabled: true, stage: 'some_stage')

--- a/spec/lib/auth0/api/v2/stats_spec.rb
+++ b/spec/lib/auth0/api/v2/stats_spec.rb
@@ -15,7 +15,7 @@ describe Auth0::Api::V2::Stats do
   context '.daily_stats' do
     it { expect(@instance).to respond_to(:daily_stats) }
     it 'expect client to send get to /api/v2/stats/daily' do
-      expect(@instance).to receive(:get).with('/api/v2/stats/daily', from: '20120222', to: '20151222')
+      expect(@instance).to receive(:get).with('/api/v2/stats/daily', { from: '20120222', to: '20151222' })
       expect { @instance.daily_stats('20120222', '20151222') }.not_to raise_error
     end
   end

--- a/spec/lib/auth0/api/v2/tenants_spec.rb
+++ b/spec/lib/auth0/api/v2/tenants_spec.rb
@@ -7,7 +7,7 @@ describe Auth0::Api::V2::Tenants do
   context '.get_tenant_settings' do
     it { expect(@instance).to respond_to(:get_tenant_settings) }
     it 'expect client to send post to /api/v2/tenants/settings with fields' do
-      expect(@instance).to receive(:get).with('/api/v2/tenants/settings', fields: 'field', include_fields: true)
+      expect(@instance).to receive(:get).with('/api/v2/tenants/settings', { fields: 'field', include_fields: true })
       expect { @instance.get_tenant_settings(fields: 'field') }.not_to raise_error
     end
   end

--- a/spec/lib/auth0/api/v2/tickets_spec.rb
+++ b/spec/lib/auth0/api/v2/tickets_spec.rb
@@ -7,28 +7,28 @@ describe Auth0::Api::V2::Tickets do
   context '.post_email_verification' do
     it { expect(@instance).to respond_to(:post_email_verification) }
     it 'expect client to send post to /api/v2/tickets/email-verification with body' do
-      expect(@instance).to receive(:post).with('/api/v2/tickets/email-verification', user_id: 'user_id',
-                                                                                     result_url: nil, ttl_sec: nil)
+      expect(@instance).to receive(:post).with('/api/v2/tickets/email-verification', { user_id: 'user_id',
+                                                                                     result_url: nil, ttl_sec: nil })
       expect { @instance.post_email_verification('user_id') }.not_to raise_error
     end
     it 'expect client to accept integer ttl_sec' do
-      expect(@instance).to receive(:post).with('/api/v2/tickets/email-verification', user_id: 'user_id',
-                                                                                     result_url: nil, ttl_sec: 300)
+      expect(@instance).to receive(:post).with('/api/v2/tickets/email-verification', { user_id: 'user_id',
+                                                                                     result_url: nil, ttl_sec: 300 })
       expect { @instance.post_email_verification('user_id', ttl_sec: 300) }.not_to raise_error
     end
     it 'expect client to return nil when calling with a non-integer ttl_sec' do
-      expect(@instance).to receive(:post).with('/api/v2/tickets/email-verification', user_id: 'user_id',
-                                                                                     result_url: nil, ttl_sec: nil)
+      expect(@instance).to receive(:post).with('/api/v2/tickets/email-verification', { user_id: 'user_id',
+                                                                                     result_url: nil, ttl_sec: nil })
       expect { @instance.post_email_verification('user_id', ttl_sec: "noninteger") }.not_to raise_error
     end
     it 'expect client to accept hash identity' do
-      expect(@instance).to receive(:post).with('/api/v2/tickets/email-verification', user_id: 'user_id',
+      expect(@instance).to receive(:post).with('/api/v2/tickets/email-verification', { user_id: 'user_id',
                                                                                      result_url: nil, 
                                                                                      ttl_sec: nil,
                                                                                      identity: {
                                                                                       provider: "auth0",
                                                                                       user_id: "user_id"
-                                                                                     })
+                                                                                     }})
       expect {
         @instance.post_email_verification('user_id', identity: { provider: "auth0", user_id: "user_id"}) 
       }.not_to raise_error
@@ -48,7 +48,7 @@ describe Auth0::Api::V2::Tickets do
   context '.post_password_change' do
     it { expect(@instance).to respond_to(:post_password_change) }
     it 'expect client to send post to /api/v2/tickets/password-change with body' do
-      expect(@instance).to receive(:post).with('/api/v2/tickets/password-change',
+      expect(@instance).to receive(:post).with('/api/v2/tickets/password-change', {
                                                result_url: nil,
                                                user_id: nil,
                                                connection_id: nil,
@@ -56,12 +56,12 @@ describe Auth0::Api::V2::Tickets do
                                                ttl_sec: nil,
                                                mark_email_as_verified: nil,
                                                includeEmailInRedirect: nil,
-                                               new_password: nil)
+                                               new_password: nil })
       expect {@instance.post_password_change}.not_to raise_error
     end
     
     it 'expect client to accept organization_id' do
-      expect(@instance).to receive(:post).with('/api/v2/tickets/password-change',
+      expect(@instance).to receive(:post).with('/api/v2/tickets/password-change', {
         result_url: nil,
         user_id: nil,
         connection_id: nil,
@@ -72,7 +72,7 @@ describe Auth0::Api::V2::Tickets do
         new_password: nil,
         client_id: '123',
         organization_id: '999'
-      )
+      })
       expect {
         @instance.post_password_change(
           result_url: nil,
@@ -89,7 +89,7 @@ describe Auth0::Api::V2::Tickets do
     end
 
     it 'expect client to accept client_id' do
-      expect(@instance).to receive(:post).with('/api/v2/tickets/password-change',
+      expect(@instance).to receive(:post).with('/api/v2/tickets/password-change', {
         result_url: nil,
         user_id: nil,
         connection_id: nil,
@@ -99,7 +99,7 @@ describe Auth0::Api::V2::Tickets do
         includeEmailInRedirect: nil,
         new_password: nil,
         client_id: '123'
-      )
+      })
       expect {
         @instance.post_password_change(
           result_url: nil,

--- a/spec/lib/auth0/api/v2/user_blocks_spec.rb
+++ b/spec/lib/auth0/api/v2/user_blocks_spec.rb
@@ -9,7 +9,7 @@ describe Auth0::Api::V2::UserBlocks do
   context '.user_blocks' do
     it { expect(@instance).to respond_to(:user_blocks) }
     it 'is expected to call /api/v2/user-blocks?identifier=Test' do
-      expect(@instance).to receive(:get).with('/api/v2/user-blocks', identifier: 'Test')
+      expect(@instance).to receive(:get).with('/api/v2/user-blocks', { identifier: 'Test' })
       expect { @instance.user_blocks('Test') }.not_to raise_error
     end
     it 'expect client to raise an error when calling with empty identifier' do
@@ -20,7 +20,7 @@ describe Auth0::Api::V2::UserBlocks do
   context '.delete_user_blocks' do
     it { expect(@instance).to respond_to(:delete_user_blocks) }
     it 'is expected to call /api/v2/user-blocks?identifier=Test' do
-      expect(@instance).to receive(:delete).with('/api/v2/user-blocks', identifier: 'Test')
+      expect(@instance).to receive(:delete).with('/api/v2/user-blocks', { identifier: 'Test' })
       expect { @instance.delete_user_blocks('Test') }.not_to raise_error
     end
     it 'expect client to raise an error when calling with empty identifier' do

--- a/spec/lib/auth0/api/v2/users_by_email_spec.rb
+++ b/spec/lib/auth0/api/v2/users_by_email_spec.rb
@@ -10,11 +10,11 @@ describe Auth0::Api::V2::UsersByEmail do
     it { expect(@instance).to respond_to(:users_by_email) }
     it 'is expected to call /api/v2/users-by-email' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/users-by-email',
+        '/api/v2/users-by-email', {
         fields: nil,
         include_fields: nil,
         email: 'email'
-      )
+      })
       expect { @instance.users_by_email('email') }.not_to raise_error
     end
   end

--- a/spec/lib/auth0/api/v2/users_spec.rb
+++ b/spec/lib/auth0/api/v2/users_spec.rb
@@ -17,7 +17,7 @@ describe Auth0::Api::V2::Users do
 
     it 'is expected to get /api/v2/users' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/users',
+        '/api/v2/users', {
         per_page: nil,
         page: nil,
         include_totals: nil,
@@ -27,13 +27,13 @@ describe Auth0::Api::V2::Users do
         include_fields: nil,
         q: nil,
         search_engine: nil
-      )
+      })
       expect { @instance.users }.not_to raise_error
     end
 
     it 'is expected to get /api/v2/users with custom parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/users',
+        '/api/v2/users', {
         per_page: 10,
         page: 1,
         include_totals: true,
@@ -43,7 +43,7 @@ describe Auth0::Api::V2::Users do
         include_fields: nil,
         q: nil,
         search_engine: 'v3'
-      )
+      })
       expect do
         @instance.users(
           search_engine: 'v3',
@@ -64,10 +64,10 @@ describe Auth0::Api::V2::Users do
 
     it 'is expected to call get request to /api/v2/users/USER_ID' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/users/USER_ID',
+        '/api/v2/users/USER_ID', {
         fields: nil,
         include_fields: true
-      )
+      })
       expect { @instance.user('USER_ID') }.not_to raise_error
     end
 
@@ -83,11 +83,11 @@ describe Auth0::Api::V2::Users do
 
     it 'is expected to post to /api/v2/users' do
       expect(@instance).to receive(:post).with(
-        '/api/v2/users',
+        '/api/v2/users', {
         email: 'test@test.com',
         password: 'password',
         connection: 'conn'
-      )
+      })
       expect do
         @instance.create_user(
           'conn',
@@ -169,12 +169,12 @@ describe Auth0::Api::V2::Users do
 
     it 'is expected to patch /api/v2/users/USER_ID' do
       expect(@instance).to receive(:patch).with(
-        '/api/v2/users/USER_ID',
+        '/api/v2/users/USER_ID', {
         email: 'test@test.com',
         password: 'password',
         connection: 'conn',
         name: 'name'
-      )
+      })
       @instance.patch_user(
         'USER_ID',
         email: 'test@test.com',
@@ -199,7 +199,7 @@ describe Auth0::Api::V2::Users do
     end
 
     it 'is expected to post to /api/v2/users/UserId/identities' do
-      expect(@instance).to receive(:post).with('/api/v2/users/USER_ID/identities', body: 'json body')
+      expect(@instance).to receive(:post).with('/api/v2/users/USER_ID/identities', { body: 'json body' })
       @instance.link_user_account('USER_ID', body: 'json body')
     end
 
@@ -255,12 +255,12 @@ describe Auth0::Api::V2::Users do
 
     it 'is expected to get /api/v2/USER_ID/logs' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/users/USER_ID/logs',
+        '/api/v2/users/USER_ID/logs', {
         per_page: nil,
         page: nil,
         include_totals: nil,
         sort: nil
-      )
+      })
       expect { @instance.user_logs('USER_ID') }.not_to raise_error
     end
 
@@ -292,21 +292,21 @@ describe Auth0::Api::V2::Users do
 
     it 'is expected to get roles with default parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/users/USER_ID/roles',
+        '/api/v2/users/USER_ID/roles', {
         per_page: nil,
         page: nil,
         include_totals: nil
-      )
+      })
       expect { @instance.get_user_roles('USER_ID') }.not_to raise_error
     end
 
     it 'is expected to get roles with custom parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/users/USER_ID/roles',
+        '/api/v2/users/USER_ID/roles', {
         per_page: 20,
         page: 2,
         include_totals: true
-      )
+      })
       expect do
         @instance.get_user_roles('USER_ID', per_page: 20, page: 2, include_totals: true)
       end.not_to raise_error
@@ -401,11 +401,11 @@ describe Auth0::Api::V2::Users do
 
     it 'is expected to get permissions' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/users/USER_ID/permissions',
+        '/api/v2/users/USER_ID/permissions', {
         per_page: nil,
         page: nil,
         include_totals: nil,
-      )
+      })
       expect do
         @instance.get_user_permissions('USER_ID')
       end.not_to raise_error
@@ -413,11 +413,11 @@ describe Auth0::Api::V2::Users do
 
     it 'is expected to get permissions with custom parameters' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/users/USER_ID/permissions',
+        '/api/v2/users/USER_ID/permissions', {
         per_page: 10,
         page: 3,
         include_totals: true
-      )
+      })
       expect do
         @instance.get_user_permissions('USER_ID', per_page: 10, page: 3, include_totals: true)
       end.not_to raise_error
@@ -445,7 +445,7 @@ describe Auth0::Api::V2::Users do
 
     it 'is expected to remove permissions' do
       expect(@instance).to receive(:delete_with_body).with(
-        '/api/v2/users/USER_ID/permissions',
+        '/api/v2/users/USER_ID/permissions', {
         permissions: [
           {
             permission_name: 'permission-name-1',
@@ -456,7 +456,7 @@ describe Auth0::Api::V2::Users do
             resource_server_identifier: 'server-id-2'
           }
         ]
-      )
+      })
       expect do
         @instance.remove_user_permissions(
           'USER_ID',


### PR DESCRIPTION
### Changes

Tests were starting to fail after upgrading `rspec-mocks` on Ruby 3.0, thanks to [this change in Ruby 3](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/). This PR updates the tests so that they now run and pass.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of Ruby

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [ ] Rubocop passes on all added/modified files
- [x] All active GitHub checks have passed
