### PR TITLE
Release v5.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v5.14.1](https://github.com/auth0/ruby-auth0/tree/v5.14.1) (2023-07-19)
+[Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.14.0...v5.14.1)
+
+**Fixed**
+- chore: should not lowercase org_name claim [\#499](https://github.com/auth0/ruby-auth0/pull/499) ([stevehobbsdev](https://github.com/stevehobbsdev))
+
 ## [v5.14.0](https://github.com/auth0/ruby-auth0/tree/v5.14.0) (2023-07-13)
 [Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.13.0...v5.14.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auth0 (5.14.0)
+    auth0 (5.14.1)
       addressable (~> 2.8)
       jwt (~> 2.7)
       rest-client (~> 2.1)
@@ -93,7 +93,7 @@ GEM
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    lumberjack (1.2.8)
+    lumberjack (1.2.9)
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)

--- a/lib/auth0/version.rb
+++ b/lib/auth0/version.rb
@@ -1,4 +1,4 @@
 # current version of gem
 module Auth0
-  VERSION = '5.14.0'.freeze
+  VERSION = '5.14.1'.freeze
 end


### PR DESCRIPTION

**Fixed**
- chore: should not lowercase org_name claim [\#499](https://github.com/auth0/ruby-auth0/pull/499) ([stevehobbsdev](https://github.com/stevehobbsdev))
