### PR TITLE
Add authorization_details to AccessToken struct

### DIFF
--- a/lib/auth0/mixins/access_token_struct.rb
+++ b/lib/auth0/mixins/access_token_struct.rb
@@ -2,7 +2,8 @@ Auth0::AccessToken = Struct.new(
   :access_token,
   :expires_in,
   :refresh_token,
-  :id_token
+  :id_token,
+  :authorization_details
 ) do
 
   def self.from_response(response)
@@ -10,7 +11,8 @@ Auth0::AccessToken = Struct.new(
       response['access_token'],
       response['expires_in'],
       response['refresh_token'],
-      response['id_token']
+      response['id_token'],
+      response['authorization_details']
     )
   end
 


### PR DESCRIPTION
### Changes

When using the **Authorization Code flow**, the `exchange_auth_code_for_tokens` method can now return a token containing the `authorization_details` key. This field is required to handle detailed authorization information provided by Auth0 for certain requests (e.g., PAR/OAuth2 Pushed Authorization Requests).

This change allows:

Retrieving and using `authorization_details` in the Auth0 callback. Preparing the application for advanced authorization scenarios (such as fine-grained permission management). Thank you for your review!

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
