### PR TITLE
Cache RS256 JWKS by url to allow for multiple Auth0 tenants per runtime

### DIFF
--- a/lib/auth0/mixins/validation.rb
+++ b/lib/auth0/mixins/validation.rb
@@ -286,7 +286,7 @@ module Auth0
 
             # Clear the JWK set cache.
             def remove_jwks
-              @@cache.remove(:jwks)
+              @@cache.remove_by { true }
             end
           end
 
@@ -311,13 +311,13 @@ module Auth0
             result = fetch_jwks if force
 
             if result
-              @@cache.put(:jwks, result, lifetime: @lifetime)
+              @@cache.put(@jwks_url, result, lifetime: @lifetime)
               return result
             end
 
-            previous_value = @@cache.last(:jwks)
+            previous_value = @@cache.last(@jwks_url)
 
-            @@cache.get(:jwks, lifetime: @lifetime, dirty: true) do
+            @@cache.get(@jwks_url, lifetime: @lifetime, dirty: true) do
               new_value = fetch_jwks
 
               raise Auth0::InvalidIdToken, 'Could not fetch the JWK set' unless new_value || previous_value

--- a/spec/lib/auth0/mixins/validation_spec.rb
+++ b/spec/lib/auth0/mixins/validation_spec.rb
@@ -6,6 +6,7 @@ RSA_PUB_KEY_JWK_2 = { 'kty': "RSA", 'use': 'sig', 'n': "uGbXWiK3dQTyCbX5xdE4yCuY
 JWKS_RESPONSE_1 = { 'keys': [RSA_PUB_KEY_JWK_1] }.freeze
 JWKS_RESPONSE_2 = { 'keys': [RSA_PUB_KEY_JWK_2] }.freeze
 JWKS_URL = 'https://tokens-test.auth0.com/.well-known/jwks.json'.freeze
+JWKS_URL_2 = 'https://tokens-test2.auth0.com/.well-known/jwks.json'.freeze
 HMAC_SHARED_SECRET = 'secret'.freeze
 
 LEEWAY = 60
@@ -459,6 +460,19 @@ describe Auth0::Algorithm::RS256 do
       expect(a_request(:get, JWKS_URL)).to have_been_made.once
     end
 
+    it 'is expected to fetch the jwks from multiple urls' do
+      stub_jwks(JWKS_RESPONSE_2, JWKS_URL_2)
+
+      instance1 = Auth0::Algorithm::RS256.jwks_url(JWKS_URL)
+      instance2 = Auth0::Algorithm::RS256.jwks_url(JWKS_URL_2)
+      instance1.jwks
+      instance2.jwks
+      instance1.jwks
+
+      expect(a_request(:get, JWKS_URL)).to have_been_made.once
+      expect(a_request(:get, JWKS_URL_2)).to have_been_made.once
+    end
+
     it 'is expected to forcibly fetch the jwks from the url' do
       instance = Auth0::Algorithm::RS256.jwks_url(JWKS_URL)
       instance.jwks
@@ -493,6 +507,6 @@ describe Auth0::Algorithm::RS256 do
 end
 # rubocop:enable Metrics/BlockLength
 
-def stub_jwks(stub = JWKS_RESPONSE_1)
-  stub_request(:get, JWKS_URL).to_return(body: stub.to_json)
+def stub_jwks(stub = JWKS_RESPONSE_1, url = JWKS_URL)
+  stub_request(:get, url).to_return(body: stub.to_json)
 end


### PR DESCRIPTION
Fixes #324

### Changes

The underlying issue is discussed in #324, but in summary, JWT validation using RS256 caches the JWKS for the entire runtime, even if multiple Auth0 tenants (varying JWKS URLs are in use). This change caches the JWKS per JWKS url instead of using just a generic cache key. This allows applications that use multiple Auth0 tenants to properly cache their JWKS and avoid unnecessary HTTP requests to pull the well-known JWKS.  Otherwise, the JWKS cache thrashes itself while switching between multiple Auth0 tenants.

### References

Fixes #324

### Testing

* [X] This change adds unit test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files (it didn't pass beforehand)
* [x] All active GitHub checks have passed
