### PR TITLE
Add user session management API calls

### DIFF
--- a/lib/auth0/api/v2/users.rb
+++ b/lib/auth0/api/v2/users.rb
@@ -445,6 +445,26 @@ module Auth0
           delete "#{users_path}/#{user_id}/authentication-methods/#{authentication_method_id}"
         end
 
+        # Delete all sessions for a user.
+        #
+        # @param user_id [string] The user ID
+        # @see https://auth0.com/docs/api/management/v2/users/delete-sessions-for-user
+        def delete_user_sessions(user_id)
+          raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
+
+          delete "#{users_path}/#{user_id}/sessions"
+        end
+
+        # Retrieve details for a user's sessions.
+        #
+        # @param user_id [string] The user ID
+        # @see https://auth0.com/docs/api/management/v2/users/get-sessions-for-user
+        def user_sessions(user_id)
+          raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
+
+          get "#{users_path}/#{user_id}/sessions"
+        end
+
         private
 
         # Users API path

--- a/spec/lib/auth0/api/v2/users_spec.rb
+++ b/spec/lib/auth0/api/v2/users_spec.rb
@@ -801,4 +801,49 @@ describe Auth0::Api::V2::Users do
       end.to_not raise_error
     end
   end
+
+  context '.delete_user_sessions' do
+    it 'is expected to respond to delete_user_sessions' do
+      expect(@instance).to respond_to(:delete_user_sessions)
+    end
+
+    it 'is expected to raise an exception for a missing user ID' do
+      expect { @instance.delete_user_sessions(nil) }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to call the endpoint' do
+      expect(@instance).to receive(:delete).with(
+        '/api/v2/users/USER_ID/sessions'
+      )
+
+      expect do
+        @instance.delete_user_sessions 'USER_ID'
+      end.to_not raise_error
+    end
+  end
+
+  context '.user_sessions' do
+    it 'is expected to respond to user_sessions' do
+      expect(@instance).to respond_to :user_authentication_method
+    end
+
+    it 'is expected to respond to user_sessions' do
+      expect(@instance).to respond_to :user_sessions
+    end
+
+    it 'is expected to raise an exception for a missing user ID' do
+      expect { @instance.user_sessions(nil) }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to GET a user authentication method' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/users/USER_ID/sessions'
+      )
+
+      expect do
+        @instance.user_sessions('USER_ID')
+      end.not_to raise_error
+
+    end
+  end
 end


### PR DESCRIPTION
### Changes

Adding support for user sessions endpoints.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
