### PR TITLE
Add Refresh Token endpoints for the Auth0 Management API #614

### DIFF
--- a/lib/auth0/api/v2.rb
+++ b/lib/auth0/api/v2.rb
@@ -11,6 +11,7 @@ require 'auth0/api/v2/emails'
 require 'auth0/api/v2/jobs'
 require 'auth0/api/v2/prompts'
 require 'auth0/api/v2/organizations'
+require 'auth0/api/v2/refresh_tokens'
 require 'auth0/api/v2/rules'
 require 'auth0/api/v2/roles'
 require 'auth0/api/v2/stats'
@@ -45,6 +46,7 @@ module Auth0
       include Auth0::Api::V2::LogStreams
       include Auth0::Api::V2::Prompts
       include Auth0::Api::V2::Organizations
+      include Auth0::Api::V2::RefreshTokens
       include Auth0::Api::V2::Rules
       include Auth0::Api::V2::Roles
       include Auth0::Api::V2::Stats

--- a/lib/auth0/api/v2/refresh_tokens.rb
+++ b/lib/auth0/api/v2/refresh_tokens.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Auth0
+  module Api
+    module V2
+      # Methods to use the Refresh Token endpoints
+      module RefreshTokens
+        # Retrieve refresh token information.
+        # @see https://auth0.com/docs/api/management/v2/refresh-tokens/get-refresh-token
+        # @param id [string] The id of the refresh token to retrieve
+        def refresh_token(id)
+          raise Auth0::InvalidParameter, 'Must supply a valid id' if id.to_s.empty?
+
+          get "#{resource_path}/#{id}"
+        end
+
+        # Delete a refresh token by its ID.
+        # @see https://auth0.com/docs/api/management/v2/refresh-tokens/delete-refresh-token
+        # @param id [string] The id of the refresh token to delete
+        def delete_refresh_token(id)
+          raise Auth0::InvalidParameter, 'Must supply a valid id' if id.to_s.empty?
+
+          delete "#{resource_path}/#{id}"
+        end
+
+        private
+
+        def resource_path
+          @resource_path ||= '/api/v2/refresh-tokens'
+        end
+      end
+    end
+  end
+end

--- a/lib/auth0/api/v2/users.rb
+++ b/lib/auth0/api/v2/users.rb
@@ -465,13 +465,45 @@ module Auth0
           get "#{users_path}/#{user_id}/sessions"
         end
 
+        # Retrieve details for a user's refresh tokens.
+        # @see https://auth0.com/docs/api/management/v2/users/get-refresh-tokens-for-user
+        #
+        # @param use_id [String] The user ID
+        # @param options [hash] A hash of options for getting permissions
+        #   * :take [Integer] Number of results per page. Defaults to 50.
+        #   * :from [String] Optional token ID from which to start selection (exclusive).
+        #   * :include_totals [boolean] Return results inside an object that contains the total result count (true)
+        #     or as a direct array of results (false, default)
+        #
+        # @return [json] Returns refresh tokens for the given user_id.
+        def user_refresh_tokens(user_id, options = {})
+          raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
+
+          request_params = {
+            take: options.fetch(:take, nil),
+            from: options.fetch(:from, nil),
+            include_totals: options.fetch(:include_totals, nil)
+          }
+
+          get "#{users_path}/#{user_id}/refresh-tokens", request_params
+        end
+
+        # Delete all refresh tokens for a user.
+        #
+        # @param user_id [String] ID of the user to get remove refresh tokens for
+        # @see https://auth0.com/docs/api/management/v2/users/delete-refresh-tokens-for-user
+        def delete_user_refresh_tokens(user_id)
+          raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
+
+          delete "#{users_path}/#{user_id}/refresh-tokens"
+        end
+
         private
 
         # Users API path
         def users_path
           @users_path ||= '/api/v2/users'
         end
-
       end
     end
   end

