### PR TITLE
Make Auth0::Client#get_token public

### DIFF
--- a/lib/auth0/mixins/token_management.rb
+++ b/lib/auth0/mixins/token_management.rb
@@ -1,22 +1,14 @@
 module Auth0
   module Mixins
     module TokenManagement
-      
-      private
 
-      def initialize_token(options)
-        @token = options[:access_token] || options[:token]
-        # default expiry to an hour if a token was given but no expires_at
-        @token_expires_at = @token ? options[:token_expires_at] || Time.now.to_i + 3600 : nil 
-
-        @audience = options[:api_identifier] || "https://#{@domain}/api/v2/"
-        get_token() if @token.nil?
-      end
-
+      # Get the Client's api token (or generate a new one if it has expired).
+      #
+      # @return [String] the api token
       def get_token
         # pp @token_expires_at
         has_expired = @token && @token_expires_at ? @token_expires_at < (Time.now.to_i + 10) : false
-        
+
         if (@token.nil? || has_expired) && @client_id && (@client_secret || @client_assertion_signing_key)
           response = api_token(audience: @audience)
           @token = response.token
@@ -26,6 +18,17 @@ module Auth0
         else
           @token
         end
+      end
+
+      private
+
+      def initialize_token(options)
+        @token = options[:access_token] || options[:token]
+        # default expiry to an hour if a token was given but no expires_at
+        @token_expires_at = @token ? options[:token_expires_at] || Time.now.to_i + 3600 : nil
+
+        @audience = options[:api_identifier] || "https://#{@domain}/api/v2/"
+        get_token() if @token.nil?
       end
     end
   end

--- a/lib/auth0/mixins/token_management.rb
+++ b/lib/auth0/mixins/token_management.rb
@@ -4,9 +4,9 @@ module Auth0
 
       # Get the Client's api token (or generate a new one if it has expired).
       #
+      # @note This method may perform a network request to refresh an expired token. It is not thread-safe.
       # @return [String] the api token
       def get_token
-        # pp @token_expires_at
         has_expired = @token && @token_expires_at ? @token_expires_at < (Time.now.to_i + 10) : false
 
         if (@token.nil? || has_expired) && @client_id && (@client_secret || @client_assertion_signing_key)

--- a/spec/lib/auth0/mixins/token_management_spec.rb
+++ b/spec/lib/auth0/mixins/token_management_spec.rb
@@ -15,7 +15,7 @@ describe Auth0::Mixins::TokenManagement do
     organization: nil
   } }
 
-  let(:params) { { 
+  let(:params) { {
     domain: domain,
     client_id: client_id,
     client_secret: client_secret,
@@ -43,15 +43,15 @@ describe Auth0::Mixins::TokenManagement do
         )))
 
         expect(JSON.parse(arg[:payload], { symbolize_names: true })).to eq(payload)
-      
-        StubResponse.new({ 
-          "access_token" => "test", 
-          "expires_in" => 86400}, 
-          true, 
+
+        StubResponse.new({
+          "access_token" => "test",
+          "expires_in" => 86400},
+          true,
           200)
       end
 
-      instance.send(:get_token)
+      instance.get_token
 
       expect(instance.instance_variable_get('@token')).to eq('test')
       expect(instance.instance_variable_get('@token_expires_at')).to eq(time_now.to_i + 86400)
@@ -66,7 +66,7 @@ describe Auth0::Mixins::TokenManagement do
         url: 'https://samples.auth0.com/oauth/token',
       ))
 
-      instance.send(:get_token)
+      instance.get_token
 
       expect(instance.instance_variable_get('@token')).to eq('test-token')
       expect(instance.instance_variable_get('@token_expires_at')).to eq(time_now.to_i + 86400)
@@ -84,15 +84,15 @@ describe Auth0::Mixins::TokenManagement do
         )))
 
         expect(JSON.parse(arg[:payload], { symbolize_names: true })).to eq(payload)
-      
-        StubResponse.new({ 
-          "access_token" => "renewed_token", 
-          "expires_in" => 86400}, 
-          true, 
+
+        StubResponse.new({
+          "access_token" => "renewed_token",
+          "expires_in" => 86400},
+          true,
           200)
       end
 
-      instance.send(:get_token)
+      instance.get_token
 
       expect(instance.instance_variable_get('@token')).to eq('renewed_token')
       expect(instance.instance_variable_get('@token_expires_at')).to eq(time_now.to_i + 86400)
@@ -110,15 +110,15 @@ describe Auth0::Mixins::TokenManagement do
         )))
 
         expect(JSON.parse(arg[:payload], { symbolize_names: true })).to eq(payload)
-      
-        StubResponse.new({ 
-          "access_token" => "renewed_token", 
-          "expires_in" => 86400}, 
-          true, 
+
+        StubResponse.new({
+          "access_token" => "renewed_token",
+          "expires_in" => 86400},
+          true,
           200)
       end
 
-      instance.send(:get_token)
+      instance.get_token
 
       expect(instance.instance_variable_get('@token')).to eq('renewed_token')
       expect(instance.instance_variable_get('@token_expires_at')).to eq(time_now.to_i + 86400)
@@ -130,7 +130,7 @@ describe Auth0::Mixins::TokenManagement do
 
       expect(RestClient::Request).not_to receive(:execute)
 
-      instance.send(:get_token)
+      instance.get_token
     end
   end
 end

--- a/spec/lib/auth0/mixins/token_management_spec.rb
+++ b/spec/lib/auth0/mixins/token_management_spec.rb
@@ -130,7 +130,7 @@ describe Auth0::Mixins::TokenManagement do
 
       expect(RestClient::Request).not_to receive(:execute)
 
-      instance.get_token
+      expect(instance.get_token).to eq('test-token')
     end
   end
 end


### PR DESCRIPTION
## Summary
- Makes `Auth0::Client#get_token` a public method (previously private)
- Allows callers to retrieve the current API token without a redundant `/oauth/token` request
- Updates tests to call `get_token` directly instead of via `send(:get_token)`

This takes forward the community contribution from #648 by @ttstarck.

## References
- Original PR: #648