### PR TITLE
[SDK-3863] Add support for Client Assertion in authentication endpoints

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -193,3 +193,28 @@ end
 ```
 
 For more information, please read [Work with Tokens and Organizations](https://auth0.com/docs/organizations/using-tokens) on Auth0 Docs.
+
+## Use a private key to authenticate with Auth0
+
+You are able to take advantage of using a JWT signed with a private key to authenticate with Auth0 in place of using a client secret.
+
+**Note:** you must upload the corresponding public key to your Auth0 tenant, so that Auth0 is able to verify the JWT signature.
+
+Specify the client assertion key when creating the Auth0 client as in the following example:
+
+```ruby
+key_string = File.read 'key.pem'
+key = OpenSSL::PKey::RSA.new key_string
+
+client = Auth0Client.new(
+  domain: 'AUTH0_DOMAIN',
+  client_id: 'AUTH0_CLIENT_ID',
+  client_assertion_signing_key: key,
+  client_assertion_signing_alg: 'RS256')
+```
+
+Some notes:
+
+* If both `client_secret` and `client_assertion_signing_key` are specified, `client_assertion_signing_key` takes precedence
+* `client_assertion_signing_alg` is optional and defaults to `RS256` if omitted
+* Only `RS256`, `RS384` and `PS256` algorithms are supported by Auth0 currently

--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -18,8 +18,6 @@ module Auth0
       # @see https://auth0.com/docs/api-auth/tutorials/client-credentials
       # @param audience [string] API audience to use
       # @param organization [string] Organization ID
-      # @param client_assertion_signing_key [string] Signing key to use with Client Assertion
-      # @param client_assertion_signing_alg [string] The algorithm to use with Client Assertion. Defaults to 'RS256'
       # @return [json] Returns the API token
       def api_token(
         client_id: @client_id,
@@ -46,8 +44,6 @@ module Auth0
       #   Required only if it was set at the GET /authorize endpoint
       # @param client_id [string] Client ID for the Application
       # @param client_secret [string] Client Secret for the Application. Ignored if using Client Assertion
-      # @param client_assertion_signing_key [string] Signing key to use with Client Assertion
-      # @param client_assertion_signing_alg [string] The algorithm to use with Client Assertion. Defaults to 'RS256'
       # @return [Auth0::AccessToken] Returns the access_token and id_token
       def exchange_auth_code_for_tokens(
         code,

--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -16,6 +16,8 @@ module Auth0
 
       # Request an API access token using a Client Credentials grant
       # @see https://auth0.com/docs/api-auth/tutorials/client-credentials
+      # @param client_id [string] Client ID for the application
+      # @param client_secret [string] Client secret for the application. Ignored if using Client Assertion
       # @param audience [string] API audience to use
       # @param organization [string] Organization ID
       # @return [json] Returns the API token
@@ -41,9 +43,9 @@ module Auth0
       # @see https://auth0.com/docs/api/authentication#authorization-code
       # @param code [string] The authentication code obtained from /authorize
       # @param redirect_uri [string] URL to redirect to after authorization.
+      # @param client_id [string] Client ID for the application
+      # @param client_secret [string] Client secret for the application. Ignored if using Client Assertion
       #   Required only if it was set at the GET /authorize endpoint
-      # @param client_id [string] Client ID for the Application
-      # @param client_secret [string] Client Secret for the Application. Ignored if using Client Assertion
       # @return [Auth0::AccessToken] Returns the access_token and id_token
       def exchange_auth_code_for_tokens(
         code,
@@ -69,8 +71,8 @@ module Auth0
       # @see https://auth0.com/docs/api/authentication#refresh-token
       # @param refresh_token [string] Refresh token to use. Request this with
       #   the offline_access scope when logging in.
-      # @param client_id [string] Client ID for the Application
-      # @param client_secret [string] Client Secret for the Application.
+      # @param client_id [string] Client ID for the application
+      # @param client_secret [string] Client secret for the application. Ignored if using Client Assertion
       #   Required when the Application's Token Endpoint Authentication Method
       #   is Post or Basic.
       # @return [Auth0::AccessToken] Returns tokens allowed in the refresh_token
@@ -98,8 +100,8 @@ module Auth0
       # @see https://auth0.com/docs/api/authentication#resource-owner-password
       # @param login_name [string] Email or username for the connection
       # @param password [string] Password
-      # @param client_id [string] Client ID from Application settings
-      # @param client_secret [string] Client Secret from Application settings
+      # @param client_id [string] Client ID for the application
+      # @param client_secret [string] Client secret for the application. Ignored if using Client Assertion
       # @param realm [string] Specific realm to authenticate against
       # @param audience [string] API audience
       # @param scope [string] Scope(s) requested

--- a/lib/auth0/client_assertion.rb
+++ b/lib/auth0/client_assertion.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'jwt'
+
+module Auth0
+  module ClientAssertion
+    CLIENT_ASSERTION_TYPE = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer'.freeze
+
+    # Adds keys into the supplied hash for either the client secret, or client assertion. If `client_assertion_signing_key` is not nil,
+    # it takes precedence over `client_secret`.
+    # @param [hash] The hash to add the keys to
+    # @param client_id [string] The client ID
+    # @param client_secret [string] The client secret
+    # @param client_assertion_signing_key [PKey] The key used to sign the client assertion JWT
+    # @param client_assertion_signing_alg [string] The algorithm used when signing the client assertion JWT
+    def populate_client_assertion_or_secret(hash, 
+      domain: @domain,
+      client_id: @client_id, 
+      client_secret: @client_secret,
+      client_assertion_signing_key: @client_assertion_signing_key,
+      client_assertion_signing_alg: @client_assertion_signing_alg)
+
+      if !client_assertion_signing_key.nil?
+        # Create JWT
+        now = Time.now.to_i
+
+        payload = {
+          iss: client_id,
+          sub: client_id,
+          aud: "https://#{domain}/",
+          iat: now,
+          exp: now + 180,
+          jti: SecureRandom.uuid
+        }
+
+        jwt = JWT.encode payload, client_assertion_signing_key, client_assertion_signing_alg
+
+        hash[:client_assertion] = jwt
+        hash[:client_assertion_type] = Auth0::ClientAssertion::CLIENT_ASSERTION_TYPE
+      else
+        hash[:client_secret] = client_secret
+      end
+    end
+  end
+end

--- a/lib/auth0/mixins/initializer.rb
+++ b/lib/auth0/mixins/initializer.rb
@@ -16,6 +16,8 @@ module Auth0
         @headers = client_headers
         @timeout = options[:timeout] || 10
         @retry_count = options[:retry_count]
+        @client_assertion_signing_key = options[:client_assertion_signing_key]
+        @client_assertion_signing_alg = options[:client_assertion_signing_alg] || 'RS256';        
         extend Auth0::Api::AuthenticationEndpoints
         @client_id = options[:client_id]
         @client_secret = options[:client_secret]

--- a/lib/auth0/mixins/token_management.rb
+++ b/lib/auth0/mixins/token_management.rb
@@ -17,7 +17,7 @@ module Auth0
         # pp @token_expires_at
         has_expired = @token && @token_expires_at ? @token_expires_at < (Time.now.to_i + 10) : false
         
-        if (@token.nil? || has_expired) && @client_id && @client_secret
+        if (@token.nil? || has_expired) && @client_id && (@client_secret || @client_assertion_signing_key)
           response = api_token(audience: @audience)
           @token = response.token
           @token_expires_at = response.expires_in ? Time.now.to_i + response.expires_in : nil

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -1,0 +1,438 @@
+require 'spec_helper'
+require 'timecop'
+
+describe Auth0::Api::AuthenticationEndpoints do
+  let(:client_id) { 'test-client-id' }
+  let(:client_secret) { 'test-client-secret' }
+  let(:api_identifier) { 'test-audience' }
+  let(:domain) { 'samples.auth0.com' }
+
+  let(:client_secret_config) { { 
+    domain: domain,
+    client_id: client_id,
+    client_secret: client_secret,
+    token: 'test',
+    api_identifier: api_identifier
+  } }
+
+  let(:client_assertion_config) { { 
+    domain: domain,
+    client_id: client_id,
+    client_assertion_signing_key: client_assertion_signing_key_pair[:private_key],
+    client_assertion_signing_alg: 'RS256',
+    token: 'test',
+    api_identifier: api_identifier
+  } }
+
+  let(:client_assertion_signing_key_pair) do
+    rsa_private = OpenSSL::PKey::RSA.generate 2048
+
+    { 
+      public_key: rsa_private.public_key,
+      private_key: rsa_private
+    }
+  end
+
+  let(:client_secret_instance) { DummyClassForTokens.send(:include, described_class).new(client_secret_config) }
+  let(:client_assertion_instance) { DummyClassForTokens.send(:include, described_class).new(client_assertion_config) }
+  let(:time_now) { Time.now }
+
+  before :each do
+    Timecop.freeze(time_now)
+  end
+
+  after :each do
+    Timecop.return
+  end
+  
+  context 'AuthenticationEndponts' do
+    context 'api_token' do
+      it 'requests a new token using client_secret' do
+        expect(RestClient::Request).to receive(:execute).with(hash_including(
+          method: :post,
+          url: 'https://samples.auth0.com/oauth/token',
+          payload: {
+            grant_type: 'client_credentials',
+            client_id: client_id,
+            audience: api_identifier,
+            client_secret: client_secret
+          }.to_json
+        ))
+        .and_return(StubResponse.new({ 
+          "access_token" => "test_response", 
+          "expires_in" => 86400,
+          "scope" => "scope"}, 
+          true, 
+          200))
+
+        result = client_secret_instance.send :api_token, audience: api_identifier
+        
+        expect(result).to be_a_kind_of(Auth0::ApiToken)
+        expect(result.access_token).not_to be_nil
+        expect(result.scope).not_to be_nil
+        expect(result.expires_in).not_to be_nil
+      end
+
+      it 'requests a new token using client_assertion' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/oauth/token'
+          ))
+
+          payload = JSON.parse(arg[:payload], { symbolize_names: true })
+          
+          expect(payload[:client_secret]).to be_nil
+          expect(payload[:client_assertion]).not_to be_nil
+          expect(payload[:client_assertion_type]).to eq(Auth0::ClientAssertion::CLIENT_ASSERTION_TYPE)
+
+          StubResponse.new({ 
+            "access_token" => "test_response", 
+            "expires_in" => 86400,
+            "scope" => "scope"}, 
+            true, 
+            200)
+        end
+
+        result = client_assertion_instance.send :api_token, audience: api_identifier
+        
+        expect(result).to be_a_kind_of(Auth0::ApiToken)
+        expect(result.access_token).not_to be_nil
+        expect(result.scope).not_to be_nil
+        expect(result.expires_in).not_to be_nil
+      end
+    end
+
+    context 'exchange_auth_code_for_tokens' do
+      it 'requests a new token using client_secret' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/oauth/token'
+            )
+          )
+
+          expect(JSON.parse(arg[:payload], { symbolize_names: true })).to eq({
+            grant_type: 'authorization_code',
+            client_id: client_id,
+            client_secret: client_secret,
+            code: 'the_auth_code',
+            redirect_uri: nil
+          })
+        
+          StubResponse.new({ 
+            "id_token" => "id_token",
+            "access_token" => "test_access_token", 
+            "expires_in" => 86400}, 
+            true,
+            200)
+        end
+
+        result = client_secret_instance.send :exchange_auth_code_for_tokens, 'the_auth_code'
+        
+        expect(result).to be_a_kind_of(Auth0::AccessToken)
+        expect(result.id_token).not_to be_nil
+        expect(result.access_token).not_to be_nil
+        expect(result.expires_in).not_to be_nil
+      end
+
+      it 'requests a new token using client_assertion' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/oauth/token',
+            )
+          )
+
+          payload = JSON.parse arg[:payload], symbolize_names: true
+
+          expect(payload[:client_secret]).to be_nil
+          expect(payload[:client_assertion]).not_to be_nil
+          expect(payload[:client_assertion_type]).to eq Auth0::ClientAssertion::CLIENT_ASSERTION_TYPE
+        
+          StubResponse.new({ 
+            "id_token" => "id_token",
+            "access_token" => "test_access_token", 
+            "expires_in" => 86400}, 
+            true,
+            200)
+        end
+
+        result = client_assertion_instance.send :exchange_auth_code_for_tokens, 'the_auth_code'
+        
+        expect(result).to be_a_kind_of(Auth0::AccessToken)
+        expect(result.id_token).not_to be_nil
+        expect(result.access_token).not_to be_nil
+        expect(result.expires_in).not_to be_nil
+      end
+    end
+
+    context 'exchange_refresh_token' do
+      it 'exchanges the refresh token using a client secret' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/oauth/token'
+            )
+          )
+
+          expect(JSON.parse(arg[:payload], { symbolize_names: true })).to eq({
+            grant_type: 'refresh_token',
+            client_id: client_id,
+            client_secret: client_secret,
+            refresh_token: 'the_refresh_token'
+          })
+        
+          StubResponse.new({ 
+            "id_token" => "id_token",
+            "access_token" => "test_access_token", 
+            "expires_in" => 86400}, 
+            true,
+            200)
+        end
+
+        result = client_secret_instance.send :exchange_refresh_token, 'the_refresh_token'
+        
+        expect(result).to be_a_kind_of(Auth0::AccessToken)
+        expect(result.id_token).not_to be_nil
+        expect(result.access_token).not_to be_nil
+        expect(result.expires_in).not_to be_nil
+      end
+
+      it 'exchanges the refresh token using client_assertion' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/oauth/token'
+            )
+          )
+
+          payload = JSON.parse arg[:payload], symbolize_names: true
+
+          expect(payload[:grant_type]).to eq('refresh_token')
+          expect(payload[:refresh_token]).to eq('the_refresh_token')
+          expect(payload[:client_secret]).to be_nil
+          expect(payload[:client_assertion]).not_to be_nil
+          expect(payload[:client_assertion_type]).to eq Auth0::ClientAssertion::CLIENT_ASSERTION_TYPE
+        
+          StubResponse.new({ 
+            "id_token" => "id_token",
+            "access_token" => "test_access_token", 
+            "expires_in" => 86400}, 
+            true,
+            200)
+        end
+
+        result = client_assertion_instance.send :exchange_refresh_token, 'the_refresh_token'
+        
+        expect(result).to be_a_kind_of(Auth0::AccessToken)
+        expect(result.id_token).not_to be_nil
+        expect(result.access_token).not_to be_nil
+        expect(result.expires_in).not_to be_nil
+      end
+    end
+
+    context 'login_with_resource_owner' do
+      it 'logs in using a client secret' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/oauth/token'
+            )
+          )
+
+          expect(JSON.parse(arg[:payload], { symbolize_names: true })).to eq({
+            username: 'the_username',
+            password: 'the_password',
+            grant_type: 'password', 
+            client_id: client_id,
+            client_secret: client_secret,
+            realm: nil,
+            audience: nil,
+            scope: 'openid'
+          })
+        
+          StubResponse.new({ 
+            "id_token" => "id_token",
+            "access_token" => "test_access_token", 
+            "expires_in" => 86400}, 
+            true,
+            200)
+        end
+
+        result = client_secret_instance.send :login_with_resource_owner, 'the_username', 'the_password'
+        
+        expect(result).to be_a_kind_of(Auth0::AccessToken)
+        expect(result.id_token).not_to be_nil
+        expect(result.access_token).not_to be_nil
+        expect(result.expires_in).not_to be_nil
+      end
+
+      it 'logs in using a client secret, realm and audience' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/oauth/token'
+            )
+          )
+
+          expect(JSON.parse(arg[:payload], { symbolize_names: true })).to eq({
+            username: 'the_username',
+            password: 'the_password',
+            grant_type: 'http://auth0.com/oauth/grant-type/password-realm',
+            client_id: client_id,
+            client_secret: client_secret,
+            realm: 'my-realm',
+            audience: api_identifier,
+            scope: 'openid'
+          })
+        
+          StubResponse.new({ 
+            "id_token" => "id_token",
+            "access_token" => "test_access_token", 
+            "expires_in" => 86400}, 
+            true,
+            200)
+        end
+
+        result = client_secret_instance.send :login_with_resource_owner, 'the_username', 'the_password', realm: 'my-realm', audience: api_identifier
+        
+        expect(result).to be_a_kind_of(Auth0::AccessToken)
+        expect(result.id_token).not_to be_nil
+        expect(result.access_token).not_to be_nil
+        expect(result.expires_in).not_to be_nil
+      end
+
+      it 'logs in using client assertion' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/oauth/token'
+            )
+          )
+
+          payload = JSON.parse arg[:payload], symbolize_names: true
+
+          expect(payload[:grant_type]).to eq('password')          
+          expect(payload[:client_secret]).to be_nil
+          expect(payload[:client_assertion]).not_to be_nil
+          expect(payload[:client_assertion_type]).to eq Auth0::ClientAssertion::CLIENT_ASSERTION_TYPE
+        
+          StubResponse.new({ 
+            "id_token" => "id_token",
+            "access_token" => "test_access_token", 
+            "expires_in" => 86400}, 
+            true,
+            200)
+        end
+
+        result = client_assertion_instance.send :login_with_resource_owner, 'the_username', 'the_password'
+        
+        expect(result).to be_a_kind_of(Auth0::AccessToken)
+        expect(result.id_token).not_to be_nil
+        expect(result.access_token).not_to be_nil
+        expect(result.expires_in).not_to be_nil
+      end
+    end
+
+    context 'start_passwordless_email_flow' do
+      it 'starts passwordless flow using a client secret' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/passwordless/start'
+            )
+          )
+
+          expect(JSON.parse(arg[:payload], { symbolize_names: true })).to eq({
+            email: 'email@test.com',
+            send: 'link',
+            authParams: {},
+            connection: 'email',
+            client_id: client_id,
+            client_secret: client_secret
+          })
+        
+          StubResponse.new({}, true, 200)
+        end
+
+        client_secret_instance.send :start_passwordless_email_flow, 'email@test.com'
+      end
+
+      it 'starts passwordless email flow using client assertion' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/passwordless/start'
+            )
+          )
+
+          payload = JSON.parse arg[:payload], symbolize_names: true
+
+          expect(payload[:client_secret]).to be_nil
+          expect(payload[:client_assertion]).not_to be_nil
+          expect(payload[:client_assertion_type]).to eq Auth0::ClientAssertion::CLIENT_ASSERTION_TYPE
+        
+          StubResponse.new({}, true, 200)
+        end
+
+        client_assertion_instance.send :start_passwordless_email_flow, 'email@test.com'
+      end
+    end
+
+    context 'start_passwordless_sms_flow' do
+      it 'starts passwordless flow using a client secret' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/passwordless/start'
+            )
+          )
+
+          expect(JSON.parse(arg[:payload], { symbolize_names: true })).to eq({
+            phone_number: '123456789',
+            connection: 'sms',
+            client_id: client_id,
+            client_secret: client_secret
+          })
+        
+          StubResponse.new({}, true, 200)
+        end
+
+        client_secret_instance.send :start_passwordless_sms_flow, '123456789'
+      end
+
+      it 'starts passwordless email flow using client assertion' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/passwordless/start'
+            )
+          )
+
+          payload = JSON.parse arg[:payload], symbolize_names: true
+
+          expect(payload[:client_secret]).to be_nil
+          expect(payload[:client_assertion]).not_to be_nil
+          expect(payload[:client_assertion_type]).to eq Auth0::ClientAssertion::CLIENT_ASSERTION_TYPE
+        
+          StubResponse.new({}, true, 200)
+        end
+
+        client_assertion_instance.send :start_passwordless_sms_flow, '123456789'
+      end
+    end
+  end
+end

--- a/spec/lib/auth0/mixins/initializer_spec.rb
+++ b/spec/lib/auth0/mixins/initializer_spec.rb
@@ -89,9 +89,10 @@ describe Auth0::Mixins::Initializer do
       end
     end
 
-    context 'with a client assertion signing key', focus: true do
+    context 'with a client assertion signing key' do
       it 'fetches a token if none was given' do
-        client_assertion_signing_key_pair => {private_key:}
+        private_key = client_assertion_signing_key_pair[:private_key]
+
         params[:client_id] = client_id = 'test_client_id'
         params[:api_identifier] = api_identifier = 'test'
         params[:client_assertion_signing_key] = private_key
@@ -105,7 +106,7 @@ describe Auth0::Mixins::Initializer do
           ))
 
           payload = JSON.parse(arg[:payload], { symbolize_names: true })
-          
+
           expect(payload[:grant_type]).to eq 'client_credentials'
           expect(payload[:client_id]).to eq client_id
           expect(payload[:audience]).to eq api_identifier

--- a/spec/lib/auth0/mixins/initializer_spec.rb
+++ b/spec/lib/auth0/mixins/initializer_spec.rb
@@ -57,16 +57,22 @@ describe Auth0::Mixins::Initializer do
         audience: api_identifier
       }  
 
-      expect(RestClient::Request).to receive(:execute).with(hash_including(
-        method: :post,
-        url: 'https://samples.auth0.com/oauth/token',
-        payload: payload.to_json
-      ))
-      .and_return(StubResponse.new({ 
+      expect(RestClient::Request).to receive(:execute) do |arg|
+        expect(arg).to(match(
+          include(
+            method: :post,
+            url: 'https://samples.auth0.com/oauth/token'
+          )
+        ))
+
+        expect(JSON.parse(arg[:payload], { symbolize_names: true })).to eq(payload)
+        
+        StubResponse.new({ 
         "access_token" => "test", 
         "expires_in" => 86400}, 
         true, 
-        200))
+        200)
+      end
 
       expect(instance.instance_variable_get('@token')).to eq('test')
       expect(instance.instance_variable_get('@token_expires_at')).to eq(time_now.to_i + 86400)

--- a/spec/lib/auth0/mixins/token_management_spec.rb
+++ b/spec/lib/auth0/mixins/token_management_spec.rb
@@ -34,16 +34,21 @@ describe Auth0::Mixins::TokenManagement do
 
   context 'get_token' do
     it 'renews the token if there is no token set' do
-      expect(RestClient::Request).to receive(:execute).with(hash_including(
-        method: :post,
-        url: 'https://samples.auth0.com/oauth/token',
-        payload: payload.to_json
-      ))
-      .and_return(StubResponse.new({ 
-        "access_token" => "test", 
-        "expires_in" => 86400}, 
-        true, 
-        200))
+      expect(RestClient::Request).to receive(:execute) do |arg|
+        expect(arg).to(match(
+          include(
+            method: :post,
+            url: 'https://samples.auth0.com/oauth/token'
+        )))
+
+        expect(JSON.parse(arg[:payload], { symbolize_names: true })).to eq(payload)
+      
+        StubResponse.new({ 
+          "access_token" => "test", 
+          "expires_in" => 86400}, 
+          true, 
+          200)
+      end
 
       instance.send(:get_token)
 
@@ -70,16 +75,21 @@ describe Auth0::Mixins::TokenManagement do
       params[:token] = 'test-token'
       params[:token_expires_at] = time_now.to_i + 5
 
-      expect(RestClient::Request).to receive(:execute).with(hash_including(
-        method: :post,
-        url: 'https://samples.auth0.com/oauth/token',
-        payload: payload.to_json
-      ))
-      .and_return(StubResponse.new({ 
-        "access_token" => "renewed_token", 
-        "expires_in" => 86400}, 
-        true, 
-        200))
+      expect(RestClient::Request).to receive(:execute) do |arg|
+        expect(arg).to(match(
+          include(
+            method: :post,
+            url: 'https://samples.auth0.com/oauth/token'
+        )))
+
+        expect(JSON.parse(arg[:payload], { symbolize_names: true })).to eq(payload)
+      
+        StubResponse.new({ 
+          "access_token" => "renewed_token", 
+          "expires_in" => 86400}, 
+          true, 
+          200)
+      end
 
       instance.send(:get_token)
 
@@ -91,16 +101,21 @@ describe Auth0::Mixins::TokenManagement do
       params[:token] = 'test-token'
       params[:token_expires_at] = time_now.to_i - 10
 
-      expect(RestClient::Request).to receive(:execute).with(hash_including(
-        method: :post,
-        url: 'https://samples.auth0.com/oauth/token',
-        payload: payload.to_json
-      ))
-      .and_return(StubResponse.new({ 
-        "access_token" => "renewed_token", 
-        "expires_in" => 86400}, 
-        true, 
-        200))
+      expect(RestClient::Request).to receive(:execute) do |arg|
+        expect(arg).to(match(
+          include(
+            method: :post,
+            url: 'https://samples.auth0.com/oauth/token'
+        )))
+
+        expect(JSON.parse(arg[:payload], { symbolize_names: true })).to eq(payload)
+      
+        StubResponse.new({ 
+          "access_token" => "renewed_token", 
+          "expires_in" => 86400}, 
+          true, 
+          200)
+      end
 
       instance.send(:get_token)
 

--- a/spec/support/dummy_class_for_tokens.rb
+++ b/spec/support/dummy_class_for_tokens.rb
@@ -13,5 +13,7 @@ class DummyClassForTokens
     @base_uri = "https://#{@domain}"
     @token = config[:token]
     @token_expires_at = config[:token_expires_at]
+    @client_assertion_signing_key = config[:client_assertion_signing_key]
+    @client_assertion_signing_alg = config[:client_assertion_signing_alg] || 'RS256'
   end
 end


### PR DESCRIPTION
### Changes

This PR adds support for specifying an asymmetric key for the purposes of signing a client assertion JWT to authenticate with Auth0, as an alternative to `client_secret`. See [Private Key Jwt](https://oauth.net/private-key-jwt/).

With these changes, the SDK accepts two new arguments on client creation:

- `client_assertion_signing_key`: A key used for signing the client assertion JWT (the corresponding public key should be uploaded to your Auth0 tenant)
- `client_assertion_signing_alg`: The signing algorithm to use (defaults to `RS256` if not specified

The `client_secret` argument can then be omitted. If both `client_secret` and `client_assertion_signing_key` are specified, the latter takes precedence.

The key can be anything accepted by [`ruby-jwt`](https://github.com/jwt/ruby-jwt).

```ruby
key_string = File.read 'key.pem'
key = OpenSSL::PKey::RSA.new key_string

client = Auth0Client.new(
  domain: 'AUTH0_DOMAIN',
  client_id: 'AUTH0_CLIENT_ID',
  client_assertion_signing_key: key)
```

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] Rubocop passes on all added/modified files
* [X] All active GitHub checks have passed
