### PR TITLE
[SDK-3869] Support client credentials in management client

### DIFF
--- a/lib/auth0/api/v2/clients.rb
+++ b/lib/auth0/api/v2/clients.rb
@@ -73,11 +73,23 @@ module Auth0
           patch(path, options)
         end
 
+        # Creates credentials for a client
+        # @param client_id [string] The Id of the client to update
+        def create_credentials(client_id, options)
+          raise Auth0::MissingClientId, 'Must specify a client id' if client_id.to_s.empty?
+          raise Auth0::MissingParameter, 'Must specify a valid body' if options.to_s.empty?
+          post(client_credentials_path(client_id), options)
+        end
+
         private
 
         # Clients API path
         def clients_path
           @clients_path ||= '/api/v2/clients'
+        end
+
+        def client_credentials_path(client_id)
+          "#{clients_path}/#{client_id}/credentials"
         end
       end
     end

--- a/lib/auth0/api/v2/clients.rb
+++ b/lib/auth0/api/v2/clients.rb
@@ -82,12 +82,19 @@ module Auth0
           post(client_credentials_path(client_id), options)
         end
 
+        # Gets the credentials for a client
+        # @param client_id [string] The Id of the client
+        # @return [hash] The client credentials 
         def client_credentials(client_id)
           raise Auth0::MissingClientId, 'Must specify a client id' if client_id.to_s.empty?
           get(client_credentials_path(client_id))
         end
         alias get_client_credentials client_credentials
 
+        # Gets a client credential by ID
+        # @param client_id [string] The Id of the client
+        # @param credential_id [string] The Id of the credential to retrieve
+        # @return [hash] The credential
         def client_credential(client_id, credential_id)
           raise Auth0::MissingClientId, 'Must specify a client id' if client_id.to_s.empty?
           raise Auth0::MissingParameter, 'Must specify a credential id' if credential_id.to_s.empty?
@@ -95,10 +102,12 @@ module Auth0
         end
         alias get_client_credential client_credential
 
+        # Deletes a credential from the specified client
+        # @param client_id [string] The Id of the client
+        # @param credential_id [string] The Id of the credential to delete
         def delete_client_credential(client_id, credential_id)
           raise Auth0::MissingClientId, 'Must specify a client id' if client_id.to_s.empty?
           raise Auth0::MissingParameter, 'Must specify a credential id' if credential_id.to_s.empty?
-
           delete("#{client_credentials_path(client_id)}/#{credential_id}")
         end
 

--- a/lib/auth0/api/v2/clients.rb
+++ b/lib/auth0/api/v2/clients.rb
@@ -95,6 +95,13 @@ module Auth0
         end
         alias get_client_credential client_credential
 
+        def delete_client_credential(client_id, credential_id)
+          raise Auth0::MissingClientId, 'Must specify a client id' if client_id.to_s.empty?
+          raise Auth0::MissingParameter, 'Must specify a credential id' if credential_id.to_s.empty?
+
+          delete("#{client_credentials_path(client_id)}/#{credential_id}")
+        end
+
         private
 
         # Clients API path

--- a/lib/auth0/api/v2/clients.rb
+++ b/lib/auth0/api/v2/clients.rb
@@ -88,6 +88,13 @@ module Auth0
         end
         alias get_client_credentials client_credentials
 
+        def client_credential(client_id, credential_id)
+          raise Auth0::MissingClientId, 'Must specify a client id' if client_id.to_s.empty?
+          raise Auth0::MissingParameter, 'Must specify a credential id' if credential_id.to_s.empty?
+          get("#{client_credentials_path(client_id)}/#{credential_id}")
+        end
+        alias get_client_credential client_credential
+
         private
 
         # Clients API path

--- a/lib/auth0/api/v2/clients.rb
+++ b/lib/auth0/api/v2/clients.rb
@@ -75,11 +75,18 @@ module Auth0
 
         # Creates credentials for a client
         # @param client_id [string] The Id of the client to update
-        def create_credentials(client_id, options)
+        # @param options [hash] The payload to send to the endpoint
+        def create_client_credentials(client_id, options)
           raise Auth0::MissingClientId, 'Must specify a client id' if client_id.to_s.empty?
           raise Auth0::MissingParameter, 'Must specify a valid body' if options.to_s.empty?
           post(client_credentials_path(client_id), options)
         end
+
+        def client_credentials(client_id)
+          raise Auth0::MissingClientId, 'Must specify a client id' if client_id.to_s.empty?
+          get(client_credentials_path(client_id))
+        end
+        alias get_client_credentials client_credentials
 
         private
 

--- a/spec/lib/auth0/api/v2/clients_spec.rb
+++ b/spec/lib/auth0/api/v2/clients_spec.rb
@@ -140,4 +140,16 @@ describe Auth0::Api::V2::Clients do
     it { expect { @instance.client_credential('', '') }.to raise_error 'Must specify a client id' }
     it { expect { @instance.client_credential('1', '') }.to raise_error 'Must specify a credential id' }
   end
