### PR TITLE
chore: Fix Codecov uploader in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,8 @@ jobs:
             - vendor/bundle
       # Must define DOMAIN, CLIENT_ID, CLIENT_SECRET and MASTER_JWT env
       - run: bundle exec rake test
-      - codecov/upload
+      - codecov/upload:
+        file: /home/circleci/project/coverage/coverage.xml
 
 workflows:
   tests:


### PR DESCRIPTION
### Changes

This PR resolves a break in the CircleCI configuration for Codecov which resulted in coverage files not being uploaded.

### References

N/A

### Testing

* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
