### PR TITLE
Add parameters for pager to device_credentials method

### DIFF
--- a/lib/auth0/api/v2/device_credentials.rb
+++ b/lib/auth0/api/v2/device_credentials.rb
@@ -13,6 +13,9 @@ module Auth0
         #   * :include_fields [boolean] True if the fields specified are to be included in the result, false otherwise.
         #   * :user_id [string] The user_id of the devices to retrieve.
         #   * :type [string] Type of credentials to retrieve. Must be 'public_key', 'refresh_token' or 'rotating_refresh_token'
+        #   * :page [integer] The page number. Zero based
+        #   * :per_page [integer] The amount of entries per page
+        #   * :include_totals [boolean] Return results inside an object that contains the total result count (true) or as a direct array of results (false, default).
         #
         # @return [json] Returns the list of existing devices for the specified client_id.
         # rubocop:disable Metrics/AbcSize
@@ -22,7 +25,10 @@ module Auth0
             include_fields: options.fetch(:include_fields, nil),
             user_id: options.fetch(:user_id, nil),
             client_id: client_id,
-            type: options.fetch(:type, nil)
+            type: options.fetch(:type, nil),
+            page: options.fetch(:page, nil),
+            per_page: options.fetch(:per_page, nil),
+            include_totals: options.fetch(:include_totals, nil)
           }
           raise Auth0::InvalidParameter, 'Must supply a valid client_id' if client_id.to_s.empty?
           if !request_params[:type].nil? && !%w(public_key refresh_token rotating_refresh_token).include?(request_params[:type])

--- a/spec/lib/auth0/api/v2/device_credentials_spec.rb
+++ b/spec/lib/auth0/api/v2/device_credentials_spec.rb
@@ -18,9 +18,26 @@ describe Auth0::Api::V2::DeviceCredentials do
         include_fields: nil,
         user_id: nil,
         client_id: client_id,
-        type: nil
+        type: nil,
+        page: nil,
+        per_page: nil,
+        include_totals: nil
       })
       expect { @instance.device_credentials(client_id) }.not_to raise_error
+    end
+    it 'is expected to send get request with options to /api/v2/device-credentials' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/device-credentials', {
+        fields: 'name',
+        include_fields: true,
+        user_id: '1',
+        client_id: client_id,
+        type: 'rotating_refresh_token',
+        page: 1,
+        per_page: 10,
+        include_totals: true
+      })
+      expect { @instance.device_credentials(client_id, fields: 'name', include_fields: true, user_id: '1', type: 'rotating_refresh_token', page: 1, per_page: 10, include_totals: true) }.not_to raise_error
     end
     it 'is expect to raise an error when type is not one of \'public_key\', \'refresh_token\', \'rotating_refresh_token\'' do
       expect { @instance.device_credentials(client_id, type: 'invalid_type') }.to raise_error(


### PR DESCRIPTION
### Changes

I added `page`, `per_page`, `include_totals` parameters to device_credentials method, because [API documents](https://auth0.com/docs/api/management/v2#!/Device_Credentials/get_device_credentials) describe that Retrieve device credentials API has parameters for pagerize.

### References

No References

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
    * I found some offenses by rubocop in lib/auth0/api/v2/device_credentials.rb and spec/lib/auth0/api/v2/device_credentials_spec.rb.  But I left it at that because there were originally many offenses
* [x] All active GitHub checks have passed
