### PR TITLE
Fix 'password_reset' -> 'reset_password'

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -152,7 +152,7 @@ module Auth0
       # @param password [string] User's new password. This is only available
       #   on legacy tenants with change password v1 flow enabled
       # @param connection_name [string] Database connection name
-      # @deprecated Use {#password_reset} instead.
+      # @deprecated Use {#reset_password} instead.
       def change_password(email, password, connection_name = UP_AUTH)
         raise Auth0::InvalidParameter, 'Must supply a valid email' if email.to_s.empty?
 


### PR DESCRIPTION
### Changes

Fix the wrong method name in the document.

### References

-

### Testing

-

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
