### PR TITLE
[SDK-3118] Add attack protection endpoints

### DIFF
--- a/lib/auth0/api/v2.rb
+++ b/lib/auth0/api/v2.rb
@@ -23,6 +23,7 @@ require 'auth0/api/v2/logs'
 require 'auth0/api/v2/log_streams'
 require 'auth0/api/v2/resource_servers'
 require 'auth0/api/v2/guardian'
+require 'auth0/api/v2/attack_protection'
 
 module Auth0
   module Api
@@ -53,6 +54,7 @@ module Auth0
       include Auth0::Api::V2::ResourceServers
       include Auth0::Api::V2::Tenants
       include Auth0::Api::V2::Tickets
+      include Auth0::Api::V2::AttackProtection
     end
   end
 end

--- a/lib/auth0/api/v2/attack_protection.rb
+++ b/lib/auth0/api/v2/attack_protection.rb
@@ -1,0 +1,24 @@
+module Auth0
+  module Api
+    module V2
+      module AttackProtection
+        attr_reader :attack_protection_path
+
+        def breached_password_detection
+          get(breached_password_settings_path)
+        end
+        alias get_breached_password_detection_settings breached_password_detection
+      end
+
+      private
+      
+      def attack_protection_path
+        @attack_protection_path ||= '/api/v2/attack_protection'
+      end
+
+      def breached_password_settings_path
+        "#{@attack_protection_path}/breached-password-detection"
+      end
+    end
+  end
+end

--- a/lib/auth0/api/v2/attack_protection.rb
+++ b/lib/auth0/api/v2/attack_protection.rb
@@ -12,6 +12,16 @@ module Auth0
         def patch_breached_password_detection(body)
           patch(breached_password_settings_path, body)
         end
+
+        def brute_force_protection
+          get(brute_force_protection_settings_path)
+        end
+        alias get_brute_force_protection_settings brute_force_protection
+
+        def patch_brute_force_protection(body)
+          patch(brute_force_protection_settings_path, body)
+        end
+        alias update_brute_force_protection_settings patch_brute_force_protection
         
         private
         
@@ -22,6 +32,10 @@ module Auth0
         
         def breached_password_settings_path
           "#{attack_protection_path}/breached-password-detection"
+        end
+
+        def brute_force_protection_settings_path
+          "#{attack_protection_path}/brute-force-protection"
         end
       end
     end

--- a/lib/auth0/api/v2/attack_protection.rb
+++ b/lib/auth0/api/v2/attack_protection.rb
@@ -1,33 +1,55 @@
 module Auth0
   module Api
     module V2
+      # Methods to use the attack-protection endpoints
       module AttackProtection
         attr_reader :attack_protection_path
 
+        # Get breached password detection settings
+        # @see https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_breached_password_detection
+        # @return [json] The configuration for breached password detection
         def breached_password_detection
           get(breached_password_settings_path)
         end
         alias get_breached_password_detection_settings breached_password_detection
 
+        # Update breached password detection settings
+        # @see https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_breached_password_detection
+        # @param body [hash] See https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_breached_password_detection for available options
+        # @return [json] The configuration for breached password detection
         def patch_breached_password_detection(body)
           patch(breached_password_settings_path, body)
         end
 
+        # Get brute force protection settings.
+        # @see https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_brute_force_protection
+        # @return [json] The configuration for brute force protection
         def brute_force_protection
           get(brute_force_protection_settings_path)
         end
         alias get_brute_force_protection_settings brute_force_protection
 
+        # Update brute force protection settings.
+        # @see https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_brute_force_protection
+        # @param body [hash] See https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_brute_force_protection for available options
+        # @return [json] The configuration for brute force protection
         def patch_brute_force_protection(body)
           patch(brute_force_protection_settings_path, body)
         end
         alias update_brute_force_protection_settings patch_brute_force_protection
 
+        # Get suspicious IP throttling settings
+        # @see https://auth0.com/docs/api/management/v2#!/Attack_Protection/get_suspicious_ip_throttling
+        # @return The configuration for suspicious IP throttling
         def suspicious_ip_throttling
           get(suspicious_ip_throttling_settings_path)
         end
         alias get_suspicious_ip_throttling_settings suspicious_ip_throttling
 
+        # Update suspicious IP throttling settings
+        # @see https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_suspicious_ip_throttling
+        # @param body [hash] See https://auth0.com/docs/api/management/v2#!/Attack_Protection/patch_suspicious_ip_throttling for available options
+        # @return The configuration for suspicious IP throttling
         def patch_suspicious_ip_throttling(body)
           patch(suspicious_ip_throttling_settings_path, body)
         end

--- a/lib/auth0/api/v2/attack_protection.rb
+++ b/lib/auth0/api/v2/attack_protection.rb
@@ -22,7 +22,17 @@ module Auth0
           patch(brute_force_protection_settings_path, body)
         end
         alias update_brute_force_protection_settings patch_brute_force_protection
