### PR TITLE
feat: support exchanging OTP codes for tokens

### DIFF
--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -237,6 +237,200 @@ describe Auth0::Api::AuthenticationEndpoints do
       end
     end
 
+    context 'exchange_sms_otp_for_tokens', focus: true do
+      it 'requests the tokens using an OTP from SMS' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/oauth/token'
+            )
+          )
+
+          payload = JSON.parse arg[:payload], symbolize_names: true
+
+          expect(payload[:grant_type]).to eq 'http://auth0.com/oauth/grant-type/passwordless/otp'
+          expect(payload[:username]).to eq 'phone_number'
+          expect(payload[:realm]).to eq 'sms'
+          expect(payload[:otp]).to eq 'code'
+          expect(payload[:client_id]).to eq client_id
+          expect(payload[:client_secret]).to eq client_secret
+          expect(payload[:scope]).to eq 'openid profile email'
+          expect(payload[:audience]).to be_nil
+          
+          StubResponse.new({ 
+            "id_token" => "id_token",
+            "access_token" => "test_access_token", 
+            "expires_in" => 86400}, 
+            true,
+            200)
+        end
+
+        result = client_secret_instance.send :exchange_sms_otp_for_tokens, 'phone_number', 'code'
+
+        expect(result).to be_a_kind_of(Auth0::AccessToken)
+        expect(result.id_token).not_to be_nil
+        expect(result.access_token).not_to be_nil
+        expect(result.expires_in).not_to be_nil
+      end
+
+      it 'requests the tokens using OTP from SMS, and overrides scope and audience' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/oauth/token'
+            )
+          )
+
+          payload = JSON.parse arg[:payload], symbolize_names: true
+
+          expect(payload[:scope]).to eq 'openid'
+          expect(payload[:audience]).to eq api_identifier
+          
+          StubResponse.new({ 
+            "id_token" => "id_token",
+            "access_token" => "test_access_token", 
+            "expires_in" => 86400}, 
+            true,
+            200)
+        end
+
+        result = client_secret_instance.send(:exchange_sms_otp_for_tokens, 'phone_number', 'code',
+          audience: api_identifier,
+          scope: 'openid'
+        )
+
+        expect(result).to be_a_kind_of(Auth0::AccessToken)
+        expect(result.id_token).not_to be_nil
+        expect(result.access_token).not_to be_nil
+        expect(result.expires_in).not_to be_nil
+      end
+
+      it 'requests the tokens using an OTP from SMS using client assertion' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/oauth/token'
+            )
+          )
+
+          payload = JSON.parse arg[:payload], symbolize_names: true
+
+          expect(payload[:grant_type]).to eq 'http://auth0.com/oauth/grant-type/passwordless/otp'
+          expect(payload[:client_secret]).to be_nil
+          expect(payload[:client_assertion]).not_to be_nil
+          expect(payload[:client_assertion_type]).to eq Auth0::ClientAssertion::CLIENT_ASSERTION_TYPE
+          
+          StubResponse.new({ 
+            "id_token" => "id_token",
+            "access_token" => "test_access_token", 
+            "expires_in" => 86400}, 
+            true,
+            200)
+        end
+
+        client_assertion_instance.send :exchange_sms_otp_for_tokens, 'phone_number', 'code'
+      end
+    end
+
+    context 'exchange_email_otp_for_tokens', focus: true do
+      it 'requests the tokens using email OTP' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/oauth/token'
+            )
+          )
+
+          payload = JSON.parse arg[:payload], symbolize_names: true
+
+          expect(payload[:grant_type]).to eq 'http://auth0.com/oauth/grant-type/passwordless/otp'
+          expect(payload[:username]).to eq 'email_address'
+          expect(payload[:realm]).to eq 'email'
+          expect(payload[:otp]).to eq 'code'
+          expect(payload[:client_id]).to eq client_id
+          expect(payload[:client_secret]).to eq client_secret
+          expect(payload[:scope]).to eq 'openid profile email'
+          expect(payload[:audience]).to be_nil
+          
+          StubResponse.new({ 
+            "id_token" => "id_token",
+            "access_token" => "test_access_token", 
+            "expires_in" => 86400}, 
+            true,
+            200)
+        end
+
+        result = client_secret_instance.send :exchange_email_otp_for_tokens, 'email_address', 'code'
+
+        expect(result).to be_a_kind_of(Auth0::AccessToken)
+        expect(result.id_token).not_to be_nil
+        expect(result.access_token).not_to be_nil
+        expect(result.expires_in).not_to be_nil
+      end
+
+      it 'requests the tokens using OTP from email, and overrides scope and audience' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/oauth/token'
+            )
+          )
+
+          payload = JSON.parse arg[:payload], symbolize_names: true
+
+          expect(payload[:scope]).to eq 'openid'
+          expect(payload[:audience]).to eq api_identifier
+          
+          StubResponse.new({ 
+            "id_token" => "id_token",
+            "access_token" => "test_access_token", 
+            "expires_in" => 86400}, 
+            true,
+            200)
+        end
+
+        client_secret_instance.send(:exchange_email_otp_for_tokens, 'email_address', 'code',
+          audience: api_identifier,
+          scope: 'openid'
+        )
+      end
+
+      it 'requests the tokens using OTP from email using client assertion' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg).to match(
+            include(
+              method: :post,
+              url: 'https://samples.auth0.com/oauth/token'
+            )
+          )
+
+          payload = JSON.parse arg[:payload], symbolize_names: true
+
+          expect(payload[:grant_type]).to eq 'http://auth0.com/oauth/grant-type/passwordless/otp'
+          expect(payload[:client_secret]).to be_nil
+          expect(payload[:client_assertion]).not_to be_nil
+          expect(payload[:client_assertion_type]).to eq Auth0::ClientAssertion::CLIENT_ASSERTION_TYPE
+          
+          StubResponse.new({ 
+            "id_token" => "id_token",
+            "access_token" => "test_access_token", 
+            "expires_in" => 86400}, 
+            true,
+            200)
+        end
+
+        client_assertion_instance.send(:exchange_email_otp_for_tokens, 'email_address', 'code',
+          audience: api_identifier,
+          scope: 'openid'
+        )
+      end
+    end
+
     context 'login_with_resource_owner' do
       it 'logs in using a client secret' do
         expect(RestClient::Request).to receive(:execute) do |arg|

