### PR TITLE
chore: prepare CI for GA and re-enable release scanner

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - master
-      - v6
+      - v5
   schedule:
     - cron: "37 10 * * 2"
 
@@ -20,7 +20,7 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/v6' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/v5' }}
 
 jobs:
   analyze:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,22 +14,21 @@ permissions:
 ### TODO: Also remove `get-prerelease`, `get-version`, `rubygems-publish`, `release-create`, `tag-create` and `tag-exists` actions from this repo's .github/actions folder and `ruby-release` from `./github/workflows` once the repo is public.
 
 jobs:
-  # TODO: Re-enable rl-scanner once it is configured for the v6 branch.
-  # rl-scanner:
-  #   uses: ./.github/workflows/rl-scanner.yml
-  #   with:
-  #     ruby-version: 3.2
-  #   secrets:
-  #     RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}
-  #     RLSECURE_SITE_KEY: ${{ secrets.RLSECURE_SITE_KEY }}
-  #     SIGNAL_HANDLER_TOKEN: ${{ secrets.SIGNAL_HANDLER_TOKEN }}
-  #     PRODSEC_TOOLS_USER: ${{ secrets.PRODSEC_TOOLS_USER }}
-  #     PRODSEC_TOOLS_TOKEN: ${{ secrets.PRODSEC_TOOLS_TOKEN }}
-  #     PRODSEC_TOOLS_ARN: ${{ secrets.PRODSEC_TOOLS_ARN }}
+  rl-scanner:
+    uses: ./.github/workflows/rl-scanner.yml
+    with:
+      ruby-version: 3.3
+    secrets:
+      RLSECURE_LICENSE: ${{ secrets.RLSECURE_LICENSE }}
+      RLSECURE_SITE_KEY: ${{ secrets.RLSECURE_SITE_KEY }}
+      SIGNAL_HANDLER_TOKEN: ${{ secrets.SIGNAL_HANDLER_TOKEN }}
+      PRODSEC_TOOLS_USER: ${{ secrets.PRODSEC_TOOLS_USER }}
+      PRODSEC_TOOLS_TOKEN: ${{ secrets.PRODSEC_TOOLS_TOKEN }}
+      PRODSEC_TOOLS_ARN: ${{ secrets.PRODSEC_TOOLS_ARN }}
 
   release:
     uses: ./.github/workflows/ruby-release.yml
-    # needs: rl-scanner
+    needs: rl-scanner
     with:
       ruby-version: 3.3
     secrets:

--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -1,9 +1,9 @@
 name: SCA
 on:
   push:
-    branches: ["master", "v6"]
+    branches: ["master", "v5"]
   pull_request:
-    branches: ["master", "v6"]
+    branches: ["master", "v5"]
 jobs:
   snyk-cli:
     uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,18 +6,18 @@ on:
   pull_request:
     branches:
       - master
-      - v6
+      - v5
   push:
     branches:
       - master
-      - v6
+      - v5
 
 permissions:
   contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/v6' }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && github.ref != 'refs/heads/v5' }}
 
 env:
   CACHE_KEY: "${{ github.ref }}-${{ github.run_id }}-${{ github.run_attempt }}"

--- a/v6_MIGRATION_GUIDE.md
+++ b/v6_MIGRATION_GUIDE.md
@@ -1,6 +1,6 @@
 # V6 Migration Guide
 
-A guide to migrating from `ruby-auth0` (v5.x) to `auth0-ruby-sdk` (v6.x).
+A guide to migrating from v5.x to v6.x of the `auth0` gem.
 
 - [Overview](#overview)
   - [Authentication API](#authentication-api)


### PR DESCRIPTION
### Changes

Prepares the v6 branch for GA so CI and the release workflow behave correctly once v6 becomes the default branch. The current `master` (v5) has been backed up to a `v5` branch, which now becomes the maintenance branch that CI should watch.

- Point the `test`, `codeql`, and `sca_scan` workflow branch triggers (and cancel-in-progress guards) at `v5` instead of `v6`
- Re-enable `rl-scanner` as a required step in the release workflow
- Correct the migration guide intro to reference the `auth0` gem instead of a non-existent package name