### PR TITLE
fix: scope .fernignore to custom tests so Fern owns generated wire tests

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -51,9 +51,10 @@ reference.md
 # GitHub (entire directory - workflows, actions, templates, CODEOWNERS)
 .github/
 
-# Tests
-test/
-wiremock/
+# Tests (custom only - Fern owns test/wire/)
+test/unit/
+test/test_helper.rb
+test/custom.test.rb
 
 # Examples
 examples/


### PR DESCRIPTION
### Changes
This scopes the ignore to the genuinely custom tests only, letting Fern own `test/wire/` and `wiremock/` again:

- `test/unit/`
- `test/test_helper.rb`
- `test/custom.test.rb`
