### PR TITLE
Add Management API calls for session API endpoints #613

### DIFF
--- a/lib/auth0/api/v2.rb
+++ b/lib/auth0/api/v2.rb
@@ -24,6 +24,7 @@ require 'auth0/api/v2/log_streams'
 require 'auth0/api/v2/resource_servers'
 require 'auth0/api/v2/guardian'
 require 'auth0/api/v2/attack_protection'
+require 'auth0/api/v2/sessions'
 
 module Auth0
   module Api
@@ -55,6 +56,7 @@ module Auth0
       include Auth0::Api::V2::Tenants
       include Auth0::Api::V2::Tickets
       include Auth0::Api::V2::AttackProtection
+      include Auth0::Api::V2::Sessions
     end
   end
 end

--- a/lib/auth0/api/v2/sessions.rb
+++ b/lib/auth0/api/v2/sessions.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Auth0
+  module Api
+    module V2
+      # Methods to use the Session endpoints
+      module Sessions
+        # Retrieve session information by id
+        # @see https://auth0.com/docs/api/management/v2/sessions/get-session
+        # @param id [string] The id of the session to retrieve.
+        def session(session_id)
+          raise Auth0::InvalidParameter, 'Must supply a valid session_id' if session_id.to_s.empty?
+
+          get "#{sessions_path}/#{session_id}"
+        end
+
+        # Deletes a session by id
+        # @see https://auth0.com/docs/api/management/v2/sessions/delete-session
+        # @param id [string] The id of the session to delete.
+        def delete_session(session_id)
+          raise Auth0::InvalidParameter, 'Must supply a valid session_id' if session_id.to_s.empty?
+
+          delete "#{sessions_path}/#{session_id}"
+        end
+
+        private
+
+        def sessions_path
+          @sessions_path ||= '/api/v2/sessions'
+        end
+      end
+    end
+  end
+end

--- a/lib/auth0/api/v2/sessions.rb
+++ b/lib/auth0/api/v2/sessions.rb
@@ -23,6 +23,15 @@ module Auth0
           delete "#{sessions_path}/#{session_id}"
         end
 
+        # Revokes a session by ID and all associated refresh tokens
+        # @see https://auth0.com/docs/api/management/v2/sessions/revoke-session
+        # @param id [string] The ID of the session to revoke
+        def revoke_session(session_id)
+          raise Auth0::InvalidParameter, 'Must supply a valid session_id' if session_id.to_s.empty?
+
+          post "#{sessions_path}/#{session_id}/revoke"
+        end
+
         private
 
         def sessions_path

--- a/spec/lib/auth0/api/v2/sessions_spec.rb
+++ b/spec/lib/auth0/api/v2/sessions_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+describe Auth0::Api::V2::Sessions do
+  before :all do
+    dummy_instance = DummyClass.new
+    dummy_instance.extend(Auth0::Api::V2::Sessions)
+    @instance = dummy_instance
+  end
+  context '.session' do
+    it 'is expected to respond to a session method' do
+      expect(@instance).to respond_to(:session)
+    end
+
+    it 'is expected to GET a session' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/sessions/SESSION_ID'
+      )
+
+      expect do
+        @instance.session('SESSION_ID')
+      end.not_to raise_error
+    end
+
+    it 'is expected to raise an exception when the session ID is empty' do
+      expect { @instance.session(nil) }.to raise_error('Must supply a valid session_id')
+    end
+  end
+  context '.delete_session' do
+    it 'is expected to respond to a delete_session method' do
+      expect(@instance).to respond_to(:delete_session)
+    end
+
+    it 'is expected to DELETE a session' do
+      expect(@instance).to receive(:delete).with(
+        '/api/v2/sessions/SESSION_ID'
+      )
+
+      expect do
+        @instance.delete_session('SESSION_ID')
+      end.not_to raise_error
+    end
+
+    it 'is expected to raise an exception when the session ID is empty' do
+      expect { @instance.delete_session(nil) }.to raise_error('Must supply a valid session_id')
+    end
+  end
+end

--- a/spec/lib/auth0/api/v2/sessions_spec.rb
+++ b/spec/lib/auth0/api/v2/sessions_spec.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+
 describe Auth0::Api::V2::Sessions do
   before :all do
     dummy_instance = DummyClass.new
     dummy_instance.extend(Auth0::Api::V2::Sessions)
     @instance = dummy_instance
   end
+
   context '.session' do
     it 'is expected to respond to a session method' do
       expect(@instance).to respond_to(:session)
@@ -26,6 +28,7 @@ describe Auth0::Api::V2::Sessions do
       expect { @instance.session(nil) }.to raise_error('Must supply a valid session_id')
     end
   end
+
   context '.delete_session' do
     it 'is expected to respond to a delete_session method' do
       expect(@instance).to respond_to(:delete_session)
@@ -43,6 +46,26 @@ describe Auth0::Api::V2::Sessions do
 
     it 'is expected to raise an exception when the session ID is empty' do
       expect { @instance.delete_session(nil) }.to raise_error('Must supply a valid session_id')
+    end
+  end
+
+  context '.revoke_session' do
+    it 'is expected to respond to a revoke_session method' do
+      expect(@instance).to respond_to(:revoke_session)
+    end
+
+    it 'is expected to POST to /api/v2/sessions/{id}/revoke' do
+      expect(@instance).to receive(:post).with(
+        '/api/v2/sessions/SESSION_ID/revoke'
+      )
+
+      expect do
+        @instance.revoke_session('SESSION_ID')
+      end.not_to raise_error
+    end
+
+    it 'is expected to raise an exception when the session ID is empty' do
+      expect { @instance.revoke_session(nil) }.to raise_error('Must supply a valid session_id')
     end
   end
 end


### PR DESCRIPTION
### Changes

Add support for the Session resource endpoints in the Management API.

### References
https://github.com/auth0/ruby-auth0/pull/613

### Testing

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
