### PR TITLE
correct remove_user_roles doc: roles param is ids, not names

### DIFF
--- a/lib/auth0/api/v2/users.rb
+++ b/lib/auth0/api/v2/users.rb
@@ -215,7 +215,7 @@ module Auth0
         # @see https://auth0.com/docs/api/management/v2#!/Users/delete_user_roles
         #
         # @param user_id [string] The user_id of the roles to remove.
-        # @param roles [array] An array of role names to remove.
+        # @param roles [array] An array of role ids to remove.
         def remove_user_roles(user_id, roles)
           raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
           validate_strings_array roles


### PR DESCRIPTION
### Changes

Changes the doc comments for `User.remove_user_roles`.  It erroneously says it takes role *names*, but it actually needs role *ids*.

### References

See the [API docs for this endpoint](https://auth0.com/docs/api/management/v2#!/Users/delete_permissions); in the samples sidebar it says

> roles: List of roles IDs to remove from the user"

Here's a screenshot:

![Screen Shot 2022-07-15 at 5 12 34 PM](https://user-images.githubusercontent.com/237288/179318459-a9b8d2a2-0c9e-4830-adbd-d80dc99f3f78.png)

### Testing

This isn't a code change (just a doc change), so no tests to change/update.

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
