### PR TITLE
[SDK-4142] Add support for /oauth/par

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -323,6 +323,21 @@ module Auth0
         URI::HTTPS.build(host: @domain, path: '/authorize', query: to_query(request_params))
       end
 
+      # Return an authorization URL for PAR requests
+      # @see https://www.rfc-editor.org/rfc/rfc9126.html
+      # @param request_uri [string] The request_uri as obtained by calling `pushed_authorization_request`
+      # @param additional_parameters Any additional parameters to send
+      def par_authorization_url(request_uri)
+        raise Auth0::InvalidParameter, 'Must supply a valid request_uri' if request_uri.to_s.empty?
+
+        request_params = {
+          client_id: @client_id,
+          request_uri: request_uri,
+        }
+
+        URI::HTTPS.build(host: @domain, path: '/authorize', query: to_query(request_params))
+      end
+
       # Returns an Auth0 logout URL with a return URL.
       # @see https://auth0.com/docs/api/authentication#logout
       # @see https://auth0.com/docs/logout

--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -344,6 +344,28 @@ module Auth0
         )
       end
 
+      # Make a request to the PAR endpoint and receive a `request_uri` to send to the '/authorize' endpoint.
+      # @see https://auth0.com/docs/api/authentication#authorization-code-grant
+      # @param redirect_uri [string] URL to redirect after authorization
+      # @param options [hash] Can contain response_type, connection, state, organization, invitation, and additional_parameters.
+      # @return [url] Authorization URL.
+      def pushed_authorization_request(parameters = {})
+        request_params = {
+          client_id: @client_id,
+          response_type: parameters.fetch(:response_type, 'code'),
+          connection: parameters.fetch(:connection, nil),
+          redirect_uri: parameters.fetch(:redirect_uri, nil),
+          state: parameters.fetch(:state, nil),
+          scope: parameters.fetch(:scope, nil),
+          organization: parameters.fetch(:organization, nil),
+          invitation: parameters.fetch(:invitation, nil)
+        }.merge(parameters.fetch(:additional_parameters, {}))
+
+        populate_client_assertion_or_secret(request_params)
+        
+        request_with_retry(:post_form, '/oauth/par', request_params, {})
+      end
+
       # Return a SAMLP URL.
       # The SAML Request AssertionConsumerServiceURL will be used to POST back
       # the assertion and it must match with the application callback URL.

--- a/lib/auth0/mixins/httpproxy.rb
+++ b/lib/auth0/mixins/httpproxy.rb
@@ -16,7 +16,7 @@ module Auth0
       BASE_DELAY = 100
 
       # proxying requests from instance methods to HTTP class methods
-      %i(get post post_file put patch delete delete_with_body).each do |method|
+      %i(get post post_file post_form put patch delete delete_with_body).each do |method|
         define_method(method) do |uri, body = {}, extra_headers = {}|
           body = body.delete_if { |_, v| v.nil? }
           token = get_token()
@@ -88,6 +88,9 @@ module Auth0
           post_file_headers = headers.slice(*headers.keys - ['Content-Type'])
           # Actual call with the altered headers
           call(:post, encode_uri(uri), timeout, post_file_headers, body)
+        elsif method == :post_form
+          form_post_headers = headers.slice(*headers.keys - ['Content-Type']) if headers != nil
+          call(:post, encode_uri(uri), timeout, form_post_headers, body)
         else
           call(method, encode_uri(uri), timeout, headers, body.to_json)
         end

--- a/lib/auth0/mixins/httpproxy.rb
+++ b/lib/auth0/mixins/httpproxy.rb
@@ -85,12 +85,12 @@ module Auth0
         elsif method == :post_file
           body.merge!(multipart: true)
           # Ignore the default Content-Type headers and let the HTTP client define them
-          post_file_headers = headers.slice(*headers.keys - ['Content-Type'])
+          post_file_headers = headers.except('Content-Type') if headers != nil
           # Actual call with the altered headers
           call(:post, encode_uri(uri), timeout, post_file_headers, body)
         elsif method == :post_form
-          form_post_headers = headers.slice(*headers.keys - ['Content-Type']) if headers != nil
-          call(:post, encode_uri(uri), timeout, form_post_headers, body)
+          form_post_headers = headers.except('Content-Type') if headers != nil
+          call(:post, encode_uri(uri), timeout, form_post_headers, body.compact)
         else
           call(method, encode_uri(uri), timeout, headers, body.to_json)
         end

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -671,6 +671,7 @@ describe Auth0::Api::AuthenticationEndpoints do
           StubResponse.new({}, true, 200)
         end
 
+        client_secret_instance.headers = {} if client_secret_instance.headers == nil
         client_secret_instance.headers['Content-Type'] = 'application/x-www-form-urlencoded'
         client_secret_instance.send :pushed_authorization_request
       end

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -666,12 +666,10 @@ describe Auth0::Api::AuthenticationEndpoints do
       it 'allows the RestClient to handle the correct header defaults' do
         expect(RestClient::Request).to receive(:execute) do |arg|
           expect(arg[:headers]).not_to have_key('Content-Type')
