### PR TITLE
fix(ci): pass ruby input to setup action in rl-scanner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types:
       - closed
+      - opened # TEMP: test rl-scanner on PR
+      - synchronize # TEMP: test rl-scanner on PR
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     types:
       - closed
-      - opened # TEMP: test rl-scanner on PR
-      - synchronize # TEMP: test rl-scanner on PR
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/rl-scanner.yml
+++ b/.github/workflows/rl-scanner.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Configure Ruby
         uses: ./.github/actions/setup
         with:
-          ruby-version: ${{ inputs.ruby-version }}
+          ruby: ${{ inputs.ruby-version }}
 
       - name: Build RubyGems
         shell: bash

--- a/.github/workflows/rl-scanner.yml
+++ b/.github/workflows/rl-scanner.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   rl-scanner:
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # TEMP: test rl-scanner on PR
     runs-on: ubuntu-latest
     outputs:
       scan-status: ${{ steps.rl-scan-conclusion.outcome }}

--- a/.github/workflows/rl-scanner.yml
+++ b/.github/workflows/rl-scanner.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   rl-scanner:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # TEMP: test rl-scanner on PR
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, 'release/'))
     runs-on: ubuntu-latest
     outputs:
       scan-status: ${{ steps.rl-scan-conclusion.outcome }}


### PR DESCRIPTION
### Changes

The `rl-scanner` reusable workflow passed `ruby-version:` to the local `setup` action, but that action's input is named `ruby`. GitHub Actions rejected the unknown input and the "Configure Ruby" step failed with exit code 6, which failed the whole `rl-scanner` job and skipped the gated `release` job.

- Pass `ruby:` (the `setup` action's actual input name) instead of `ruby-version:` in `rl-scanner.yml`. The `workflow_call` input stays named `ruby-version`.

This surfaced when `rl-scanner` was re-enabled for the GA release.

### References

N/A

### Testing

N/A

### Contributor Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 code of conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)