### PR TITLE
fix: update .fernignore to protect custom files from regeneration

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,29 +1,59 @@
 # Specify files that shouldn't be modified by Fern
-changelog.md
+
+# Custom SDK files
 lib/auth0/client.rb
 lib/auth0/auth_client.rb
 lib/auth0/exception.rb
 lib/auth0/algorithm.rb
 lib/auth0/client_assertion.rb
+lib/auth0/version.rb
+lib/auth0/environment.rb
 lib/auth0/mixins.rb
 lib/auth0/mixins/
 lib/auth0/api/
+lib/auth0/errors/
 lib/auth0_client.rb
-custom.gemspec.rb
+
+# Internal infrastructure (custom HTTP, iterators, JSON, multipart)
+lib/auth0/internal/
 
 # Telemetry customization
 lib/auth0/internal/http/raw_client.rb
-test/unit/authentication_endpoints_test.rb
 
+# Packaging & build
+auth0.gemspec
+custom.gemspec.rb
+Gemfile
+Gemfile.custom
+Gemfile.lock
+Rakefile
+
+# Project configuration
+.gitignore
+.version
+.shiprc
+.snyk
 .rubocop.yml
+codecov.yml
+LICENSE
 
 # Documentation
 README.md
+CHANGELOG.md
 EXAMPLES.md
 DEVELOPMENT.md
 DEPLOYMENT.md
 CODE_OF_CONDUCT.md
 RUBYGEM.md
 v6_MIGRATION_GUIDE.md
-.github/PULL_REQUEST_TEMPLATE.md
+reference.md
+
+# GitHub (entire directory - workflows, actions, templates, CODEOWNERS)
+.github/
+
+# Tests
+test/
+wiremock/
+
+# Examples
 examples/


### PR DESCRIPTION
## Changes

Added missing files to `.fernignore` to prevent Fern regeneration from deleting custom project files.

**Added:**
- `lib/auth0/version.rb`
- `lib/auth0/environment.rb`
- `lib/auth0/errors/`
- `lib/auth0/internal/`
- `auth0.gemspec`
- `Gemfile`
- `Gemfile.custom`
- `Gemfile.lock`
- `Rakefile`
- `.gitignore`
- `.version`
- `.shiprc`
- `.snyk`
- `codecov.yml`
- `LICENSE`
- `CHANGELOG.md`
- `reference.md`
- `.github/`
- `test/`
- `wiremock/`