-          expect(arg[:headers]).to have_key('Auth0-Client')
 
           StubResponse.new({}, true, 200)
         end
 
-        client_secret_instance.headers = {} if client_secret_instance.headers == nil
         client_secret_instance.headers['Content-Type'] = 'application/x-www-form-urlencoded'
         client_secret_instance.send :pushed_authorization_request
       end

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -638,18 +638,24 @@ describe Auth0::Api::AuthenticationEndpoints do
           expect(arg[:payload]).to eq({
             client_id: client_id,
             client_secret: client_secret,
-            connection: nil,
-            organization: nil,
-            invitation: nil,
-            redirect_uri: nil,
             response_type: 'code',
-            scope: nil,
-            state: nil
           })
 
           StubResponse.new({}, true, 200)
         end
 
+        client_secret_instance.send :pushed_authorization_request
+      end
+
+      it 'allows the RestClient to handle the correct header defaults' do
+        expect(RestClient::Request).to receive(:execute) do |arg|
+          expect(arg[:headers]).not_to have_key('Content-Type')
+          expect(arg[:headers]).to have_key('Auth0-Client')
+
+          StubResponse.new({}, true, 200)
+        end
+
+        client_secret_instance.headers['Content-Type'] = 'application/x-www-form-urlencoded'
         client_secret_instance.send :pushed_authorization_request
       end
 

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -6,6 +6,7 @@ describe Auth0::Api::AuthenticationEndpoints do
   let(:client_secret) { 'test-client-secret' }
   let(:api_identifier) { 'test-audience' }
   let(:domain) { 'samples.auth0.com' }
+  let(:request_uri) { 'urn:ietf:params:oauth:request_uri:the.request.uri' }
 
   let(:client_secret_config) { { 
     domain: domain,
@@ -629,7 +630,22 @@ describe Auth0::Api::AuthenticationEndpoints do
       end
     end
 
-    context 'pushed_authorization_request', focus: true do
+    context 'par_authorization_url' do
+      it 'throws an exception if request_uri is nil' do
+        expect { client_secret_instance.send :par_authorization_url, nil}.to raise_error Auth0::InvalidParameter
+      end
+
+      it 'throws an exception if request_uri is empty' do
+        expect { client_secret_instance.send :par_authorization_url, ''}.to raise_error Auth0::InvalidParameter
+      end
+      
+      it 'builds a URL containing the request_uri' do
+        url = client_secret_instance.send :par_authorization_url, request_uri
+        expect(CGI.unescape(url.to_s)).to eq("https://samples.auth0.com/authorize?client_id=#{client_id}&request_uri=#{request_uri}")
+      end
+    end
+
+    context 'pushed_authorization_request' do
       it 'sends the request as a form post' do
         expect(RestClient::Request).to receive(:execute) do |arg|
           expect(arg[:url]).to eq('https://samples.auth0.com/oauth/par')

--- a/spec/lib/auth0/mixins/httpproxy_spec.rb
+++ b/spec/lib/auth0/mixins/httpproxy_spec.rb
@@ -271,7 +271,7 @@ describe Auth0::Mixins::HTTPProxy do
   end
 
   %i(post post_form put patch).each do |http_method|
-    context ".#{http_method}", focus: true  do
+    context ".#{http_method}" do
       it { expect(@instance).to respond_to(http_method.to_sym) }
       it "should call send http #{http_method} method to path defined through HTTP"do
         expect(RestClient::Request).to receive(:execute).with(expected_payload(http_method))

--- a/spec/support/dummy_class_for_tokens.rb
+++ b/spec/support/dummy_class_for_tokens.rb
@@ -15,5 +15,6 @@ class DummyClassForTokens
     @token_expires_at = config[:token_expires_at]
     @client_assertion_signing_key = config[:client_assertion_signing_key]
     @client_assertion_signing_alg = config[:client_assertion_signing_alg] || 'RS256'
+    @headers ||= {}
   end
 end


### PR DESCRIPTION
### Changes

This PR implements two new auth API methods:

* `pushed_authorization_request`: calls the `/oauth/par` endpoint with all the parameters that would normally be sent to `/authorize`, and returns the payload including `request_uri`
* `par_authorization_url`: accepts `request_uri` and builds a URL that includes it along with `client_id`

#### Note

Something I would like some feedback on: the SDK already exposes `authorization_url` ([source](https://github.com/auth0/ruby-auth0/blob/7d6bfa7e595d0893b71cad2889c7a4f20c8c7c60/lib/auth0/api/authentication_endpoints.rb#L309)) that builds a URL for `/authorize` with all the params. However, I decided not to support PAR here for two reasons:

* It currently takes a required parameter `redirect_url` that is not required for the PAR request
* It currently takes a set of additional parameters to include in the request, all of which will be ignored by the server when sending a `request_uri`

It made sense to build a new method. However, also looking for feedback on the name `par_authorization_url`.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] Rubocop passes on all added/modified files
* [X] All active GitHub checks have passed
