### PR TITLE
feat: add Device Authorization Flow to the Authentication API

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -16,6 +16,44 @@ client.authorization_url 'http://localhost:3000'
 # => #<URI::HTTPS https://YOUR_DOMAIN/authorize?client_id=YOUR_CLIENT_ID&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A3000>
 ```
 
+## Device Authorization Flow
+
+The [Device Authorization Flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/device-authorization-flow) lets input-constrained devices, such as a CLI or a smart TV, obtain tokens by having the user complete the login in a browser elsewhere.
+
+Start the flow, show the user code to the user, then poll for the tokens until they finish:
+
+```ruby
+require 'auth0'
+
+client = Auth0::Client.new(
+  client_id: ENV['AUTH0_RUBY_CLIENT_ID'],
+  domain: ENV['AUTH0_RUBY_DOMAIN']
+)
+
+flow = client.start_device_flow(
+  scope: 'openid profile offline_access',
+  audience: 'https://api.example.com'
+)
+
+puts "Go to #{flow['verification_uri']} and enter the code #{flow['user_code']}"
+
+# Poll no more frequently than the interval Auth0 returns, until the code expires.
+tokens = loop do
+  sleep flow['interval']
+
+  begin
+    break client.exchange_device_code_for_tokens(flow['device_code'])
+  rescue Auth0::HTTPError => e
+    # While the user has not finished, Auth0 answers with an `error` of
+    # `authorization_pending` or `slow_down`. Anything else is terminal.
+    error = JSON.parse(e.message)['error'] rescue nil
+    raise unless %w[authorization_pending slow_down].include?(error)
+  end
+end
+
+tokens.access_token
+```
+
 ## Management API Client
 
 As a simple example of how to get started with the Management API, we'll create an admin route to point to a list of all users from Auth0:

--- a/lib/auth0/api/authentication_endpoints.rb
+++ b/lib/auth0/api/authentication_endpoints.rb
@@ -74,6 +74,40 @@ module Auth0
         ::Auth0::AccessToken.from_response request_with_retry(:post, '/oauth/token', request_params)
       end
 
+      # Start a Device Authorization flow.
+      # @see https://auth0.com/docs/api/authentication#device-authorization-flow
+      # @param scope [string] Space-separated list of requested scopes.
+      # @param audience [string] Unique identifier of the target API.
+      # @param client_id [string] Client ID for the application
+      # @return [json] Returns device_code, user_code, verification_uri,
+      #   verification_uri_complete, expires_in and interval.
+      def start_device_flow(scope: nil, audience: nil, client_id: @client_id)
+        request_params = {
+          client_id: client_id,
+          scope: scope,
+          audience: audience
+        }
+
+        request_with_retry(:post, '/oauth/device/code', request_params)
+      end
+
+      # Get access and ID tokens using a device code.
+      # @see https://auth0.com/docs/api/authentication#device-authorization-flow
+      # @param device_code [string] The device code returned by start_device_flow.
+      # @param client_id [string] Client ID for the application
+      # @return [Auth0::AccessToken] Returns the access_token and id_token
+      def exchange_device_code_for_tokens(device_code, client_id: @client_id)
+        raise Auth0::InvalidParameter, 'Must provide a device code' if device_code.to_s.empty?
+
+        request_params = {
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+          client_id: client_id,
+          device_code: device_code
+        }
+
+        ::Auth0::AccessToken.from_response request_with_retry(:post, '/oauth/token', request_params)
+      end
+
       # Get access and ID tokens using a refresh token.
       # @see https://auth0.com/docs/api/authentication#refresh-token
       # @param refresh_token [string] Refresh token to use. Request this with

--- a/test/unit/authentication_endpoints_test.rb
+++ b/test/unit/authentication_endpoints_test.rb
@@ -248,6 +248,66 @@ class AuthenticationEndpointsTest < Minitest::Test
     refute_nil result.access_token
   end
 
+  # --- start_device_flow ---
+
+  def test_start_device_flow_requests_a_device_code
+    stub_request(:post, "https://#{@domain}/oauth/device/code")
+      .with do |req|
+        body = JSON.parse(req.body, symbolize_names: true)
+        body[:client_id] == @client_id &&
+          body[:scope] == "openid profile" &&
+          body[:audience] == "https://api.example.com"
+      end
+      .to_return(
+        status: 200,
+        body: {
+          "device_code" => "the_device_code",
+          "user_code" => "ABCD-EFGH",
+          "verification_uri" => "https://#{@domain}/activate",
+          "expires_in" => 900,
+          "interval" => 5
+        }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    result = @client_secret_instance.send(
+      :start_device_flow, scope: "openid profile", audience: "https://api.example.com"
+    )
+
+    assert_equal "the_device_code", result["device_code"]
+    assert_equal "ABCD-EFGH", result["user_code"]
+    assert_equal 5, result["interval"]
+  end
+
+  # --- exchange_device_code_for_tokens ---
+
+  def test_exchange_device_code_for_tokens
+    stub_request(:post, "https://#{@domain}/oauth/token")
+      .with do |req|
+        body = JSON.parse(req.body, symbolize_names: true)
+        body[:grant_type] == "urn:ietf:params:oauth:grant-type:device_code" &&
+          body[:device_code] == "the_device_code" &&
+          body[:client_id] == @client_id
+      end
+      .to_return(
+        status: 200,
+        body: { "id_token" => "id_token", "access_token" => "test_access_token", "expires_in" => 86_400 }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    result = @client_secret_instance.send(:exchange_device_code_for_tokens, "the_device_code")
+
+    assert_kind_of Auth0::AccessToken, result
+    refute_nil result.access_token
+    refute_nil result.id_token
+  end
+
+  def test_exchange_device_code_for_tokens_raises_on_empty
+    assert_raises(Auth0::InvalidParameter) do
+      @client_secret_instance.send(:exchange_device_code_for_tokens, "")
+    end
+  end
+
   # --- exchange_refresh_token ---
 
   def test_exchange_refresh_token_with_client_secret


### PR DESCRIPTION
### Changes

Implements the [Device Authorization Flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/device-authorization-flow) in `Auth0::Api::AuthenticationEndpoints`. This is the proposal from #792, opened as a pull request per the general contributing guidelines ("PRs to our libraries are always welcome"); happy to close it if you would rather settle the design on the issue first.

Two new methods, additive only — no existing method, endpoint or signature changes:

- **`start_device_flow(scope:, audience:, client_id:)`** → `POST /oauth/device/code`, returning the parsed body (`device_code`, `user_code`, `verification_uri`, `verification_uri_complete`, `expires_in`, `interval`).
- **`exchange_device_code_for_tokens(device_code, client_id:)`** → `POST /oauth/token` with `grant_type=urn:ietf:params:oauth:grant-type:device_code`, returning an `Auth0::AccessToken`.

They are named after the existing `start_passwordless_sms_flow` / `exchange_sms_otp_for_tokens` pair so they read like their neighbours, and they follow the conventions already in the file: an `Auth0::InvalidParameter` guard on the required positional argument, a `request_params` hash, `request_with_retry`, and `::Auth0::AccessToken.from_response` for the token response.

Note this is unrelated to `Auth0::Api::V2::DeviceCredentials`, which is the Management API device-credentials resource.

**No new exception classes.** While the user completes their part, Auth0 answers with an HTTP error whose body carries an `error` of `authorization_pending` or `slow_down`. `Mixins::HTTPProxy#request` already raises `Auth0::HTTPError` subclasses with the raw response body as the message — `AccessDenied` for 403 and `BadRequest` for 400, both `HTTPError` — so callers can distinguish the polling states with what is already there. A documented accessor for that `error` code would be a good follow-up, but it is deliberately not in this pull request.

