### PR TITLE
fix: let Fern own client.rb so sub-client accessors stay in sync

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -1,7 +1,6 @@
 # Specify files that shouldn't be modified by Fern
 
 # Custom SDK files
-lib/auth0/client.rb
 lib/auth0/auth_client.rb
 lib/auth0/exception.rb
 lib/auth0/algorithm.rb


### PR DESCRIPTION
### Changes

Removes `lib/auth0/client.rb` (the root `Auth0::Management` client) from `.fernignore` so Fern owns it on regeneration.