--- a/spec/lib/auth0/api/v2/refresh_tokens_spec.rb
+++ b/spec/lib/auth0/api/v2/refresh_tokens_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Auth0::Api::V2::RefreshTokens do
+  before :all do
+    dummy_instance = DummyClass.new
+    dummy_instance.extend(Auth0::Api::V2::RefreshTokens)
+    @instance = dummy_instance
+  end
+
+  describe '.refresh_token' do
+    it 'is expected to respond to a refresh_token method' do
+      expect(@instance).to respond_to(:refresh_token)
+    end
+
+    it 'is expected to GET a refresh_token' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/refresh-tokens/REFRESH_TOKEN_ID'
+      )
+
+      expect do
+        @instance.refresh_token('REFRESH_TOKEN_ID')
+      end.not_to raise_error
+    end
+
+    it 'is expected to raise an exception when the id is empty' do
+      expect { @instance.refresh_token(nil) }.to raise_error('Must supply a valid id')
+    end
+  end
+
+  describe '.delete_refresh_token' do
+    it 'is expected to respond to a delete_refresh_token method' do
+      expect(@instance).to respond_to(:delete_refresh_token)
+    end
+
+    it 'is expected to DELETE a refresh_token' do
+      expect(@instance).to receive(:delete).with(
+        '/api/v2/refresh-tokens/REFRESH_TOKEN_ID'
+      )
+
+      expect do
+        @instance.delete_refresh_token('REFRESH_TOKEN_ID')
+      end.not_to raise_error
+    end
+
+    it 'is expected to raise an exception when the id is empty' do
+      expect { @instance.delete_refresh_token(nil) }.to raise_error('Must supply a valid id')
+    end
+  end
+end

--- a/spec/lib/auth0/api/v2/users_spec.rb
+++ b/spec/lib/auth0/api/v2/users_spec.rb
@@ -843,7 +843,62 @@ describe Auth0::Api::V2::Users do
       expect do
         @instance.user_sessions('USER_ID')
       end.not_to raise_error
+    end
+  end
 
+  context '.user_refresh_tokens' do
+    it 'is expected to respond to a user_refresh_tokens method' do
+      expect(@instance).to respond_to(:user_refresh_tokens)
+    end
+
+    it 'is expected to raise an exception when the user ID is empty' do
+      expect { @instance.user_refresh_tokens(nil) }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to get user refresh tokens' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/users/USER_ID/refresh-tokens', {
+          from: nil,
+          take: nil,
+          include_totals: nil
+        }
+      )
+      expect do
+        @instance.user_refresh_tokens('USER_ID')
+      end.not_to raise_error
+    end
+
+    it 'is expected to get user refresh tokens with custom parameters' do
+      expect(@instance).to receive(:get).with(
+        '/api/v2/users/USER_ID/refresh-tokens', {
+          from: 'TOKEN_ID',
+          take: 10,
+          include_totals: true
+        }
+      )
+      expect do
+        @instance.user_refresh_tokens('USER_ID', from: 'TOKEN_ID', take: 10, include_totals: true)
+      end.not_to raise_error
+    end
+  end
+
+  context '.delete_user_refresh_tokens' do
+    it 'is expected to respond to delete_user_refresh_tokens' do
+      expect(@instance).to respond_to(:delete_user_refresh_tokens)
+    end
+
+    it 'is expected to raise an exception for a missing user ID' do
+      expect { @instance.delete_user_refresh_tokens(nil) }.to raise_exception(Auth0::MissingUserId)
+    end
+
+    it 'is expected to call the endpoint' do
+      expect(@instance).to receive(:delete).with(
+        '/api/v2/users/USER_ID/refresh-tokens'
+      )
+
+      expect do
+        @instance.delete_user_refresh_tokens 'USER_ID'
+      end.to_not raise_error
     end
   end
 end


### PR DESCRIPTION
### Changes

Adds support for the Management API endpoints introduced in [Manage Refresh Tokens with Auth0 Management API](https://auth0.com/docs/secure/tokens/manage-refresh-tokens-with-auth0-management-api)

### References

https://github.com/auth0/ruby-auth0/pull/614

### Testing

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