-        
+
+        def suspicious_ip_throttling
+          get(suspicious_ip_throttling_settings_path)
+        end
+        alias get_suspicious_ip_throttling_settings suspicious_ip_throttling
+
+        def patch_suspicious_ip_throttling(body)
+          patch(suspicious_ip_throttling_settings_path, body)
+        end
+        alias update_suspicious_ip_throttling_settings patch_suspicious_ip_throttling
+
         private
         
         def attack_protection_path
@@ -36,6 +46,10 @@ module Auth0
 
         def brute_force_protection_settings_path
           "#{attack_protection_path}/brute-force-protection"
+        end
+
+        def suspicious_ip_throttling_settings_path
+          "#{attack_protection_path}/suspicious-ip-throttling"
         end
       end
     end

--- a/lib/auth0/api/v2/attack_protection.rb
+++ b/lib/auth0/api/v2/attack_protection.rb
@@ -8,12 +8,17 @@ module Auth0
           get(breached_password_settings_path)
         end
         alias get_breached_password_detection_settings breached_password_detection
+
+        def patch_breached_password_detection(body)
+          patch(breached_password_settings_path, body)
+        end
         
         private
         
         def attack_protection_path
           @attack_protection_path ||= '/api/v2/attack-protection'
         end
+        alias update_breached_password_detection_settings patch_breached_password_detection
         
         def breached_password_settings_path
           "#{attack_protection_path}/breached-password-detection"

--- a/lib/auth0/api/v2/attack_protection.rb
+++ b/lib/auth0/api/v2/attack_protection.rb
@@ -8,16 +8,16 @@ module Auth0
           get(breached_password_settings_path)
         end
         alias get_breached_password_detection_settings breached_password_detection
-      end
-
-      private
-      
-      def attack_protection_path
-        @attack_protection_path ||= '/api/v2/attack_protection'
-      end
-
-      def breached_password_settings_path
-        "#{@attack_protection_path}/breached-password-detection"
+        
+        private
+        
+        def attack_protection_path
+          @attack_protection_path ||= '/api/v2/attack-protection'
+        end
+        
+        def breached_password_settings_path
+          "#{attack_protection_path}/breached-password-detection"
+        end
       end
     end
   end

--- a/spec/lib/auth0/api/v2/attack_protection_spec.rb
+++ b/spec/lib/auth0/api/v2/attack_protection_spec.rb
@@ -11,5 +11,17 @@ describe Auth0::Api::V2::AttackProtection do
     it 'is expected to respond to a breached_password_detection method' do
       expect(@instance).to respond_to(:breached_password_detection)
     end
+
+    it 'is expected to respond to get_breached_password_detection_settings' do
+      expect(@instance).to respond_to(:get_breached_password_detection_settings)
+    end
+
+    it 'is expected to get /api/v2/attack-protection/breached-password' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/attack-protection/breached-password-detection'
+      )
+
+      expect { @instance.breached_password_detection }.not_to raise_error
+    end
   end
 end

--- a/spec/lib/auth0/api/v2/attack_protection_spec.rb
+++ b/spec/lib/auth0/api/v2/attack_protection_spec.rb
@@ -7,12 +7,12 @@ describe Auth0::Api::V2::AttackProtection do
     @instance = dummy_instance
   end
 
-  context '.attack_protection' do
-    it 'is expected to respond to a breached_password_detection method' do
+  context '.get breached-password-detection' do
+    it 'responds to a breached_password_detection method' do
       expect(@instance).to respond_to(:breached_password_detection)
     end
 
-    it 'is expected to respond to get_breached_password_detection_settings' do
+    it 'responds to get_breached_password_detection_settings' do
       expect(@instance).to respond_to(:get_breached_password_detection_settings)
     end
 
@@ -26,17 +26,18 @@ describe Auth0::Api::V2::AttackProtection do
   end
 
   context '.patch breached-password-detection' do
-    it 'is expected to respond to a patch_breached_password_detection method' do
+    it 'responds to a patch_breached_password_detection method' do
       expect(@instance).to respond_to(:patch_breached_password_detection)
     end
 