+
+  context '.delete_client_credential', focus: true do
+    it { expect(@instance).to respond_to(:delete_client_credential) }
+    
+    it 'is expected to delete /api/v2/clients/1/credentials/2' do
+      expect(@instance).to receive(:delete).with('/api/v2/clients/1/credentials/2')
+      expect { @instance.delete_client_credential('1', '2') }.not_to raise_error
+    end
+
+    it { expect { @instance.delete_client_credential('', '') }.to raise_error 'Must specify a client id' }
+    it { expect { @instance.delete_client_credential('1', '') }.to raise_error 'Must specify a credential id' }
+  end
 end

--- a/spec/lib/auth0/api/v2/clients_spec.rb
+++ b/spec/lib/auth0/api/v2/clients_spec.rb
@@ -101,4 +101,18 @@ describe Auth0::Api::V2::Clients do
     it { expect { @instance.patch_client('', nil) }.to raise_error 'Must specify a client id' }
     it { expect { @instance.patch_client('some', nil) }.to raise_error 'Must specify a valid body' }
   end
+
+  context '.create_credentials' do
+    it { expect(@instance).to respond_to(:create_credentials) }
+
+    it 'is expected to send post to /api/v2/clients/1/credentials' do
+      payload = { credential_type: 'public_key', name: 'my credentials', pem: '' }
+
+      expect(@instance).to receive(:post).with('/api/v2/clients/1/credentials', payload)
+      expect { @instance.create_credentials('1', payload) }.not_to raise_error
+    end
+
+    it { expect { @instance.create_credentials('', nil) }.to raise_error 'Must specify a client id' }
+    it { expect { @instance.create_credentials('1', nil) }.to raise_error 'Must specify a valid body' }
+  end
 end

--- a/spec/lib/auth0/api/v2/clients_spec.rb
+++ b/spec/lib/auth0/api/v2/clients_spec.rb
@@ -102,17 +102,29 @@ describe Auth0::Api::V2::Clients do
     it { expect { @instance.patch_client('some', nil) }.to raise_error 'Must specify a valid body' }
   end
 
-  context '.create_credentials' do
-    it { expect(@instance).to respond_to(:create_credentials) }
+  context '.create_client_credentials' do
+    it { expect(@instance).to respond_to(:create_client_credentials) }
 
     it 'is expected to send post to /api/v2/clients/1/credentials' do
       payload = { credential_type: 'public_key', name: 'my credentials', pem: '' }
 
       expect(@instance).to receive(:post).with('/api/v2/clients/1/credentials', payload)
-      expect { @instance.create_credentials('1', payload) }.not_to raise_error
+      expect { @instance.create_client_credentials('1', payload) }.not_to raise_error
     end
 
-    it { expect { @instance.create_credentials('', nil) }.to raise_error 'Must specify a client id' }
-    it { expect { @instance.create_credentials('1', nil) }.to raise_error 'Must specify a valid body' }
+    it { expect { @instance.create_client_credentials('', nil) }.to raise_error 'Must specify a client id' }
+    it { expect { @instance.create_client_credentials('1', nil) }.to raise_error 'Must specify a valid body' }
+  end
+
+  context '.client_credentials' do
+    it { expect(@instance).to respond_to(:client_credentials) }
+    it { expect(@instance).to respond_to(:get_client_credentials) }
+
+    it 'is expected to send get to /api/v2/clients/1/credentials' do
+      expect(@instance).to receive(:get).with('/api/v2/clients/1/credentials')
+      expect { @instance.client_credentials('1') }.not_to raise_error 
+    end
+
+    it { expect { @instance.client_credentials('') }.to raise_error 'Must specify a client id' }
   end
 end

--- a/spec/lib/auth0/api/v2/clients_spec.rb
+++ b/spec/lib/auth0/api/v2/clients_spec.rb
@@ -127,4 +127,17 @@ describe Auth0::Api::V2::Clients do
 
     it { expect { @instance.client_credentials('') }.to raise_error 'Must specify a client id' }
   end
+
+  context '.client_credential' do
+    it { expect(@instance).to respond_to(:client_credential) }
+    it { expect(@instance).to respond_to(:get_client_credential) }
+
+    it 'is expected to send get to /api/v2/clients/1/credentials/2' do
+      expect(@instance).to receive(:get).with('/api/v2/clients/1/credentials/2')
+      expect { @instance.client_credential('1', '2') }.not_to raise_error
+    end
+
+    it { expect { @instance.client_credential('', '') }.to raise_error 'Must specify a client id' }
+    it { expect { @instance.client_credential('1', '') }.to raise_error 'Must specify a credential id' }
+  end
 end


### PR DESCRIPTION
### Changes

This PR adds support for the following new management client endpoints:

- `POST /clients/<client_id>/credentials`
- `GET /clients/<client_id>/credentials`
- `GET /clients/<client_id>/credentials/<credential_id>`
- `DELETE /clients/<client_id>/credentials/<credential_id>`

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] Rubocop passes on all added/modified files
* [X] All active GitHub checks have passed
