### PR TITLE
[SDK-4546] Add orgs in client credentials support

### DIFF
--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -31,7 +31,8 @@ module Auth0
         request_params = {
           grant_type: 'client_credentials',
           client_id: client_id,
-          audience: audience
+          audience: audience,
+          organization: organization
         }
 
         populate_client_assertion_or_secret(request_params, client_id: client_id, client_secret: client_secret)

--- a/lib/auth0/api/v2/client_grants.rb
+++ b/lib/auth0/api/v2/client_grants.rb
@@ -11,13 +11,15 @@ module Auth0
         # @param audience [string] The audience of the client grant to retrieve.
         # @param page [int] Page number to get, 0-based.
         # @param per_page [int] Results per page if also passing a page number.
+        # @param allow_any_organization [bool] Optional filter on allow_any_organization.
         # @return [json] Returns the client grants.
-        def client_grants (client_id: nil, audience: nil, page: nil, per_page: nil)
+        def client_grants (client_id: nil, audience: nil, page: nil, per_page: nil, allow_any_organization: nil)
           request_params = {
             client_id: client_id,
             audience: audience,
             page: page,
-            per_page: per_page
+            per_page: per_page,
+            allow_any_organization: allow_any_organization
           }
           get(client_grants_path, request_params)
         end
@@ -53,6 +55,29 @@ module Auth0
           patch(path, options)
         end
         alias update_client_grant patch_client_grant
+
+
+        # Get the organizations associated to a client grant.
+        # @param id [string] The client_grant_id of the client grant.
+        # @param options [hash] The Hash options used to define the paging of results
+        #   * :per_page [integer] The amount of entries per page. Default: 50. Max value: 100.
+        #   * :page [integer] The page number. Zero based.
+        #   * :from [string] For checkpoint pagination, the ID from which to start selection from.
+        #   * :take [integer] For checkpoint pagination, the number of entries to retrieve. Default is 50.
+        #   * :include_totals [boolean] True to include query summary in the result, false or nil otherwise.
+        # @return [json] Returns the organizations.
+        def get_client_grants_organizations(client_grant_id, options = {})
+          raise Auth0::InvalidParameter, 'Must specify a client grant id' if client_grant_id.to_s.empty?
+          request_params = {
+            per_page:       options.fetch(:per_page, nil),
+            page:           options.fetch(:page, nil),
+            from:           options.fetch(:from, nil),
+            take:           options.fetch(:take, nil),
+            include_totals: options.fetch(:include_totals, nil)
+          }
+          path = "#{client_grants_path}/#{client_grant_id}/organizations"
+          get(path, request_params)
+        end
 
         private
 

--- a/lib/auth0/api/v2/organizations.rb
+++ b/lib/auth0/api/v2/organizations.rb
@@ -356,7 +356,7 @@ module Auth0
         # @param grant_id [string] The Client Grant ID you want to associate to the Organization.
         def create_organizations_client_grant(organization_id, grant_id)
           raise Auth0::MissingOrganizationId, 'Must supply a valid organization_id' if organization_id.to_s.empty?
-          raise Auth0::InvalidParameter, 'Must supply a valid grant_id' if grant_id.empty?
+          raise Auth0::InvalidParameter, 'Must supply a valid grant_id' if grant_id.to_s.empty?
           
           body = {}
           body[:grant_id] = grant_id

--- a/lib/auth0/api/v2/organizations.rb
+++ b/lib/auth0/api/v2/organizations.rb
@@ -330,6 +330,52 @@ module Auth0
         end
         alias remove_organizations_member_roles delete_organizations_member_roles
 
+        # Get client grants associated to an organization
+        # @param organization_id [string] The Organization ID
+        # @param options [hash] The Hash options used to define the paging of results
+        #   * :client_id [string] The client_id of the client grant to retrieve.
+        #   * :audience [string] The audience of the client grant to retrieve.
+        #   * :per_page [integer] The amount of entries per page. Default: 50. Max value: 100.
+        #   * :page [integer] The page number. Zero based.
+        #   * :include_totals [boolean] True to include query summary in the result, false or nil otherwise.
+        def get_organizations_client_grants(organization_id, options= {})
+          raise Auth0::MissingOrganizationId, 'Must supply a valid organization_id' if organization_id.to_s.empty?
+          request_params = {
+            client_id:      options.fetch(:client_id, nil),
+            audience:       options.fetch(:audience, nil),
+            per_page:       options.fetch(:per_page, nil),
+            page:           options.fetch(:page, nil),
+            include_totals: options.fetch(:include_totals, nil)
+          }
+          path = "#{organizations_client_grants_path(organization_id)}"
+          get(path, request_params)
+        end
+
+        # Associate a client grant with an organization
+        # @param organization_id [string] The Organization ID
+        # @param grant_id [string] The Client Grant ID you want to associate to the Organization.
+        def create_organizations_client_grant(organization_id, grant_id)
+          raise Auth0::MissingOrganizationId, 'Must supply a valid organization_id' if organization_id.to_s.empty?
+          raise Auth0::InvalidParameter, 'Must supply a valid grant_id' if grant_id.empty?
+          
+          body = {}
+          body[:grant_id] = grant_id
+
+          path = "#{organizations_client_grants_path(organization_id)}"
+          post(path, body)
+        end
+
+        # Remove a client grant from an organization
+        # @param organization_id [string] The Organization ID
+        # @param grant_id [string] The Client Grant ID you want to remove from the Organization.
+        def delete_organizations_client_grant(organization_id, grant_id)
+          raise Auth0::MissingOrganizationId, 'Must supply a valid organization_id' if organization_id.to_s.empty?
+          raise Auth0::InvalidParameter, 'Must supply a valid grant_id' if grant_id.empty?
+
+          path = "#{organizations_path}/#{organization_id}/client-grants/#{grant_id}"
+          delete(path)
+        end
+
         private
         # Organizations API path
         def organizations_path
