### PR TITLE
Add options parameter to user_sessions method

### DIFF
--- a/lib/auth0/api/v2/users.rb
+++ b/lib/auth0/api/v2/users.rb
@@ -458,11 +458,22 @@ module Auth0
         # Retrieve details for a user's sessions.
         #
         # @param user_id [string] The user ID
+        # @param options [hash] A hash of options for getting permissions
+        #   * :take [Integer] Number of results per page. Defaults to 50.
+        #   * :from [String] Optional token ID from which to start selection (exclusive).
+        #   * :include_totals [boolean] Return results inside an object that contains the total result count (true)
+        #     or as a direct array of results (false, default)
         # @see https://auth0.com/docs/api/management/v2/users/get-sessions-for-user
-        def user_sessions(user_id)
+        def user_sessions(user_id, options = {})
           raise Auth0::MissingUserId, 'Must supply a valid user_id' if user_id.to_s.empty?
 
-          get "#{users_path}/#{user_id}/sessions"
+          request_params = {
+            take: options.fetch(:take, nil),
+            from: options.fetch(:from, nil),
+            include_totals: options.fetch(:include_totals, nil)
+          }
+
+          get "#{users_path}/#{user_id}/sessions", request_params
         end
 
         # Retrieve details for a user's refresh tokens.

--- a/spec/lib/auth0/api/v2/users_spec.rb
+++ b/spec/lib/auth0/api/v2/users_spec.rb
@@ -837,11 +837,29 @@ describe Auth0::Api::V2::Users do
 
     it 'is expected to GET a user authentication method' do
       expect(@instance).to receive(:get).with(
-        '/api/v2/users/USER_ID/sessions'
+        '/api/v2/users/USER_ID/sessions',
+        {
+          from: nil,
+          take: nil,
+          include_totals: nil
+        }
       )
-
       expect do
         @instance.user_sessions('USER_ID')
+      end.not_to raise_error
+    end
+
+    it 'is expected to get user sessions with custom parameters' do
+        expect(@instance).to receive(:get).with(
+          '/api/v2/users/USER_ID/sessions',
+          {
+            from: 'TOKEN_ID',
+            take: 10,
+            include_totals: true
+          }
+      )
+      expect do
+        @instance.user_sessions('USER_ID', from: 'TOKEN_ID', take: 10, include_totals: true)
       end.not_to raise_error
     end
   end


### PR DESCRIPTION
### Changes

In this PR, the `user_sessions` method is extended to properly pass query parameters in addition to the user_id path parameter, ensuring that the API request includes the provided query parameters.

### References

[Auth0 Management API - Get sessions for user](https://auth0.com/docs/api/management/v2/users/get-sessions-for-user)

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed
