### PR TITLE
fix(ci): suppress Ruby license false positives in Snyk checks

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -12,3 +12,6 @@ ignore:
   snyk:lic:rubygems:json:Ruby:
     - '*':
         reason: Ruby standard library gem, Ruby license is acceptable
+  snyk:lic:rubygems:reline:Ruby:
+    - '*':
+        reason: Ruby standard library gem, Ruby license is acceptable


### PR DESCRIPTION
### Changes

The Snyk CI check was failing on Ruby license issues for `json` and `reline`. Both Ruby standard library gems maintained by the Ruby core team. These are not security vulnerabilities; the Ruby license (an OSI-approved open source license) is flagged by the org's Snyk license policy but is acceptable for this project.

Added `.snyk` ignore entries to suppress these false positives:
- `json`: introduced via `rubocop` and other paths
- `reline`: introduced via `guard-rspec > guard > formatador > reline`

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [ ] This change has been tested on the latest version of Ruby

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [ ] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
