### PR TITLE
fix: Remove obsolete example link

### DIFF
--- a/examples/ruby-on-rails-api/README.md
+++ b/examples/ruby-on-rails-api/README.md
@@ -2,8 +2,6 @@
 
 This is the seed project you need to use if you're going to create a Ruby on Rails API. You'll mostly use this API either for a SPA or a Mobile app. If you just want to create a Regular Ruby on Rails WebApp, please check this [other seed project](https://github.com/auth0/omniauth-auth0)
 
-This example is deployed at Heroku at http://auth0-rorapi-sample.herokuapp.com/ping
-
 #Running the example
 
 In order to run the example you need to have ruby installed.


### PR DESCRIPTION
### Changes

This PR removes an outdated/obsolete link from one of the examples.

### References

-

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