--- a/spec/lib/auth0/api/v2/clients_spec.rb
+++ b/spec/lib/auth0/api/v2/clients_spec.rb
@@ -141,7 +141,7 @@ describe Auth0::Api::V2::Clients do
     it { expect { @instance.client_credential('1', '') }.to raise_error 'Must specify a credential id' }
   end
 
-  context '.delete_client_credential', focus: true do
+  context '.delete_client_credential' do
     it { expect(@instance).to respond_to(:delete_client_credential) }
     
     it 'is expected to delete /api/v2/clients/1/credentials/2' do


### PR DESCRIPTION
### Changes

This adds two methods `exchange_email_otp_for_tokens` and `exchange_sms_otp_for_tokens` for completing the email and SMS embedded passwordless flows respectively. This is essentially a missing feature; the SDK already supports starting the flows but provides no affordances to be able to complete them.

Also supports authentication using client assertion.

The Auth0 client must have the "Passwordless OTP" grant enabled (see [Passwordless embedded login](https://auth0.com/docs/authenticate/passwordless/implement-login/embedded-login/relevant-api-endpoints#post-oauth-token)).

Usage example:

```ruby
client = Auth0Client.new domain: 'YOUR_AUTH0_DOMAIN', client_id: 'YOUR_CLIENT_ID', client_secret: 'YOUR_CLIENT_SECRET'

# Start passwordless using email..
client.start_passwordless_email_flow 'email@test.com', 'code'

# .. or SMS
client.start_passwordless_sms_flow '+44123456789'

# Once the code has been received, call the appropriate method to exchange the OTP:
# From an email:
result = client.exchange_email_otp_for_tokens 'email@test.com', 'OTP'
# <struct Auth0::AccessToken>

# or from SMS
result = client.exchange_sms_otp_for_tokens '+44123456789', 'OTP'
# <struct Auth0::AccessToken>
```

### References

Closes #422

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] Rubocop passes on all added/modified files
* [X] All active GitHub checks have passed
