### PR TITLE
chore: upgrade dev dependencies to fix snyk vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,10 +63,7 @@ GEM
     diff-lcs (1.6.2)
     docile (1.4.1)
     domain_name (0.6.20240107)
-    dotenv (2.8.1)
-    dotenv-rails (2.8.1)
-      dotenv (= 2.8.1)
-      railties (>= 3.2)
+    dotenv (3.2.0)
     drb (2.2.3)
     erb (6.0.1)
     erubi (1.13.0)
@@ -185,9 +182,9 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.6.0)
+    rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
-      nokogiri (~> 1.14)
+      nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.1.2)
       actionpack (= 8.1.2)
       activesupport (= 8.1.2)
@@ -215,7 +212,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     retryable (3.0.5)
-    rexml (3.3.9)
+    rexml (3.4.4)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -256,7 +253,7 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-cobertura (2.1.0)
+    simplecov-cobertura (3.1.0)
       rexml
       simplecov (~> 0.19)
     simplecov-html (0.13.1)
@@ -266,7 +263,7 @@ GEM
     term-ansicolor (1.11.2)
       tins (~> 1.0)
     terminal-notifier-guard (1.7.0)
-    thor (1.3.2)
+    thor (1.5.0)
     timecop (0.9.10)
     tins (1.37.0)
       bigdecimal
@@ -280,7 +277,7 @@ GEM
     uri (1.1.1)
     useragent (0.16.10)
     vcr (6.4.0)
-    webmock (3.24.0)
+    webmock (3.26.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -307,7 +304,7 @@ DEPENDENCIES
   auth0!
   bundler
   coveralls
-  dotenv-rails (~> 2.0)
+  dotenv (~> 3.0)
   faker (~> 2.0)
   fuubar (~> 2.0)
   guard-rspec (~> 4.5)

--- a/auth0.gemspec
+++ b/auth0.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 13.0'
   s.add_development_dependency 'fuubar', '~> 2.0'
   s.add_development_dependency 'guard-rspec', '~> 4.5' unless ENV['CIRCLECI']
-  s.add_development_dependency 'dotenv-rails', '~> 2.0'
+  s.add_development_dependency 'dotenv', '~> 3.0'
   s.add_development_dependency 'rspec', '~> 3.11'
   s.add_development_dependency 'simplecov', '~> 0.9'
   s.add_development_dependency 'faker', '~> 2.0'


### PR DESCRIPTION
### Changes

`snyk test` reported 7 vulnerabilities across 15 paths, all in development dependencies (zero customer impact — none of these gems are shipped as part of the auth0 gem itself).


Severity | Vulnerability | Before | After
-- | -- | -- | --
High | OS Command Injection | thor 1.3.2 | thor 1.5.0
Low ×5 | XSS | rails-html-sanitizer 1.6.0 | rails-html-sanitizer 1.6.2
Medium ×2 | XML Entity Expansion | rexml 3.3.9 | rexml 3.4.4

`auth0.gemspec` — replaced dotenv-rails with dotenv. The Rails-specific gem was pulling in the full Rails stack transitively, which introduced the thor and rails-html-sanitizer vulnerability paths. The specs only use Dotenv.load, which is available in the base dotenv gem.

`Gemfile.lock` — only the six packages listed above were changed. No other gem versions were upgraded or downgraded.


### References

* [thor OS Command Injection](https://security.snyk.io/vuln/SNYK-RUBY-THOR-6260692)
* [rails-html-sanitizer XSS](https://security.snyk.io/vuln/SNYK-RUBY-RAILSHTMLSANITIZER-8324306)
* [rexml XML Entity Expansion](https://security.snyk.io/vuln/SNYK-RUBY-REXML-6953452)

 
### Testing

Development/test dependency changes only — no production code was modified.

- `bundle install`
- `bundle exec rake spec`
- `snyk test`

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed