### PR TITLE
Add include_totals to get connections options

### DIFF
--- a/lib/auth0/api/v2/connections.rb
+++ b/lib/auth0/api/v2/connections.rb
@@ -14,6 +14,7 @@ module Auth0
         # @param include_fields [boolean] True if the fields specified are to be included in the result, false otherwise.
         # @param page [int] Page number to get, 0-based.
         # @param per_page [int] Results per page if also passing a page number.
+        # @param include_totals [boolean] True if query totals should be included in the result. Defaults to false.
         # @return [json] Returns the existing connections matching the strategy.
         def connections(
           strategy: nil,
@@ -21,7 +22,8 @@ module Auth0
           fields: nil,
           include_fields: nil,
           page: nil,
-          per_page: nil
+          per_page: nil,
+          include_totals: nil
         )
           include_fields = true if !fields.nil? && include_fields.nil?
           request_params = {
@@ -30,7 +32,8 @@ module Auth0
             fields: fields.is_a?(Array) ? fields.join(',') : fields,
             include_fields: include_fields,
             page: !page.nil? ? page.to_i : nil,
-            per_page: !page.nil? && !per_page.nil? ? per_page.to_i : nil
+            per_page: !page.nil? && !per_page.nil? ? per_page.to_i : nil,
+            include_totals: include_totals
           }
           get(connections_path, request_params)
         end
@@ -38,7 +41,7 @@ module Auth0
 
         # Creates a new connection according to the JSON object received in body.
         # @see https://auth0.com/docs/api/v2#!/Connections/post_connections
-        # @param body [hash] The Hash options used to define the conecctions's properties.
+        # @param body [hash] The Hash options used to define the connections's properties.
         #
         # @return [json] Returns the created connection.
         def create_connection(body)

--- a/spec/lib/auth0/api/v2/connections_spec.rb
+++ b/spec/lib/auth0/api/v2/connections_spec.rb
@@ -18,7 +18,8 @@ describe Auth0::Api::V2::Connections do
         fields: nil,
         include_fields: nil,
         page: nil,
-        per_page: nil
+        per_page: nil,
+        include_totals: nil
       })
       expect { @instance.connections }.not_to raise_error
     end
@@ -31,7 +32,8 @@ describe Auth0::Api::V2::Connections do
         strategy: nil,
         name: nil,
         page: nil,
-        per_page: nil
+        per_page: nil,
+        include_totals: nil
       })
       expect {
         @instance.connections(fields: 'name', include_fields: true)
@@ -46,7 +48,8 @@ describe Auth0::Api::V2::Connections do
         strategy: nil,
         name: nil,
         page: nil,
-        per_page: nil
+        per_page: nil,
+        include_totals: nil
       })
       expect {
         @instance.connections(fields: ['name','strategy'], include_fields: true)
@@ -61,10 +64,27 @@ describe Auth0::Api::V2::Connections do
         strategy: nil,
         name: nil,
         fields: nil,
-        include_fields: nil
+        include_fields: nil,
+        include_totals: nil
       })
       expect {
         @instance.connections(page: 1, per_page: 10)
+      }.not_to raise_error
+    end
+
+    it 'is expected to include totals' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/connections', {
+        page: 1,
+        per_page: 10,
+        strategy: nil,
+        name: nil,
+        fields: nil,
+        include_fields: nil,
+        include_totals: true
+      })
+      expect {
+        @instance.connections(page: 1, per_page: 10, include_totals: true)
       }.not_to raise_error
     end
   end


### PR DESCRIPTION
### Changes

This PR adds the `include_totals` option to `GET connections` API2 endpoint method.

### References

Fixes #349

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] Rubocop passes on all added/modified files
* [X] All active GitHub checks have passed
