### PR TITLE
[SDK-4386] Support Organization Name in Authorize

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,7 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/ruby/.devcontainer/base.Dockerfile
 
 # [Choice] Ruby version (use -bullseye variants on local arm64/Apple Silicon): 3, 3.1, 3.0, 2, 2.7, 3-bullseye, 3.1-bullseye, 3.0-bullseye, 2-bullseye, 2.7-bullseye, 3-buster, 3.1-buster, 3.0-buster, 2-buster, 2.7-buster
-ARG VARIANT="3.1-bullseye"
+ARG VARIANT="3.2-bullseye"
 FROM mcr.microsoft.com/vscode/devcontainers/ruby:0-${VARIANT}
 
 # [Choice] Node.js version: none, lts/*, 16, 14, 12, 10

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     auth0 (5.13.0)
       addressable (~> 2.8)
-      jwt (~> 2.5)
+      jwt (~> 2.7)
       rest-client (~> 2.1)
       retryable (~> 3.0)
       zache (~> 0.12)

--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'rest-client', '~> 2.1'
-  s.add_runtime_dependency 'jwt', '~> 2.5'
+  s.add_runtime_dependency 'jwt', '~> 2.7'
   s.add_runtime_dependency 'zache', '~> 0.12'
   s.add_runtime_dependency 'addressable', '~> 2.8'
   s.add_runtime_dependency 'retryable', '~> 3.0'

--- a/lib/auth0/mixins/validation.rb
+++ b/lib/auth0/mixins/validation.rb
@@ -188,13 +188,26 @@ module Auth0
         end
 
         def validate_org(claims, expected)
-          unless claims.key?('org_id') && claims['org_id'].is_a?(String)
-            raise Auth0::InvalidIdToken, 'Organization Id (org_id) claim must be a string present in the ID token'
-          end
+          validate_as_id = expected.start_with? 'org_'
 
-          unless expected == claims['org_id']
-            raise Auth0::InvalidIdToken, "Organization Id (org_id) claim value mismatch in the ID token; expected \"#{expected}\","\
-                                         " found \"#{claims['org_id']}\""
+          if validate_as_id
+            unless claims.key?('org_id') && claims['org_id'].is_a?(String)
+              raise Auth0::InvalidIdToken, 'Organization Id (org_id) claim must be a string present in the ID token'
+            end
+
+            unless expected == claims['org_id']
+              raise Auth0::InvalidIdToken, "Organization Id (org_id) claim value mismatch in the ID token; expected \"#{expected}\","\
+                                          " found \"#{claims['org_id']}\""
+            end
+          else
+            unless claims.key?('org_name') && claims['org_name'].is_a?(String)
+              raise Auth0::InvalidIdToken, 'Organization Name (org_name) claim must be a string present in the ID token'
+            end
+
+            unless expected.downcase == claims['org_name'].downcase
+              raise Auth0::InvalidIdToken, "Organization Name (org_name) claim value mismatch in the ID token; expected \"#{expected}\","\
+                                          " found \"#{claims['org_name']}\""
+            end
           end
         end
 

--- a/spec/lib/auth0/mixins/validation_spec.rb
+++ b/spec/lib/auth0/mixins/validation_spec.rb
@@ -347,6 +347,18 @@ describe Auth0::Mixins::Validation::IdTokenValidator do
 
         expect { instance.validate(token) }.not_to raise_exception
       end
+
+      it 'validates org_id when both claims are present in the token' do
+        token = build_id_token org_name: 'my-organization', org_id: 'org_1234'
+        instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ organization: 'org_1234' }))
+        expect { instance.validate(token) }.not_to raise_exception        
+      end
+
+      it 'validates org_name when both claims are present in the token' do
+        token = build_id_token org_name: 'my-organization', org_id: 'org_1234'
+        instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ organization: 'my-organization' }))
+        expect { instance.validate(token) }.not_to raise_exception        
+      end
     end
   end
 end

--- a/spec/lib/auth0/mixins/validation_spec.rb
+++ b/spec/lib/auth0/mixins/validation_spec.rb
@@ -1,5 +1,6 @@
 # rubocop:disable Metrics/BlockLength
 require 'spec_helper'
+require 'jwt'
 
 RSA_PUB_KEY_JWK_1 = { 'kty': "RSA", 'use': 'sig', 'n': "uGbXWiK3dQTyCbX5xdE4yCuYp0AF2d15Qq1JSXT_lx8CEcXb9RbDddl8jGDv-spi5qPa8qEHiK7FwV2KpRE983wGPnYsAm9BxLFb4YrLYcDFOIGULuk2FtrPS512Qea1bXASuvYXEpQNpGbnTGVsWXI9C-yjHztqyL2h8P6mlThPY9E9ue2fCqdgixfTFIF9Dm4SLHbphUS2iw7w1JgT69s7of9-I9l5lsJ9cozf1rxrXX4V1u_SotUuNB3Fp8oB4C1fLBEhSlMcUJirz1E8AziMCxS-VrRPDM-zfvpIJg3JljAh3PJHDiLu902v9w-Iplu1WyoB2aPfitxEhRN0Yw", 'e': 'AQAB', 'kid': 'test-key-1' }.freeze
 RSA_PUB_KEY_JWK_2 = { 'kty': "RSA", 'use': 'sig', 'n': "uGbXWiK3dQTyCbX5xdE4yCuYp0AF2d15Qq1JSXT_lx8CEcXb9RbDddl8jGDv-spi5qPa8qEHiK7FwV2KpRE983wGPnYsAm9BxLFb4YrLYcDFOIGULuk2FtrPS512Qea1bXASuvYXEpQNpGbnTGVsWXI9C-yjHztqyL2h8P6mlThPY9E9ue2fCqdgixfTFIF9Dm4SLHbphUS2iw7w1JgT69s7of9-I9l5lsJ9cozf1rxrXX4V1u_SotUuNB3Fp8oB4C1fLBEhSlMcUJirz1E8AziMCxS-VrRPDM-zfvpIJg3JljAh3PJHDiLu902v9w-Iplu1WyoB2aPfitxEhRN0Yw", 'e': 'AQAB', 'kid': 'test-key-2' }.freeze
