### PR TITLE
chore: remove rack dev dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,8 +244,6 @@ DEPENDENCIES
   guard-rspec (~> 4.5)
   irb
   pp
-  rack (~> 2.1)
-  rack-test (~> 0.6)
   rake (~> 13.0)
   rspec (~> 3.11)
   rubocop

--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -28,8 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'guard-rspec', '~> 4.5' unless ENV['CIRCLECI']
   s.add_development_dependency 'dotenv-rails', '~> 2.0'
   s.add_development_dependency 'rspec', '~> 3.11'
-  s.add_development_dependency 'rack-test', '~> 0.6'
-  s.add_development_dependency 'rack', '~> 2.1'
   s.add_development_dependency 'simplecov', '~> 0.9'
   s.add_development_dependency 'faker', '~> 2.0'
   s.license = 'MIT'


### PR DESCRIPTION
This is not used by the SDK and was added way in the past to fix a build issue at the time. Today, however, it's causing a [Snyk vulnerability check failure](https://github.com/auth0/ruby-auth0/actions/runs/6346425109/job/17239905440).