### PR TITLE
Add Delete All Authenticators API for Users

### DIFF
--- a/lib/auth0/api/v2/users.rb
+++ b/lib/auth0/api/v2/users.rb
@@ -111,6 +111,15 @@ module Auth0
         end
         alias update_user patch_user
 
+        # Delete all authenticators
+        # @see https://auth0.com/docs/api/management/v2#!/Users/delete_authenticators
+        # @param user_id [string] The user_id of the user to delete all authenticators
+        def delete_user_authenticators(user_id)
+          raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
+          path = "#{users_path}/#{user_id}/authenticators"
+          delete(path)
+        end
+
         # Delete a user's multifactor provider
         # @see https://auth0.com/docs/api/v2#!/Users/delete_multifactor_by_provider
         # @param user_id [string] The user_id of the user to delete the multifactor provider from.

--- a/spec/lib/auth0/api/v2/users_spec.rb
+++ b/spec/lib/auth0/api/v2/users_spec.rb
@@ -139,6 +139,21 @@ describe Auth0::Api::V2::Users do
     end
   end
 
+  context '.delete_user_authenticators' do
+    it 'is expected to respond to a delete_user_authenticators method' do
+      expect(@instance).to respond_to(:delete_user_authenticators)
+    end
+
+    it 'is expected to delete /api/v2/users/userId/authenticators' do
+      expect(@instance).to receive(:delete).with('/api/v2/users/USER_ID/authenticators')
+      @instance.delete_user_authenticators('USER_ID')
+    end
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.delete_user_authenticators(nil) }.to raise_exception(Auth0::MissingUserId)
+    end
+  end
+
   context '.delete_user_provider' do
     it 'is expected to respond to a delete_user_provider method' do
       expect(@instance).to respond_to(:delete_user_provider)


### PR DESCRIPTION

### Changes

This PR to add `delete_user_authenticators` to `Users` API to implement https://auth0.com/docs/api/management/v2#!/Users/delete_authenticators

### References

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