@@ -350,6 +396,10 @@ module Auth0
 
         def organizations_invitations_path(org_id)
           "#{organizations_path}/#{org_id}/invitations"
+        end
+
+        def organizations_client_grants_path(org_id)
+          "#{organizations_path}/#{org_id}/client-grants"
         end
       end
     end

--- a/lib/auth0/api/v2/organizations.rb
+++ b/lib/auth0/api/v2/organizations.rb
@@ -370,7 +370,7 @@ module Auth0
         # @param grant_id [string] The Client Grant ID you want to remove from the Organization.
         def delete_organizations_client_grant(organization_id, grant_id)
           raise Auth0::MissingOrganizationId, 'Must supply a valid organization_id' if organization_id.to_s.empty?
-          raise Auth0::InvalidParameter, 'Must supply a valid grant_id' if grant_id.empty?
+          raise Auth0::InvalidParameter, 'Must supply a valid grant_id' if grant_id.to_s.empty?
 
           path = "#{organizations_path}/#{organization_id}/client-grants/#{grant_id}"
           delete(path)

--- a/spec/lib/auth0/api/authentication_endpoints_spec.rb
+++ b/spec/lib/auth0/api/authentication_endpoints_spec.rb
@@ -56,6 +56,7 @@ describe Auth0::Api::AuthenticationEndpoints do
             grant_type: 'client_credentials',
             client_id: client_id,
             audience: api_identifier,
+            organization: nil,
             client_secret: client_secret
           }.to_json
         ))
@@ -67,6 +68,33 @@ describe Auth0::Api::AuthenticationEndpoints do
           200))
 
         result = client_secret_instance.send :api_token, audience: api_identifier
+        
+        expect(result).to be_a_kind_of(Auth0::ApiToken)
+        expect(result.access_token).not_to be_nil
+        expect(result.scope).not_to be_nil
+        expect(result.expires_in).not_to be_nil
+      end
+
+      it 'requests a new token using organization' do
+        expect(RestClient::Request).to receive(:execute).with(hash_including(
+          method: :post,
+          url: 'https://samples.auth0.com/oauth/token',
+          payload: {
+            grant_type: 'client_credentials',
+            client_id: client_id,
+            audience: api_identifier,
+            organization: 'foo',
+            client_secret: client_secret
+          }.to_json
+        ))
+        .and_return(StubResponse.new({ 
+          "access_token" => "test_response", 
+          "expires_in" => 86400,
+          "scope" => "scope"}, 
+          true, 
+          200))
+
+        result = client_secret_instance.send :api_token, audience: api_identifier, organization: 'foo'
         
         expect(result).to be_a_kind_of(Auth0::ApiToken)
         expect(result.access_token).not_to be_nil

