### PR TITLE
fix: stop :get, :delete parameters from bleeding into subsequent requests

### DIFF
--- a/lib/auth0/mixins/httpproxy.rb
+++ b/lib/auth0/mixins/httpproxy.rb
@@ -73,15 +73,13 @@ module Auth0
 
       def request(method, uri, body = {}, extra_headers = {})
         result = if method == :get
-          # Mutate the headers property to add parameters.
-          add_headers({params: body})
-          # Merge custom headers into existing ones for this req.
-          # This prevents future calls from using them.
-          get_headers = headers.merge extra_headers
-          # Make the call with extra_headers, if provided.
+          @headers ||= {}
+          get_headers = @headers.merge({params: body}).merge(extra_headers)
           call(:get, encode_uri(uri), timeout, get_headers)
         elsif method == :delete
-          call(:delete, encode_uri(uri), timeout, add_headers({params: body}))
+          @headers ||= {}
+          delete_headers = @headers.merge({ params: body })
+          call(:delete, encode_uri(uri), timeout, delete_headers)
         elsif method == :delete_with_body
           call(:delete, encode_uri(uri), timeout, headers, body.to_json)
         elsif method == :post_file

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_patch_client/should_update_the_client_with_the_correct_attributes.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Clients/_patch_client/should_update_the_client_with_the_correct_attributes.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: patch
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients/SftKo9ySyHnMPezQUFd0C70GBoNFM21F?fields=jwt_configuration&include_fields=false
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/clients/SftKo9ySyHnMPezQUFd0C70GBoNFM21F
     body:
       encoding: UTF-8
       string: '{"custom_login_page_on":false,"sso":true}'
@@ -12,6 +12,7 @@ http_interactions:
       User-Agent:
       - rest-client/2.1.0 (darwin19.6.0 x86_64) ruby/2.7.0p0
       Content-Type:
+
       - application/json
       Auth0-Client:
       - eyJuYW1lIjoicnVieS1hdXRoMCIsInZlcnNpb24iOiI1LjUuMCIsImVudiI6eyJydWJ5IjoiMi43LjAifX0=

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_update_connection/should_update_the_connection.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Connections/_update_connection/should_update_the_connection.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: patch
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_WltM0fv20JCnxOuY?email=rubytest-210908-rubytest-210908-username@auth0.com
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/connections/con_WltM0fv20JCnxOuY
     body:
       encoding: UTF-8
       string: '{"options":{"mfa":{"active":true,"return_enroll_settings":true},"passwordPolicy":"excellent","strategy_version":2,"brute_force_protection":true}}'

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_update_rule/should_update_the_disabled_rule_to_be_enabled.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Rules/_update_rule/should_update_the_disabled_rule_to_be_enabled.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: patch
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules/rul_bsg64xEPZz4WOkXz?fields=stage&include_fields=false
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/rules/rul_bsg64xEPZz4WOkXz
     body:
       encoding: UTF-8
       string: '{"enabled":true}'

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tenants/_update_tenant_settings/should_revert_the_tenant_name.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tenants/_update_tenant_settings/should_revert_the_tenant_name.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: patch
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/tenants/settings?fields=support_email&include_fields=true
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/tenants/settings
     body:
       encoding: UTF-8
       string: '{"friendly_name":"Auth0"}'

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tenants/_update_tenant_settings/should_update_the_tenant_settings_with_a_new_tenant_name.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Tenants/_update_tenant_settings/should_update_the_tenant_settings_with_a_new_tenant_name.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: patch
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/tenants/settings?fields=support_email&include_fields=true
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/tenants/settings
     body:
       encoding: UTF-8
       string: '{"friendly_name":"Auth0-CHANGED"}'

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_add_user_roles/should_add_a_Role_to_a_User_successfully.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_add_user_roles/should_add_a_Role_to_a_User_successfully.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C613282adac819400692c0dd9/roles?per_page=2
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C613282adac819400692c0dd9/roles
     body:
       encoding: UTF-8
       string: '{"roles":["rol_2VZOCes8HgBar3Tp"]}'

--- a/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_patch_user/should_patch_the_User_successfully.yml
+++ b/spec/fixtures/vcr_cassettes/Auth0_Api_V2_Users/_patch_user/should_patch_the_User_successfully.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: patch
-    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C613282adac819400692c0dd9?fields=email&include_fields=true
+    uri: https://auth0-sdk-tests.auth0.com/api/v2/users/auth0%7C613282adac819400692c0dd9
     body:
       encoding: UTF-8
       string: '{"email_verified":true,"user_metadata":{"addresses":{"home_address":"742


### PR DESCRIPTION
### Changes

This change means that parameters supplied to a `:get` or `:delete` request in `RestClient` should no longer bleed into subsequent calls, as the shared headers hash is no longer mutated by these calls.

This fix has caused some of the integration test fixtures to no longer match requests being made, so these have also been updated.

### References

Fixes #344

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] Rubocop passes on all added/modified files
* [X] All active GitHub checks have passed
