### PR TITLE
ci: include Ruby 3.2 in test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,9 @@ orbs:
 matrix_ruby_versions: &matrix_ruby_versions
   matrix:
     parameters:
-      ruby_version: ["2.7", "3.0", "3.1"]
+      ruby_version: ["2.7", "3.0", "3.1", "3.2"]
 # Default version of ruby to use for lint and publishing
-default_ruby_version: &default_ruby_version "3.1"
+default_ruby_version: &default_ruby_version "3.2"
 
 executors:
   ruby-image:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
 			// Update 'VARIANT' to pick a Ruby version: 3, 3.1, 3.0, 2, 2.7
 			// Append -bullseye or -buster to pin to an OS version.
 			// Use -bullseye variants on local on arm64/Apple Silicon.
-			"VARIANT": "3.1",
+			"VARIANT": "3.2",
 			// Options
 			"NODE_VERSION": "lts/*"
 		}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,8 +121,6 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    pry-nav (0.3.0)
-      pry (>= 0.9.10, < 0.13.0)
     public_suffix (5.0.1)
     racc (1.6.2)
     rack (2.2.6.2)
@@ -234,8 +232,6 @@ DEPENDENCIES
   guard-rspec (~> 4.5)
   irb
   pp
-  pry (~> 0.10)
-  pry-nav (~> 0.2)
   rack (~> 2.1)
   rack-test (~> 0.6)
   rake (~> 13.0)

--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -27,8 +27,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'fuubar', '~> 2.0'
   s.add_development_dependency 'guard-rspec', '~> 4.5' unless ENV['CIRCLECI']
   s.add_development_dependency 'dotenv-rails', '~> 2.0'
-  s.add_development_dependency 'pry', '~> 0.10'
-  s.add_development_dependency 'pry-nav', '~> 0.2'
   s.add_development_dependency 'rspec', '~> 3.11'
   s.add_development_dependency 'rack-test', '~> 0.6'
   s.add_development_dependency 'rack', '~> 2.1'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'pry'
 require 'rack/test'
 require 'faker'
 require 'json'


### PR DESCRIPTION
This PR removes `pry` (a debug tool) from the dev dependency list, it wasn't being actively used other than being required. It's a useful tool but has been superseded in 3.2 with new built-in debug tools.

Including it produces an error that is fixed in `pry@0.14`, but unable to upgrade to that version thanks to an incompatible transient dependency chain.

However, removing it means the SDK can be tested in Ruby 3.2.