### PR TITLE
Release v5.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v5.16.0](https://github.com/auth0/ruby-auth0/tree/v5.16.0) (2023-11-13)
+[Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.15.0...v5.16.0)
+
+**Added**
+- [SDK-4546] Add orgs in client credentials support [\#540](https://github.com/auth0/ruby-auth0/pull/540) ([adamjmcgrath](https://github.com/adamjmcgrath))
+
 ## [v5.15.0](https://github.com/auth0/ruby-auth0/tree/v5.15.0) (2023-10-30)
 [Full Changelog](https://github.com/auth0/ruby-auth0/compare/v5.14.2...v5.15.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auth0 (5.15.0)
+    auth0 (5.16.0)
       addressable (~> 2.8)
       jwt (~> 2.7)
       rest-client (~> 2.1)
@@ -11,22 +11,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (7.1.1)
-      actionview (= 7.1.1)
-      activesupport (= 7.1.1)
+    actionpack (7.1.2)
+      actionview (= 7.1.2)
+      activesupport (= 7.1.2)
       nokogiri (>= 1.8.5)
+      racc
       rack (>= 2.2.4)
       rack-session (>= 1.0.1)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    actionview (7.1.1)
-      activesupport (= 7.1.1)
+    actionview (7.1.2)
+      activesupport (= 7.1.2)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activesupport (7.1.1)
+    activesupport (7.1.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -39,7 +40,7 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
-    base64 (0.1.1)
+    base64 (0.2.0)
     bigdecimal (3.1.4)
     builder (3.2.4)
     coderay (1.1.3)
@@ -62,7 +63,7 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
-    drb (2.1.1)
+    drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
     faker (2.23.0)
@@ -93,7 +94,7 @@ GEM
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
-    irb (1.8.3)
+    irb (1.9.0)
       rdoc
       reline (>= 0.3.8)
     json (2.6.3)
@@ -112,7 +113,7 @@ GEM
     mime-types-data (3.2023.1003)
     minitest (5.20.0)
     multi_json (1.15.0)
-    mutex_m (0.1.2)
+    mutex_m (0.2.0)
     nenv (0.3.0)
     netrc (0.11.0)
     nokogiri (1.15.4-aarch64-linux)
@@ -139,7 +140,7 @@ GEM
     psych (5.1.1.1)
       stringio
     public_suffix (5.0.3)
-    racc (1.7.1)
+    racc (1.7.3)
     rack (3.0.8)
     rack-session (2.0.0)
       rack (>= 3.0.0)
@@ -155,9 +156,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
-    railties (7.1.1)
-      actionpack (= 7.1.1)
-      activesupport (= 7.1.1)
+    railties (7.1.2)
+      actionpack (= 7.1.2)
+      activesupport (= 7.1.2)
       irb
       rackup (>= 1.0.0)
       rake (>= 12.2)
@@ -168,10 +169,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rdoc (6.5.0)
+    rdoc (6.6.0)
       psych (>= 4.0.0)
     regexp_parser (2.8.2)
-    reline (0.3.9)
+    reline (0.4.0)
       io-console (~> 0.5)
     rest-client (2.1.0)
       http-accept (>= 1.7.0, < 2.0)
@@ -222,7 +223,7 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    stringio (3.0.8)
+    stringio (3.0.9)
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
@@ -235,7 +236,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.8.2)
+    unf_ext (0.0.9)
     unicode-display_width (2.5.0)
     vcr (6.2.0)
     webmock (3.19.1)

--- a/lib/auth0/version.rb
+++ b/lib/auth0/version.rb
@@ -1,4 +1,4 @@
 # current version of gem
 module Auth0
-  VERSION = '5.15.0'.freeze
+  VERSION = '5.16.0'.freeze
 end


### PR DESCRIPTION

**Added**
- [SDK-4546] Add orgs in client credentials support [\#540](https://github.com/auth0/ruby-auth0/pull/540) ([adamjmcgrath](https://github.com/adamjmcgrath))


[SDK-4546]: https://auth0team.atlassian.net/browse/SDK-4546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