### References

- #792 — the feature request this implements
- [Auth0 docs — Device Authorization Flow](https://auth0.com/docs/get-started/authentication-and-authorization-flow/device-authorization-flow)
- [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628)

For prior art inside the SDK family, **Auth0.NET** exposes the same two operations as `StartDeviceFlowAsync(DeviceCodeRequest)` and `GetTokenAsync(DeviceCodeTokenRequest)` on `IAuthenticationApiClient`.

Motivation: we run a small Rails service that acts as an OAuth proxy for our command-line client. It starts the flow, hands `user_code` and `verification_uri` to the CLI, and polls for the token. With this in place we can delete the hand-written Faraday client that exists only because the flow is not reachable from this SDK.

### Testing

Three cases added to `test/unit/authentication_endpoints_test.rb`, alongside the existing ones and using the same WebMock body-matching style:

- `test_start_device_flow_requests_a_device_code` — asserts `client_id`, `scope` and `audience` are sent to `/oauth/device/code`, and that the response fields come back
- `test_exchange_device_code_for_tokens` — asserts the `urn:ietf:params:oauth:grant-type:device_code` grant type and `device_code` are sent, and that an `Auth0::AccessToken` is returned
- `test_exchange_device_code_for_tokens_raises_on_empty` — the `InvalidParameter` guard

```sh
bundle exec rake test TEST=test/unit/authentication_endpoints_test.rb TESTOPTS="--name=/device_code|start_device_flow/"
```

I checked the tests are not vacuous: pointing `start_device_flow` at a different path makes its test fail, and restoring it makes it pass again.

| Ruby | full suite |
|---|---|
| 3.3.9 | `555 runs, 4585 assertions, 0 failures, 0 errors` |
| 4.0.6 | `555 runs, 0 failures, 1 error` — the pre-existing `CGI.parse` failure on master, unrelated to this change and fixed by #793 |

The three new tests pass on both (`3 runs, 7 assertions, 0 failures`).

`bundle exec rubocop --force-exclusion` reports no offences on the changed files. As with the rest of `authentication_endpoints.rb`, I followed the file's single-quoted style — it is listed under `AllCops.Exclude` in `.rubocop.yml` as ported verbatim from the legacy SDK.

### Documentation

Added a **Device Authorization Flow** section to `EXAMPLES.md`, showing the full loop: start the flow, display the user code, poll on the returned `interval`, and treat `authorization_pending` / `slow_down` as continue-conditions.

* [X] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [X] This change has been tested on the latest version of Ruby

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [X] All existing and new tests complete without errors
* [X] Rubocop passes on all added/modified files
* [ ] All active GitHub checks have passed