-    it 'is expected to respond to a update_breached_password_detection_settings method' do
+    it 'responds to a update_breached_password_detection_settings method' do
       expect(@instance).to respond_to(:update_breached_password_detection_settings)
     end
 
     it 'is expected to patch /api/v2/attack-protection/breached-password-detection' do
       expect(@instance).to receive(:patch).with(
-        '/api/v2/attack-protection/breached-password-detection', {
+        '/api/v2/attack-protection/breached-password-detection',
+        {
           enabled: true
         }
       )
@@ -47,4 +48,44 @@ describe Auth0::Api::V2::AttackProtection do
     end
   end
 
+  context '.get brute_force_protection' do
+    it 'responds to brute_force_protection' do
+      expect(@instance).to respond_to(:brute_force_protection)
+    end
+
+    it 'responds to get_brute_force_protection_settings' do
+      expect(@instance).to respond_to(:get_brute_force_protection_settings)
+    end
+
+    it 'is expected to get /api/v2/attack-protection/brute-force-protection' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/attack-protection/brute-force-protection'
+      )
+
+      expect { @instance.brute_force_protection }.not_to raise_error
+    end
+  end
+
+  context '.patch brute-force-protection' do
+    it 'responds to patch_brute-force-protection' do
+      expect(@instance).to respond_to(:patch_brute_force_protection)
+    end
+
+    it 'responds to update_brute_force_protection_settings' do
+      expect(@instance).to respond_to(:update_brute_force_protection_settings)
+    end
+
+    it 'is expected to respond to patch /api/v2/attack-protection/brute-force-protection' do
+      expect(@instance).to receive(:patch).with(
+        '/api/v2/attack-protection/brute-force-protection',
+        {
+          enabled: true
+        }
+      )
+
+      @instance.patch_brute_force_protection({
+        enabled: true
+      })
+    end
+  end
 end

--- a/spec/lib/auth0/api/v2/attack_protection_spec.rb
+++ b/spec/lib/auth0/api/v2/attack_protection_spec.rb
@@ -88,4 +88,45 @@ describe Auth0::Api::V2::AttackProtection do
       })
     end
   end
+
+  context '.get suspicious-ip-throttling' do
+    it 'responds to suspicious_ip_throttling' do
+      expect(@instance).to respond_to(:suspicious_ip_throttling)
+    end
+
+    it 'responds to get_suspicious_ip_throttling_settings' do
+      expect(@instance).to respond_to(:get_suspicious_ip_throttling_settings)
+    end
+
+    it 'is expected to get /api/v2/attack-protection/suspicious-ip-throttling' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/attack-protection/suspicious-ip-throttling'
+      )
+
+      expect { @instance.suspicious_ip_throttling }.not_to raise_error
+    end
+  end
+
+  context '.patch suspicious-ip-throttling' do
+    it 'responds to patch_suspicious_ip_throttling' do
+      expect(@instance).to respond_to(:patch_suspicious_ip_throttling)
+    end
+
+    it 'responds to update_suspicious_ip_throttling_settings' do
+      expect(@instance).to respond_to(:update_suspicious_ip_throttling_settings)
+    end
+
+    it 'is expected to patch /api/v2/attack-protection/suspicious-ip-throttling' do
+      expect(@instance).to receive(:patch).with(
+        '/api/v2/attack-protection/suspicious-ip-throttling',
+        {
+          enabled: true
+        }
+      )
+
+      @instance.patch_suspicious_ip_throttling({
+        enabled: true
+      })
+    end
+  end
 end

--- a/spec/lib/auth0/api/v2/attack_protection_spec.rb
+++ b/spec/lib/auth0/api/v2/attack_protection_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe Auth0::Api::V2::AttackProtection do
+  before :all do
+    dummy_instance = DummyClass.new
+    dummy_instance.extend(Auth0::Api::V2::AttackProtection)
+    @instance = dummy_instance
+  end
+
+  context '.attack_protection' do
+    it 'is expected to respond to a breached_password_detection method' do
+      expect(@instance).to respond_to(:breached_password_detection)
+    end
+  end
+end

--- a/spec/lib/auth0/api/v2/attack_protection_spec.rb
+++ b/spec/lib/auth0/api/v2/attack_protection_spec.rb
@@ -24,4 +24,27 @@ describe Auth0::Api::V2::AttackProtection do
       expect { @instance.breached_password_detection }.not_to raise_error
     end
   end
+
+  context '.patch breached-password-detection' do
+    it 'is expected to respond to a patch_breached_password_detection method' do
+      expect(@instance).to respond_to(:patch_breached_password_detection)
+    end
+
+    it 'is expected to respond to a update_breached_password_detection_settings method' do
+      expect(@instance).to respond_to(:update_breached_password_detection_settings)
+    end
+
+    it 'is expected to patch /api/v2/attack-protection/breached-password-detection' do
+      expect(@instance).to receive(:patch).with(
+        '/api/v2/attack-protection/breached-password-detection', {
+          enabled: true
+        }
+      )
+
+      @instance.patch_breached_password_detection({
+        enabled: true
+      })
+    end
+  end
+
 end


### PR DESCRIPTION
### Changes

This PR adds support for the following Attack Protection endpoints for the Auth0 Management API:

```
GET /api/v2/attack-protection/breached-password-detection
PATCH /api/v2/attack-protection/breached-password-detection
GET /api/v2/attack-protection/brute-force-protection
PATCH /api/v2/attack-protection/brute-force-protection
GET /api/v2/attack-protection/suspicious-ip-throttling
PATCH /api/v2/attack-protection/suspicious-ip-throttling
```

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of Ruby

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [ ] Rubocop passes on all added/modified files
- [x] All active GitHub checks have passed
