### PR TITLE
ci: use correct path for gem publish action

### DIFF
--- a/.github/workflows/ruby-release.yml
+++ b/.github/workflows/ruby-release.yml
@@ -1,4 +1,4 @@
-name: Create Release 
+name: Create Release
 
 on:
   workflow_call:
@@ -11,7 +11,6 @@ on:
         required: true
       rubygems-token:
         required: true
-
 
 jobs:
   release:
@@ -57,7 +56,7 @@ jobs:
         run: exit 1
 
       # Publish the release to our package manager
-      - uses: ./.github/actions/ruby-publish
+      - uses: ./.github/actions/rubygems-publish
         with:
           ruby-version: ${{ inputs.ruby-version }}
           rubygems-token: ${{ secrets.rubgems-token }}


### PR DESCRIPTION
Currently publish is blocked as the incorrect path to the publishing action is being used; this PR corrects that.