### PR TITLE
Release 5.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-# Changelog
+# Change Log
+
+## [v5.6.2](https://github.com/auth0/ruby-auth0/tree/v5.6.2) (2022-02-14)
+
+[Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.6.1...v5.6.2)
+
+**Fixed**
+
+- [SDK-3106] Fix up tests for Ruby 3 and rspec-mocks update [\#313](https://github.com/auth0/ruby-auth0/pull/313) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- `delete_organizations_member_roles` should use `delete_with_body` instead of `delete` [\#311](https://github.com/auth0/ruby-auth0/pull/311) ([SanterreJo](https://github.com/SanterreJo))
 
 ## [v5.6.1](https://github.com/auth0/ruby-auth0/tree/v5.6.1) (2021-09-14)
 

--- a/lib/auth0/version.rb
+++ b/lib/auth0/version.rb
@@ -1,4 +1,4 @@
 # current version of gem
 module Auth0
-  VERSION = '5.6.1'.freeze
+  VERSION = '5.6.2'.freeze
 end


### PR DESCRIPTION
[Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.6.1...v5.7.0)

**Added**

- [SDK-3188] Support for Attack Protection endpoints in Management API client [\#316](https://github.com/auth0/ruby-auth0/pull/316) ([stevehobbsdev](https://github.com/stevehobbsdev))

**Fixed**

- [SDK-3106] Fix up tests for Ruby 3 and rspec-mocks update [\#313](https://github.com/auth0/ruby-auth0/pull/313) ([stevehobbsdev](https://github.com/stevehobbsdev))
- `delete_organizations_member_roles` should use `delete_with_body` instead of `delete` [\#311](https://github.com/auth0/ruby-auth0/pull/311) ([SanterreJo](https://github.com/SanterreJo))


[SDK-3106]: https://auth0team.atlassian.net/browse/SDK-3106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