### PR TITLE
Reduce gem size

### DIFF
--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -11,9 +11,8 @@ Gem::Specification.new do |s|
   s.summary     = 'Auth0 API Client'
   s.description = 'Ruby toolkit for Auth0 API https://auth0.com.'
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.files         = `git ls-files -z -- LICENSE README.md lib`.split("\x0")
+  s.executables   = s.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
   s.add_runtime_dependency 'rest-client', '~> 2.1'


### PR DESCRIPTION
### Changes

This reduces the Auth0 gem size by changing `files` in the gemspec.
Currently, the gem contains many unnecessary files for execution, such as tests or examples.

Besides, since `test_files` in the gemspec is unsupported, we can remove it.
See https://guides.rubygems.org/specification-reference/

To verify this change locally, run the command for each branch and compare each output:

```sh
gem build
```

Here's a size diff in my local environment:

```sh-session
$ du -h auth0-*.gem*
 40K	auth0-5.17.0.gem
216K	auth0-5.17.0.gem.current
```

In addition, we can compare included files in the gem as well:

```shell
bundle exec ruby -e 's = Gem.loaded_specs["auth0"]; puts s.files + s.executables'
```

For example:

```shell
git switch master
bundle exec ruby -e 's = Gem.loaded_specs["auth0"]; puts s.files + s.executables' > before
git switch reduce-gem-size
bundle exec ruby -e 's = Gem.loaded_specs["auth0"]; puts s.files + s.executables' > after
diff -u before after
```

### References

- https://guides.rubygems.org/specification-reference/
- https://rubygems.org/gems/auth0
  - v5.17.0's size is 212KB:
  - <img width="221" alt="image" src="https://github.com/user-attachments/assets/dbffd188-21b8-4e69-946b-d9eb59afec85">

### Testing

This change should be tested on each developer's local environment, instead of unit/integration tests, as I explained above.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
