### PR TITLE
[SDK-3642] feat: support complex field names in export_users

### DIFF
--- a/lib/auth0/api/v2/jobs.rb
+++ b/lib/auth0/api/v2/jobs.rb
@@ -60,6 +60,9 @@ module Auth0
         #   :format [string] The format of the file. Valid values are: "json" and "csv".
         #   :limit [integer] Limit the number of users to export.
         #   :fields [array] A list of fields to be included in the CSV.
+        #     This can either be an array of strings representing field names, or an object.
+        #     If it's a string, it is mapped to the correct { name: '<field name>' } object required by the endpoint.
+        #     If it's an object, it is passed through as-is to the endpoint.
         #     If omitted, a set of predefined fields will be exported.
         #
         # @return [json] Returns the job status and properties.
@@ -109,14 +112,22 @@ module Auth0
           @jobs_path ||= '/api/v2/jobs'
         end
 
-        # Map array of field names for export to array of objects
-        # @param fields [array] Field names to be included in the export
-
+        # Map array of fields for export to array of objects
+        # @param fields [array] Fields to be included in the export
+        #     This can either be an array of strings representing field names, or an object.
+        #     If it's a string, it is mapped to the correct { name: '<field name>' } object required by the endpoint.
+        #     If it's an object, it is passed through as-is to the endpoint.
         # @return [array] Returns the fields mapped as array of objects for the export_users endpoint
         def fields_for_export(fields)
           return nil if fields.to_s.empty?
 
-          fields.map { |field| { name: field } }
+          fields.map { |field|             
+            if field.is_a? String
+              { name: field }
+            else
+              field
+            end
+          }
         end
       end
     end

--- a/spec/lib/auth0/api/v2/jobs_spec.rb
+++ b/spec/lib/auth0/api/v2/jobs_spec.rb
@@ -56,7 +56,7 @@ describe Auth0::Api::V2::Jobs do
     it { expect { @instance.import_users('', 'connnection_id') }.to raise_error('Must specify a valid file') }
     it { expect { @instance.import_users('users', '') }.to raise_error('Must specify a connection_id') }
   end
-  context '.export_users', focus: true do
+  context '.export_users' do
     it { expect(@instance).to respond_to(:export_users) }
     it { expect { @instance.export_users }.not_to raise_error }
     it 'sends post to /api/v2/jobs/users-exports with correct params' do

--- a/spec/lib/auth0/api/v2/jobs_spec.rb
+++ b/spec/lib/auth0/api/v2/jobs_spec.rb
@@ -56,7 +56,7 @@ describe Auth0::Api::V2::Jobs do
     it { expect { @instance.import_users('', 'connnection_id') }.to raise_error('Must specify a valid file') }
     it { expect { @instance.import_users('users', '') }.to raise_error('Must specify a connection_id') }
   end
-  context '.export_users' do
+  context '.export_users', focus: true do
     it { expect(@instance).to respond_to(:export_users) }
     it { expect { @instance.export_users }.not_to raise_error }
     it 'sends post to /api/v2/jobs/users-exports with correct params' do
@@ -67,8 +67,26 @@ describe Auth0::Api::V2::Jobs do
         format: 'csv',
         limit: 10
       })
+
       @instance.export_users(
         fields: ['author'],
+        connection_id: 'test-connection',
+        format: 'csv',
+        limit: 10
+      )
+    end
+
+    it 'sends post to /api/v2/jobs/users-exports with export_as field' do
+      expect(@instance).to receive(:post).with(
+        '/api/v2/jobs/users-exports', {
+        fields: [{ name: 'author', export_as: 'writer' }],
+        connection_id: 'test-connection',
+        format: 'csv',
+        limit: 10
+      })
+      
+      @instance.export_users(
+        fields: [{ name: 'author', export_as: 'writer' }],
         connection_id: 'test-connection',
         format: 'csv',
         limit: 10


### PR DESCRIPTION
### Changes

This PR tweaks `export_users` so that it could now accept (and properly forward) field names and `export_as` settings to the `jobs/users-exports` endpoint. Previously it was only possible to specify an array of field strings. Now, objects can be specified meaning that the `export_as` property can be specified.

This is done in a backwards-compatible way so as not to break those still sending string arrays.

Usage example:

```ruby
auth0.export_users(
  fields: [{ name: 'author', export_as: 'creator' }],
  connection_id: 'test-connection',
  format: 'csv',
  limit: 10
)
```

### References

Fixes #378 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
