### PR TITLE
Release v5.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log
 
+## [v5.9.0](https://github.com/auth0/ruby-auth0/tree/v5.9.0) (2022-08-24)
+[Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.8.1...v5.9.0)
+
+**Added**
+- Add Delete All Authenticators API for Users [\#375](https://github.com/auth0/ruby-auth0/pull/375) ([phongnh](https://github.com/phongnh))
+
+**Changed**
+- Add include_totals to get connections options [\#357](https://github.com/auth0/ruby-auth0/pull/357) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
+**Fixed**
+- Fix typo and remove param that is not used [\#365](https://github.com/auth0/ruby-auth0/pull/365) ([MatthewRDodds](https://github.com/MatthewRDodds))
+- correct remove_user_roles doc: roles param is ids, not names [\#359](https://github.com/auth0/ruby-auth0/pull/359) ([gbirchmeier](https://github.com/gbirchmeier))
+
 ## [v5.8.1](https://github.com/auth0/ruby-auth0/tree/v5.8.1) (2022-06-30)
 
 [Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.8.0...v5.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auth0 (5.8.1)
+    auth0 (5.9.0)
       addressable (~> 2.8)
       jwt (~> 2.3.0)
       rest-client (~> 2.1)
@@ -52,7 +52,7 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
-    erubi (1.10.0)
+    erubi (1.11.0)
     faker (2.22.0)
       i18n (>= 1.8.11, < 2)
     ffi (1.15.5)
@@ -98,7 +98,7 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_portile2 (2.8.0)
-    minitest (5.16.2)
+    minitest (5.16.3)
     multi_json (1.15.0)
     nenv (0.3.0)
     netrc (0.11.0)

--- a/lib/auth0/version.rb
+++ b/lib/auth0/version.rb
@@ -1,4 +1,4 @@
 # current version of gem
 module Auth0
-  VERSION = '5.8.1'.freeze
+  VERSION = '5.9.0'.freeze
 end


### PR DESCRIPTION

**Added**
- Add Delete All Authenticators API for Users [\#375](https://github.com/auth0/ruby-auth0/pull/375) ([phongnh](https://github.com/phongnh))

**Changed**
- Add include_totals to get connections options [\#357](https://github.com/auth0/ruby-auth0/pull/357) ([stevehobbsdev](https://github.com/stevehobbsdev))

**Fixed**
- Fix typo and remove param that is not used [\#365](https://github.com/auth0/ruby-auth0/pull/365) ([MatthewRDodds](https://github.com/MatthewRDodds))
- correct remove_user_roles doc: roles param is ids, not names [\#359](https://github.com/auth0/ruby-auth0/pull/359) ([gbirchmeier](https://github.com/gbirchmeier))
