### PR TITLE
[SDK-3463] Update Codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
-  ship: auth0/ship@0.4.0
+  ship: auth0/ship@0.4.
+  codecov: codecov/codecov@3.1.1
 
 matrix_ruby_versions: &matrix_ruby_versions
   matrix:
@@ -40,6 +41,7 @@ jobs:
             - vendor/bundle
       # Must define DOMAIN, CLIENT_ID, CLIENT_SECRET and MASTER_JWT env
       - run: bundle exec rake test
+      - codecov/upload
 
 workflows:
   tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ship: auth0/ship@0.4.
+  ship: auth0/ship@dev:alpha
   codecov: codecov/codecov@3.1.1
 
 matrix_ruby_versions: &matrix_ruby_versions

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ end
 group :test do
   gem 'webmock', require: false
   gem 'vcr', require: false
-  gem 'codecov', require: false
-  gem 'simplecov'
+  gem 'simplecov-cobertura'
   gem 'timecop', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,8 +33,6 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
     builder (3.2.4)
-    codecov (0.6.0)
-      simplecov (>= 0.15, < 0.22)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     coveralls (0.7.1)
@@ -185,6 +183,9 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     sync (0.5.0)
@@ -215,7 +216,6 @@ PLATFORMS
 DEPENDENCIES
   auth0!
   bundler
-  codecov
   coveralls
   dotenv-rails (~> 2.0)
   faker (~> 2.0)
@@ -231,7 +231,8 @@ DEPENDENCIES
   rspec (~> 3.5)
   rubocop
   rubocop-rails
-  simplecov
+  simplecov (~> 0.9)
+  simplecov-cobertura
   terminal-notifier-guard
   timecop
   vcr

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,8 +13,8 @@ require 'simplecov'
 SimpleCov.start
 
 if ENV['CI'] == 'true'
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  require 'simplecov-cobertura'
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 end
 
 require 'dotenv'


### PR DESCRIPTION
### Changes

This PR replaces the deprecated Codecov bash uploader with the current recommended path for CircleCI, an Orb. It updates the Simplecov dependency to generate a coverage clover suitable for this use.

### References

See internal ticket SDK-3464

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
