### PR TITLE
fix: require auth0/version so client construction works and correct rest-client changelog note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ v6.0.0 is the first stable release of the v6 line. The Management API client is 
 - List methods return paginated iterators instead of arrays
 - Non-2xx responses raise typed exceptions (`Auth0::Errors::NotFoundError`, etc.) instead of returning error hashes
 - The `api_version` parameter has been removed (v6 supports Management API v2 only)
-- `rest-client` dependency removed; uses `net/http` internally
+- Management API client uses `net/http` internally. The Authentication API still uses `rest-client`
 - Minimum Ruby version raised to 3.3
 
 **Added**
@@ -109,7 +109,7 @@ This beta release completely rewrites the Management API client using [Fern](htt
 - API methods return strongly-typed response objects instead of raw hashes
 - List methods return paginated iterators instead of arrays
 - Non-2xx responses raise typed exceptions (`Auth0::Errors::NotFoundError`, etc.) instead of returning error hashes
-- `rest-client` dependency removed; uses `net/http` internally
+- Management API client uses `net/http` internally. The Authentication API still uses `rest-client`
 - Minimum Ruby version raised to 3.3
 
 **Added**

--- a/lib/auth0/mixins/headers.rb
+++ b/lib/auth0/mixins/headers.rb
@@ -1,4 +1,5 @@
 require 'json'
+require_relative '../version'
 
 module Auth0
   module Mixins


### PR DESCRIPTION
### Changes

Two fixes reported against v6.

- `lib/auth0/mixins/headers.rb` now requires `auth0/version` before referencing `Auth0::VERSION`. The telemetry header is built during every client construction (`Initializer#initialize` -> `client_headers` -> `telemetry`), and the gem entrypoint never loaded the version file, so a plain `require "auth0"` followed by `Auth0::Client.new(...)` raised `NameError: uninitialized constant Auth0::VERSION`. The require lives in `headers.rb` (a `.fernignore`-protected file) so it survives Fern regeneration.
- Corrected the v6 changelog note that claimed the `rest-client` dependency was removed. Only the Management API client moved to `net/http`. The Authentication API still uses `rest-client`, and it remains a declared dependency in the gemspec.

### References

- Closes #786
- Closes #785

### Testing

- Reproduced #786 in a clean process (`require "auth0"` with no `require "auth0/version"`), confirmed the `NameError`, applied the fix, and confirmed construction succeeds with `Auth0::VERSION` resolving to `6.1.0`.
- Verified end to end against a live tenant: constructed the client, obtained an M2M token, and made a Management API call, all with only `require "auth0"`.
- Ran the full WireMock wire suite locally (445 runs, 0 failures).

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed