### PR TITLE
Release v5.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [v5.10.0](https://github.com/auth0/ruby-auth0/tree/v5.10.0) (2022-10-10)
+[Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.9.0...v5.10.0)
+
+**Changed**
+- [SDK-3643] Update jwt ~2.5 [\#384](https://github.com/auth0/ruby-auth0/pull/384) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
+**Fixed**
+- fix: stop :get, :delete parameters from bleeding into subsequent requests [\#388](https://github.com/auth0/ruby-auth0/pull/388) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- [SDK-3642] feat: support complex field names in export_users [\#387](https://github.com/auth0/ruby-auth0/pull/387) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- [SDK-3644] Reconfigure rate limiting exponential backoff [\#386](https://github.com/auth0/ruby-auth0/pull/386) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
 ## [v5.9.0](https://github.com/auth0/ruby-auth0/tree/v5.9.0) (2022-08-24)
 [Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.8.1...v5.9.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@
 [Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.9.0...v5.10.0)
 
 **Changed**
-- [SDK-3643] Update jwt ~2.5 [\#384](https://github.com/auth0/ruby-auth0/pull/384) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- Update jwt ~2.5 [\#384](https://github.com/auth0/ruby-auth0/pull/384) ([stevehobbsdev](https://github.com/stevehobbsdev))
 
 **Fixed**
-- fix: stop :get, :delete parameters from bleeding into subsequent requests [\#388](https://github.com/auth0/ruby-auth0/pull/388) ([stevehobbsdev](https://github.com/stevehobbsdev))
-- [SDK-3642] feat: support complex field names in export_users [\#387](https://github.com/auth0/ruby-auth0/pull/387) ([stevehobbsdev](https://github.com/stevehobbsdev))
-- [SDK-3644] Reconfigure rate limiting exponential backoff [\#386](https://github.com/auth0/ruby-auth0/pull/386) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- Stop :get, :delete parameters from bleeding into subsequent requests [\#388](https://github.com/auth0/ruby-auth0/pull/388) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- Support complex field names in export_users [\#387](https://github.com/auth0/ruby-auth0/pull/387) ([stevehobbsdev](https://github.com/stevehobbsdev))
+- Reconfigure rate limiting exponential backoff [\#386](https://github.com/auth0/ruby-auth0/pull/386) ([stevehobbsdev](https://github.com/stevehobbsdev))
 
 ## [v5.9.0](https://github.com/auth0/ruby-auth0/tree/v5.9.0) (2022-08-24)
 [Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.8.1...v5.9.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auth0 (5.9.0)
+    auth0 (5.10.0)
       addressable (~> 2.8)
       jwt (~> 2.5)
       rest-client (~> 2.1)
@@ -102,6 +102,8 @@ GEM
     nenv (0.3.0)
     netrc (0.11.0)
     nokogiri (1.13.8-aarch64-linux)
+      racc (~> 1.4)
+    nokogiri (1.13.8-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
@@ -215,6 +217,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -244,4 +247,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.3.22
+   2.3.7

--- a/lib/auth0/version.rb
+++ b/lib/auth0/version.rb
@@ -1,4 +1,4 @@
 # current version of gem
 module Auth0
-  VERSION = '5.9.0'.freeze
+  VERSION = '5.10.0'.freeze
 end


### PR DESCRIPTION
**Changed**
- Update jwt ~2.5 [\#384](https://github.com/auth0/ruby-auth0/pull/384) ([stevehobbsdev](https://github.com/stevehobbsdev))

**Fixed**
- fix: stop :get, :delete parameters from bleeding into subsequent requests [\#388](https://github.com/auth0/ruby-auth0/pull/388) ([stevehobbsdev](https://github.com/stevehobbsdev))
- Support complex field names in export_users [\#387](https://github.com/auth0/ruby-auth0/pull/387) ([stevehobbsdev](https://github.com/stevehobbsdev))
- Reconfigure rate limiting exponential backoff [\#386](https://github.com/auth0/ruby-auth0/pull/386) ([stevehobbsdev](https://github.com/stevehobbsdev))