### PR TITLE
Fix incorrect controller filename in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ end
 ... and a Controller to handle that route:
 
 ```ruby
-# app/controllers/all_users_controllers.rb
+# app/controllers/all_users_controller.rb
 require 'auth0'
 
 class AllUsersController < ApplicationController


### PR DESCRIPTION
### Changes

Correct controller filename in example found in README.md 

from:
`app/controllers/all_users_controllers.rb`

to:
`app/controllers/all_users_controllers.rb`

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