--- a/spec/lib/auth0/api/v2/client_grants_spec.rb
+++ b/spec/lib/auth0/api/v2/client_grants_spec.rb
@@ -14,6 +14,7 @@ describe Auth0::Api::V2::ClientGrants do
       expect(@instance).to receive(:get).with(
         '/api/v2/client-grants', {
         client_id: nil,
+        allow_any_organization: nil,
         audience: nil,
         page: nil,
         per_page: nil
@@ -27,6 +28,7 @@ describe Auth0::Api::V2::ClientGrants do
       expect(@instance).to receive(:get).with(
         '/api/v2/client-grants', {
         client_id: '1',
+        allow_any_organization: nil,
         audience: audience,
         page: nil,
         per_page: nil
@@ -38,11 +40,24 @@ describe Auth0::Api::V2::ClientGrants do
       expect(@instance).to receive(:get).with(
         '/api/v2/client-grants', {
         client_id: nil,
+        allow_any_organization: nil,
         audience: nil,
         page: 1,
         per_page: 2
       })
       expect { @instance.client_grants(page: 1, per_page: 2) }.not_to raise_error
+    end
+
+    it 'is expected to send get /api/v2/client-grants/ with allow_any_organization' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/client-grants', {
+        client_id: nil,
+        allow_any_organization: true,
+        audience: nil,
+        page: nil,
+        per_page: nil
+      })
+      expect { @instance.client_grants(allow_any_organization: true) }.not_to raise_error
     end
   end
 
@@ -72,5 +87,20 @@ describe Auth0::Api::V2::ClientGrants do
     end
     it { expect { @instance.patch_client_grant('', nil) }.to raise_error 'Must specify a client grant id' }
     it { expect { @instance.patch_client_grant('some', nil) }.to raise_error 'Must specify a valid body' }
+  end
+
+  context '.get_client_grants_organizations' do
+    it { expect(@instance).to respond_to(:get_client_grants_organizations) }
+    it 'is expected to send get to /api/v2/client-grants/organizations' do
+      expect(@instance).to receive(:get).with('/api/v2/client-grants/1/organizations', {
+        per_page: nil,
+        page: nil,
+        from: nil,
+        take: nil,
+        include_totals: nil
+      })
+      expect { @instance.get_client_grants_organizations('1') }.not_to raise_error
+    end
+    it { expect { @instance.get_client_grants_organizations('') }.to raise_error 'Must specify a client grant id' }
   end
 end

--- a/spec/lib/auth0/api/v2/organizations_spec.rb
+++ b/spec/lib/auth0/api/v2/organizations_spec.rb
@@ -693,8 +693,8 @@ describe Auth0::Api::V2::Organizations do
     end
   end
 
-  context '.delete_organizations_client_grants' do
-    it 'is expected to respond to a delete_organizations_client_grants method' do
+  context '.delete_organizations_client_grant' do
+    it 'is expected to respond to a delete_organizations_client_grant method' do
       expect(@instance).to respond_to(:delete_organizations_client_grant)
     end
 

--- a/spec/lib/auth0/api/v2/organizations_spec.rb
+++ b/spec/lib/auth0/api/v2/organizations_spec.rb
@@ -639,4 +639,70 @@ describe Auth0::Api::V2::Organizations do
       expect { @instance.delete_organizations_member_roles('org_id', 'user_id') }.to raise_error 'Must supply an array of role ids'
     end
   end
+
+  context '.get_organizations_client_grants' do
+    it 'is expected to respond to a get_organizations_client_grants method' do
+      expect(@instance).to respond_to(:get_organizations_client_grants)
+    end
+
+    it 'is expected to get /api/v2/organizations/org_id/client-grants' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/organizations/org_id/client-grants', {
+        per_page: nil,
+        page: nil,
+        client_id: nil,
+        audience: nil,
+        include_totals: nil
+      })
+      expect { @instance.get_organizations_client_grants('org_id') }.not_to raise_error
+    end
+
+    it 'is expected to get /api/v2/organizations/org_id/client-grants with custom parameters' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/organizations/org_id/client-grants', {
+        per_page: 10,
+        page: 1,
+        client_id: 'client_id',
+        audience: 'api',
+        include_totals: true
+      })
+      expect do
+        @instance.get_organizations_client_grants(
+          'org_id',
+          per_page: 10,
+          page: 1,
+          client_id: 'client_id',
+          audience: 'api',
+          include_totals: true
+        )
+      end.not_to raise_error
+    end
+  end
+
+  context '.create_organizations_client_grants' do
+    it 'is expected to respond to a create_organizations_client_grants method' do
+      expect(@instance).to respond_to(:create_organizations_client_grant)
+    end
+
+    it 'is expected to post /api/v2/organizations/org_id/client-grants' do
+      expect(@instance).to receive(:post).with(
+        '/api/v2/organizations/org_id/client-grants', {
+        grant_id: 'grant_id'
+      })
+      expect { @instance.create_organizations_client_grant('org_id', 'grant_id') }.not_to raise_error
+    end
+  end
+
+  context '.delete_organizations_client_grants' do
+    it 'is expected to respond to a delete_organizations_client_grants method' do
+      expect(@instance).to respond_to(:delete_organizations_client_grant)
+    end
+
+    it 'is expected to delete /api/v2/organizations/org_id/client-grants' do
+      expect(@instance).to receive(:delete).with(
+        '/api/v2/organizations/org_id/client-grants/grant_id')
+      expect { @instance.delete_organizations_client_grant('org_id', 'grant_id') }.not_to raise_error
+    end
+  end
+  
 end

--- a/spec/lib/auth0/mixins/initializer_spec.rb
+++ b/spec/lib/auth0/mixins/initializer_spec.rb
@@ -64,7 +64,8 @@ describe Auth0::Mixins::Initializer do
           grant_type: 'client_credentials',
           client_id: client_id,
           client_secret: client_secret,
-          audience: api_identifier
+          audience: api_identifier,
+          organization: nil
         }  
 
         expect(RestClient::Request).to receive(:execute) do |arg|

--- a/spec/lib/auth0/mixins/token_management_spec.rb
+++ b/spec/lib/auth0/mixins/token_management_spec.rb
@@ -11,7 +11,8 @@ describe Auth0::Mixins::TokenManagement do
     grant_type: 'client_credentials',
     client_id: client_id,
     client_secret: client_secret,
-    audience: api_identifier
+    audience: api_identifier,
+    organization: nil
   } }
 
   let(:params) { { 


### PR DESCRIPTION
### Changes

- Add optional organization parameter to client credentials grant
- Add Management API endpoints to /client-grants and /organizations