@@ -13,8 +14,14 @@ LEEWAY = 60
 CLOCK = 1587592561 # Apr 22 2020 21:56:01 UTC
 CONTEXT = { algorithm: Auth0::Algorithm::HS256.secret(HMAC_SHARED_SECRET), leeway: LEEWAY, audience: 'tokens-test-123', issuer: 'https://tokens-test.auth0.com/', clock: CLOCK }.freeze
 
+def build_id_token(payload = {})
+  default_payload = { iss: CONTEXT[:issuer], sub: 'user123', aud: CONTEXT[:audience], exp: CLOCK, iat: CLOCK }
+  JWT.encode(default_payload.merge(payload), HMAC_SHARED_SECRET, 'HS256')
+end
+
 describe Auth0::Mixins::Validation::IdTokenValidator do
   subject { @instance }
+  let (:minimal_id_token) { build_id_token }
 
   context 'instance' do
     it 'is expected respond to :validate' do
@@ -285,30 +292,31 @@ describe Auth0::Mixins::Validation::IdTokenValidator do
       expect { instance.validate(token) }.to raise_exception("Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time \"#{clock}\" is after last auth at \"#{auth_time}\"")
     end
 
-    it 'is expected not to raise an error when org_id exsist in the token, but not required' do
-      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNjE2NjE3ODgxLCJpYXQiOjE2MTY0NDUwODEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTYxNjUzMTQ4MSwib3JnX2lkIjoidGVzdE9yZyJ9.AOafUKUNgaxUXpSRYFCeJERcwrQZ4q2NZlutwGXnh9I'
-      expect { @instance.validate(token) }.not_to raise_exception
-    end
+    context 'Organization claims validation', focus: true do
+      it 'is expected not to raise an error when org_id exsist in the token, but not required' do
+        token = build_id_token org_id: 'org_123'
+        expect { @instance.validate(token) }.not_to raise_exception
+      end      
 
-    it 'is expected to raise an error with a missing but required organization' do
-      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNjE2NjE4MTg1LCJpYXQiOjE2MTY0NDUzODUsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTYxNjUzMTc4NX0.UMo5pmgceXO9lIKzbk7X0ZhE5DOe0IP2LfMKdUj03zQ'
-      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ organization: 'a1b2c3d4e5' }))
+      it 'is expected to raise an error with a missing but required organization' do
+        instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ organization: 'org_1234' }))
+        expect { instance.validate(minimal_id_token) }.to raise_exception('Organization Id (org_id) claim must be a string present in the ID token')
+      end
 
-      expect { instance.validate(token) }.to raise_exception('Organization Id (org_id) claim must be a string present in the ID token')
-    end
+      it 'is expected to raise an error with an invalid organization' do
+        token = build_id_token org_id: 'org_1234'      
+        instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ organization: 'org_5678' }))
 
-    it 'is expected to raise an error with an invalid organization' do
-      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNjE2NjE3ODgxLCJpYXQiOjE2MTY0NDUwODEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTYxNjUzMTQ4MSwib3JnX2lkIjoidGVzdE9yZyJ9.AOafUKUNgaxUXpSRYFCeJERcwrQZ4q2NZlutwGXnh9I'
-      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ organization: 'a1b2c3d4e5' }))
+        expect { instance.validate(token) }.to raise_exception('Organization Id (org_id) claim value mismatch in the ID token; expected "org_5678", found "org_1234"')
+      end
 
-      expect { instance.validate(token) }.to raise_exception('Organization Id (org_id) claim value mismatch in the ID token; expected "a1b2c3d4e5", found "testOrg"')
-    end
+      it 'is expected to NOT raise an error with a valid organization' do
+        token = build_id_token org_id: 'org_1234'
+        puts token
+        instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ organization: 'org_1234' }))
 
-    it 'is expected to NOT raise an error with a valid organization' do
-      token = 'eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNjE2NjE3ODgxLCJpYXQiOjE2MTY0NDUwODEsIm5vbmNlIjoiYTFiMmMzZDRlNSIsImF6cCI6InRva2Vucy10ZXN0LTEyMyIsImF1dGhfdGltZSI6MTYxNjUzMTQ4MSwib3JnX2lkIjoidGVzdE9yZyJ9.AOafUKUNgaxUXpSRYFCeJERcwrQZ4q2NZlutwGXnh9I'
-      instance = Auth0::Mixins::Validation::IdTokenValidator.new(CONTEXT.merge({ organization: 'testOrg' }))
-
-      expect { instance.validate(token) }.not_to raise_exception
+        expect { instance.validate(token) }.not_to raise_exception
+      end
     end
   end
 end


### PR DESCRIPTION
### Changes

This PR enables support for authorizing using organization name in addition to organization ID. Docs also updated.

In addition, some tweaks were made to organization tests that allow dynamic generation of the ID token as opposed to using a hard-coded value.

**Note:** use of this feature requires your Auth0 tenant to have this feature enabled.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] Rubocop passes on all added/modified files
* [X] All active GitHub checks have passed
