### PR TITLE
fix: replace CGI.parse, removed in Ruby 4.0, with URI.decode_www_form

### DIFF
--- a/test/unit/authentication_endpoints_test.rb
+++ b/test/unit/authentication_endpoints_test.rb
@@ -477,10 +477,10 @@ class AuthenticationEndpointsTest < Minitest::Test
     url = @client_secret_instance.send(:par_authorization_url, request_uri)
 
     parsed = URI.parse(url.to_s)
-    params = CGI.parse(parsed.query)
+    params = URI.decode_www_form(parsed.query).to_h
 
-    assert_equal @client_id, params["client_id"].first
-    assert_equal request_uri, params["request_uri"].first
+    assert_equal @client_id, params["client_id"]
+    assert_equal request_uri, params["request_uri"]
     assert_equal "/authorize", parsed.path
     assert_equal @domain, parsed.host
   end


### PR DESCRIPTION
### Changes

`test_par_authorization_url_builds_correctly` fails on Ruby 4.0 because `CGI.parse` no longer exists:

```
NoMethodError: undefined method 'parse' for class CGI
    test/unit/authentication_endpoints_test.rb:478
```

Ruby 4.0 trimmed the `cgi` library down to its escaping helpers. `CGI.escape`, `CGI.unescape`, `CGI.escapeHTML` and `CGI.unescapeHTML` all remain, but `CGI.parse` is gone, and `require "cgi"` does not bring it back.

This replaces the single call with `URI.decode_www_form(...).to_h`, which is the standard-library replacement and needs no new require — the test already uses `URI.parse` on the line above.

```ruby
params = URI.decode_www_form(parsed.query).to_h

assert_equal @client_id, params["client_id"]
assert_equal request_uri, params["request_uri"]
```

`URI.decode_www_form` returns `[[key, value], ...]`, so `to_h` gives values directly and the two `.first` calls are no longer needed. Both parameters in this test are single-valued, so nothing is lost.

**No library code is affected.** The only `CGI` usage in `lib/` is `CGI.escape` in `AuthenticationEndpoints#to_query`, which still exists in Ruby 4.0. This is a test-only fix.

### References

Found while testing an application against `auth0` on Ruby 4.0.6. `auth0.gemspec` declares `required_ruby_version = ">= 3.3.0"` with no upper bound, so Ruby 4 is in scope for the gem, and this is currently the only thing standing between the suite and a clean run there.

- [Ruby 4.0 NEWS](https://www.ruby-lang.org/en/news/) — `cgi` reduced to the escape helpers
- [`URI.decode_www_form`](https://docs.ruby-lang.org/en/master/URI.html#method-c-decode_www_form)

### Testing

No new test — this repairs an existing one, which is the check.

Full suite, same command on both interpreters:

| Ruby | before | after |
|---|---|---|
| 3.3.9 | `552 runs, 0 failures, 0 errors` | `552 runs, 0 failures, 0 errors` |
| 4.0.6 | `552 runs, 0 failures, **1 error**` | `552 runs, 0 failures, 0 errors` |

I also confirmed the replacement is equivalent for this test's input rather than assuming it. `request_uri` is `urn:ietf:params:oauth:request_uri:the.request.uri`, whose colons are percent-encoded by `CGI.escape` in `to_query`; `URI.decode_www_form` decodes them back identically, so the assertion still compares real decoded values and has not become vacuous.

* [ ] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
